### PR TITLE
feat(automod): add automatic nickname moderation system

### DIFF
--- a/apps/bot/src/api/dashboardApi.ts
+++ b/apps/bot/src/api/dashboardApi.ts
@@ -5809,29 +5809,23 @@ export const startDashboardApi = (client: Client) => {
 
 
           // ---------------------------------------------------------------
-          // GET /api/dashboard/guilds/:guildId/nickname-moderation
+          // GET  /api/dashboard/guilds/:guildId/nickname-moderation
           // PATCH /api/dashboard/guilds/:guildId/nickname-moderation
+          // Gère uniquement le flag `enabled`. Les mots bannis sont gérés
+          // par les endpoints /banned-words ci-dessous.
           // ---------------------------------------------------------------
           if (parts.length === 5 && parts[4] === 'nickname-moderation') {
             if (req.method === 'GET') {
               try {
                 const guild = await prisma.guild.findUnique({
                   where: { id: guildId },
-                  select: {
-                    autoNicknameModerationEnabled: true,
-                    autoNicknameModerationWords: true,
-                  },
+                  select: { autoNicknameModerationEnabled: true },
                 });
-
                 if (!guild) {
                   json(res, 404, { error: 'Serveur introuvable' });
                   return;
                 }
-
-                json(res, 200, {
-                  enabled: guild.autoNicknameModerationEnabled,
-                  bannedWords: guild.autoNicknameModerationWords,
-                });
+                json(res, 200, { enabled: guild.autoNicknameModerationEnabled });
               } catch (err) {
                 logger.error('NicknameAPI', 'GET nickname-moderation error:', err);
                 json(res, 500, { error: 'Erreur lors de la récupération de la configuration' });
@@ -5840,42 +5834,18 @@ export const startDashboardApi = (client: Client) => {
             }
 
             if (req.method === 'PATCH') {
-              const body = await readJsonBody<{
-                enabled?: boolean;
-                bannedWords?: string[];
-              }>(req);
-
-              if (!body) {
-                json(res, 400, { error: 'Payload invalide' });
+              const body = await readJsonBody<{ enabled?: boolean }>(req);
+              if (!body || !Object.prototype.hasOwnProperty.call(body, 'enabled')) {
+                json(res, 400, { error: 'Payload invalide — champ `enabled` requis' });
                 return;
               }
 
               try {
-                const data: { autoNicknameModerationEnabled?: boolean; autoNicknameModerationWords?: string[] } = {};
+                await prisma.guild.update({
+                  where: { id: guildId },
+                  data: { autoNicknameModerationEnabled: !!body.enabled },
+                });
 
-                if (Object.prototype.hasOwnProperty.call(body, 'enabled')) {
-                  data.autoNicknameModerationEnabled = !!body.enabled;
-                }
-
-                if (Object.prototype.hasOwnProperty.call(body, 'bannedWords') && Array.isArray(body.bannedWords)) {
-                  // Nettoyage : trim, lowercase, dédoublonnage, max 200 mots, max 100 chars par mot
-                  data.autoNicknameModerationWords = [
-                    ...new Set(
-                      body.bannedWords
-                        .map((w: string) => String(w).trim().toLowerCase())
-                        .filter((w: string) => w.length > 0 && w.length <= 100),
-                    ),
-                  ].slice(0, 200);
-                }
-
-                if (Object.keys(data).length === 0) {
-                  json(res, 400, { error: 'Aucun champ à mettre à jour' });
-                  return;
-                }
-
-                await prisma.guild.update({ where: { id: guildId }, data });
-
-                // Invalider le cache bot pour que les changements prennent effet immédiatement
                 const { invalidateNicknameModerationCache } = await import('../events/nicknameModeration.js');
                 invalidateNicknameModerationCache(guildId);
 
@@ -5885,17 +5855,150 @@ export const startDashboardApi = (client: Client) => {
                   context: getGuildName(client, guildId),
                   module: 'Modération des pseudos',
                   eventType: 'Manuel',
-                  details: `Activé: ${data.autoNicknameModerationEnabled ?? '(inchangé)'}, Mots bannis: ${data.autoNicknameModerationWords?.length ?? '(inchangé)'} entrée(s)`,
+                  details: `Activé: ${body.enabled}`,
                   channelId: null,
                 });
 
                 json(res, 200, { ok: true });
               } catch (err) {
                 logger.error('NicknameAPI', 'PATCH nickname-moderation error:', err);
-                json(res, 500, { error: 'Erreur lors de la mise à jour de la configuration' });
+                json(res, 500, { error: 'Erreur lors de la mise à jour' });
               }
               return;
             }
+          }
+
+          // ---------------------------------------------------------------
+          // CRUD /api/dashboard/guilds/:guildId/banned-words
+          // Service partagé : utilisable par automod pseudos, messages, etc.
+          // ---------------------------------------------------------------
+
+          // GET  /banned-words  → mots globaux + mots du serveur
+          if (parts.length === 5 && parts[4] === 'banned-words' && req.method === 'GET') {
+            try {
+              const [globalWords, guildWords] = await Promise.all([
+                prisma.bannedWord.findMany({
+                  where: { guildId: null },
+                  select: { id: true, word: true, category: true, enabled: true, guildId: true },
+                  orderBy: [{ category: 'asc' }, { word: 'asc' }],
+                }),
+                prisma.bannedWord.findMany({
+                  where: { guildId },
+                  select: { id: true, word: true, category: true, enabled: true, guildId: true },
+                  orderBy: [{ category: 'asc' }, { word: 'asc' }],
+                }),
+              ]);
+              json(res, 200, { global: globalWords, custom: guildWords });
+            } catch (err) {
+              logger.error('BannedWordsAPI', 'GET banned-words error:', err);
+              json(res, 500, { error: 'Erreur lors de la récupération des mots bannis' });
+            }
+            return;
+          }
+
+          // POST /banned-words  → ajouter un mot personnalisé au serveur
+          if (parts.length === 5 && parts[4] === 'banned-words' && req.method === 'POST') {
+            const body = await readJsonBody<{ word: string; category?: string }>(req);
+            if (!body?.word || typeof body.word !== 'string' || !body.word.trim()) {
+              json(res, 400, { error: 'Champ `word` requis' });
+              return;
+            }
+
+            const cleanWord = body.word.trim().toLowerCase().slice(0, 100);
+            const category = ['custom', 'racism', 'threat', 'sexual', 'lgbtphobia', 'hate', 'insult'].includes(body.category ?? '')
+              ? body.category!
+              : 'custom';
+
+            try {
+              const created = await prisma.bannedWord.create({
+                data: { guildId, word: cleanWord, category },
+              });
+
+              const { invalidateBannedWordsCache } = await import('../services/bannedWordsService.js');
+              invalidateBannedWordsCache(guildId);
+
+              await pushAudit(guildId, {
+                user: auditUser,
+                action: 'Ajout mot banni',
+                context: getGuildName(client, guildId),
+                module: 'Mots bannis',
+                eventType: 'Manuel',
+                details: `Mot "${cleanWord}" ajouté (catégorie: ${category})`,
+                channelId: null,
+              });
+
+              json(res, 201, { ok: true, id: created.id });
+            } catch (err: any) {
+              if (err?.code === 'P2002') {
+                json(res, 409, { error: 'Ce mot existe déjà sur ce serveur' });
+              } else {
+                logger.error('BannedWordsAPI', 'POST banned-words error:', err);
+                json(res, 500, { error: 'Erreur lors de l\'ajout du mot' });
+              }
+            }
+            return;
+          }
+
+          // PATCH /banned-words/:wordId  → activer/désactiver un mot du serveur
+          if (parts.length === 6 && parts[4] === 'banned-words' && req.method === 'PATCH') {
+            const wordId = parts[5];
+            const body = await readJsonBody<{ enabled: boolean }>(req);
+            if (!body || typeof body.enabled !== 'boolean') {
+              json(res, 400, { error: 'Champ `enabled` requis (boolean)' });
+              return;
+            }
+
+            try {
+              const existing = await prisma.bannedWord.findFirst({ where: { id: wordId, guildId } });
+              if (!existing) {
+                json(res, 404, { error: 'Mot introuvable' });
+                return;
+              }
+
+              await prisma.bannedWord.update({ where: { id: wordId }, data: { enabled: body.enabled } });
+
+              const { invalidateBannedWordsCache } = await import('../services/bannedWordsService.js');
+              invalidateBannedWordsCache(guildId);
+
+              json(res, 200, { ok: true });
+            } catch (err) {
+              logger.error('BannedWordsAPI', 'PATCH banned-words error:', err);
+              json(res, 500, { error: 'Erreur lors de la mise à jour' });
+            }
+            return;
+          }
+
+          // DELETE /banned-words/:wordId  → supprimer un mot personnalisé du serveur
+          if (parts.length === 6 && parts[4] === 'banned-words' && req.method === 'DELETE') {
+            const wordId = parts[5];
+            try {
+              const existing = await prisma.bannedWord.findFirst({ where: { id: wordId, guildId } });
+              if (!existing) {
+                json(res, 404, { error: 'Mot introuvable ou non modifiable' });
+                return;
+              }
+
+              await prisma.bannedWord.delete({ where: { id: wordId } });
+
+              const { invalidateBannedWordsCache } = await import('../services/bannedWordsService.js');
+              invalidateBannedWordsCache(guildId);
+
+              await pushAudit(guildId, {
+                user: auditUser,
+                action: 'Suppression mot banni',
+                context: getGuildName(client, guildId),
+                module: 'Mots bannis',
+                eventType: 'Manuel',
+                details: `Mot "${existing.word}" supprimé`,
+                channelId: null,
+              });
+
+              json(res, 200, { ok: true });
+            } catch (err) {
+              logger.error('BannedWordsAPI', 'DELETE banned-words error:', err);
+              json(res, 500, { error: 'Erreur lors de la suppression' });
+            }
+            return;
           }
 
           if (parts.length === 5 && parts[4] === 'notifications' && req.method === 'PUT') {

--- a/apps/bot/src/api/dashboardApi.ts
+++ b/apps/bot/src/api/dashboardApi.ts
@@ -5808,6 +5808,96 @@ export const startDashboardApi = (client: Client) => {
           }
 
 
+          // ---------------------------------------------------------------
+          // GET /api/dashboard/guilds/:guildId/nickname-moderation
+          // PATCH /api/dashboard/guilds/:guildId/nickname-moderation
+          // ---------------------------------------------------------------
+          if (parts.length === 5 && parts[4] === 'nickname-moderation') {
+            if (req.method === 'GET') {
+              try {
+                const guild = await prisma.guild.findUnique({
+                  where: { id: guildId },
+                  select: {
+                    autoNicknameModerationEnabled: true,
+                    autoNicknameModerationWords: true,
+                  },
+                });
+
+                if (!guild) {
+                  json(res, 404, { error: 'Serveur introuvable' });
+                  return;
+                }
+
+                json(res, 200, {
+                  enabled: guild.autoNicknameModerationEnabled,
+                  bannedWords: guild.autoNicknameModerationWords,
+                });
+              } catch (err) {
+                logger.error('NicknameAPI', 'GET nickname-moderation error:', err);
+                json(res, 500, { error: 'Erreur lors de la récupération de la configuration' });
+              }
+              return;
+            }
+
+            if (req.method === 'PATCH') {
+              const body = await readJsonBody<{
+                enabled?: boolean;
+                bannedWords?: string[];
+              }>(req);
+
+              if (!body) {
+                json(res, 400, { error: 'Payload invalide' });
+                return;
+              }
+
+              try {
+                const data: { autoNicknameModerationEnabled?: boolean; autoNicknameModerationWords?: string[] } = {};
+
+                if (Object.prototype.hasOwnProperty.call(body, 'enabled')) {
+                  data.autoNicknameModerationEnabled = !!body.enabled;
+                }
+
+                if (Object.prototype.hasOwnProperty.call(body, 'bannedWords') && Array.isArray(body.bannedWords)) {
+                  // Nettoyage : trim, lowercase, dédoublonnage, max 200 mots, max 100 chars par mot
+                  data.autoNicknameModerationWords = [
+                    ...new Set(
+                      body.bannedWords
+                        .map((w: string) => String(w).trim().toLowerCase())
+                        .filter((w: string) => w.length > 0 && w.length <= 100),
+                    ),
+                  ].slice(0, 200);
+                }
+
+                if (Object.keys(data).length === 0) {
+                  json(res, 400, { error: 'Aucun champ à mettre à jour' });
+                  return;
+                }
+
+                await prisma.guild.update({ where: { id: guildId }, data });
+
+                // Invalider le cache bot pour que les changements prennent effet immédiatement
+                const { invalidateNicknameModerationCache } = await import('../events/nicknameModeration.js');
+                invalidateNicknameModerationCache(guildId);
+
+                await pushAudit(guildId, {
+                  user: auditUser,
+                  action: 'Mise à jour modération pseudos',
+                  context: getGuildName(client, guildId),
+                  module: 'Modération des pseudos',
+                  eventType: 'Manuel',
+                  details: `Activé: ${data.autoNicknameModerationEnabled ?? '(inchangé)'}, Mots bannis: ${data.autoNicknameModerationWords?.length ?? '(inchangé)'} entrée(s)`,
+                  channelId: null,
+                });
+
+                json(res, 200, { ok: true });
+              } catch (err) {
+                logger.error('NicknameAPI', 'PATCH nickname-moderation error:', err);
+                json(res, 500, { error: 'Erreur lors de la mise à jour de la configuration' });
+              }
+              return;
+            }
+          }
+
           if (parts.length === 5 && parts[4] === 'notifications' && req.method === 'PUT') {
             const body = await readJsonBody<NotificationSettings>(req);
             if (!body) {

--- a/apps/bot/src/events/nicknameModeration.ts
+++ b/apps/bot/src/events/nicknameModeration.ts
@@ -1,0 +1,154 @@
+import { EmbedBuilder, Events, PermissionFlagsBits, type Client, type GuildMember } from 'discord.js';
+import { isNicknameProblematic, SAFE_NICKNAME, buildRenameReason } from '../services/nicknameModerationService.js';
+import { logger } from '../utils/logger.js';
+
+// ---------------------------------------------------------------------------
+// Cache du statut d'activation par serveur (TTL 60s, même pattern que codePolice)
+// ---------------------------------------------------------------------------
+
+type GuildNicknameModerationConfig = {
+  enabled: boolean;
+  customWords: string[];
+  expiresAt: number;
+};
+
+const configCache = new Map<string, GuildNicknameModerationConfig>();
+const CACHE_TTL_MS = 60_000;
+
+export function invalidateNicknameModerationCache(guildId?: string): void {
+  if (guildId) {
+    configCache.delete(guildId);
+    return;
+  }
+  configCache.clear();
+}
+
+async function getNicknameModerationConfig(guildId: string): Promise<{ enabled: boolean; customWords: string[] }> {
+  const cached = configCache.get(guildId);
+  const now = Date.now();
+
+  if (cached && cached.expiresAt > now) {
+    return { enabled: cached.enabled, customWords: cached.customWords };
+  }
+
+  const { default: prisma } = await import('../utils/db.js');
+  const guild = await prisma.guild.findUnique({
+    where: { id: guildId },
+    select: {
+      autoNicknameModerationEnabled: true,
+      autoNicknameModerationWords: true,
+    },
+  });
+
+  const enabled = guild?.autoNicknameModerationEnabled ?? false;
+  const customWords = guild?.autoNicknameModerationWords ?? [];
+
+  configCache.set(guildId, { enabled, customWords, expiresAt: now + CACHE_TTL_MS });
+  return { enabled, customWords };
+}
+
+// ---------------------------------------------------------------------------
+// Logique principale de vérification + renommage
+// ---------------------------------------------------------------------------
+
+async function checkAndRename(member: GuildMember): Promise<void> {
+  if (member.user.bot) return;
+
+  const guildId = member.guild.id;
+  const { enabled, customWords } = await getNicknameModerationConfig(guildId);
+  if (!enabled) return;
+
+  // Vérification des permissions du bot
+  const botMember = await member.guild.members.fetchMe().catch(() => null);
+  if (!botMember?.permissions.has(PermissionFlagsBits.ManageNicknames)) return;
+
+  // Le bot ne peut pas renommer le propriétaire du serveur
+  if (member.guild.ownerId === member.id) return;
+
+  // Pseudo effectif : nickname > globalName > username
+  const effectiveName = member.nickname ?? member.user.globalName ?? member.user.username;
+  if (!effectiveName) return;
+
+  if (!isNicknameProblematic(effectiveName, customWords)) return;
+
+  try {
+    await member.setNickname(SAFE_NICKNAME, buildRenameReason(effectiveName));
+
+    logger.warn(
+      'NicknameAutomod',
+      `Pseudo renommé pour ${member.user.tag} dans "${member.guild.name}": "${effectiveName}" → "${SAFE_NICKNAME}"`,
+    );
+
+    // Log dans le channel de logs du serveur
+    const { default: prisma } = await import('../utils/db.js');
+    const guildData = await prisma.guild.findUnique({
+      where: { id: guildId },
+      select: { logChannelId: true },
+    });
+
+    if (guildData?.logChannelId) {
+      const logChannel = member.guild.channels.cache.get(guildData.logChannelId);
+      if (logChannel?.isTextBased()) {
+        const embed = new EmbedBuilder()
+          .setColor(0xf4a261)
+          .setTitle('Pseudo non conforme | Automod')
+          .addFields(
+            { name: 'Membre', value: `<@${member.id}> \`${member.user.tag}\``, inline: false },
+            { name: 'Pseudo original', value: `\`${effectiveName}\``, inline: true },
+            { name: 'Pseudo appliqué', value: `\`${SAFE_NICKNAME}\``, inline: true },
+          )
+          .setThumbnail(member.displayAvatarURL())
+          .setFooter({ text: 'Automod | Modération des pseudos' })
+          .setTimestamp();
+
+        await logChannel.send({ embeds: [embed] }).catch(() => null);
+      }
+    }
+
+    // Audit dashboard
+    await prisma.dashboardAuditLog.create({
+      data: {
+        guildId,
+        channelId: guildData?.logChannelId ?? null,
+        user: 'Automod',
+        action: 'Renommage automatique de pseudo',
+        context: member.guild.name,
+        module: 'Modération des pseudos',
+        eventType: 'Automatique',
+        details: `Pseudo "${effectiveName}" remplacé par "${SAFE_NICKNAME}" pour ${member.user.tag}`,
+        dateIso: new Date(),
+      },
+    }).catch(() => null);
+  } catch (error) {
+    logger.error('NicknameAutomod', `Impossible de renommer ${member.user.tag}:`, error);
+  }
+}
+
+export function registerNicknameModerationListener(client: Client): void {
+  // Nouveau membre qui rejoint
+  client.on(Events.GuildMemberAdd, async (member) => {
+    await checkAndRename(member).catch((err) => {
+      logger.error('NicknameAutomod', 'Erreur GuildMemberAdd:', err);
+    });
+  });
+
+  // Membre qui change son pseudo (ou dont le pseudo global change)
+  client.on(Events.GuildMemberUpdate, async (oldMember, newMember) => {
+    if (oldMember.partial || newMember.partial) return;
+
+    const oldName = oldMember.nickname ?? oldMember.user.globalName ?? oldMember.user.username;
+    const newName = newMember.nickname ?? newMember.user.globalName ?? newMember.user.username;
+
+    // Ne rien faire si le pseudo n'a pas changé
+    if (oldName === newName) return;
+
+    // Éviter une boucle infinie si le bot vient de poser le pseudo safe
+    if (newName === SAFE_NICKNAME) return;
+
+    await checkAndRename(newMember).catch((err) => {
+      logger.error('NicknameAutomod', 'Erreur GuildMemberUpdate:', err);
+    });
+  });
+
+  logger.success('NicknameAutomod', 'Listener de modération des pseudos enregistré.');
+}

--- a/apps/bot/src/events/nicknameModeration.ts
+++ b/apps/bot/src/events/nicknameModeration.ts
@@ -1,50 +1,47 @@
 import { EmbedBuilder, Events, PermissionFlagsBits, type Client, type GuildMember } from 'discord.js';
-import { isNicknameProblematic, SAFE_NICKNAME, buildRenameReason } from '../services/nicknameModerationService.js';
+import { isNicknameProblematic, SAFE_NICKNAME, buildRenameReason, loadBannedWords } from '../services/nicknameModerationService.js';
+import { invalidateBannedWordsCache } from '../services/bannedWordsService.js';
 import { logger } from '../utils/logger.js';
 
 // ---------------------------------------------------------------------------
-// Cache du statut d'activation par serveur (TTL 60s, même pattern que codePolice)
+// Cache du statut d'activation par serveur (TTL 60s)
 // ---------------------------------------------------------------------------
 
-type GuildNicknameModerationConfig = {
-  enabled: boolean;
-  customWords: string[];
-  expiresAt: number;
-};
-
-const configCache = new Map<string, GuildNicknameModerationConfig>();
+type EnabledCache = { enabled: boolean; expiresAt: number };
+const enabledCache = new Map<string, EnabledCache>();
 const CACHE_TTL_MS = 60_000;
 
+/**
+ * Invalide uniquement le cache d'activation (enabled).
+ * Pour les mots bannis, utiliser invalidateBannedWordsCache depuis bannedWordsService.
+ */
 export function invalidateNicknameModerationCache(guildId?: string): void {
   if (guildId) {
-    configCache.delete(guildId);
+    enabledCache.delete(guildId);
+    invalidateBannedWordsCache(guildId);
     return;
   }
-  configCache.clear();
+  enabledCache.clear();
+  invalidateBannedWordsCache();
 }
 
-async function getNicknameModerationConfig(guildId: string): Promise<{ enabled: boolean; customWords: string[] }> {
-  const cached = configCache.get(guildId);
-  const now = Date.now();
+// Re-export pour les usages existants dans dashboardApi.ts
+export { invalidateBannedWordsCache };
 
-  if (cached && cached.expiresAt > now) {
-    return { enabled: cached.enabled, customWords: cached.customWords };
-  }
+async function isNicknameModerationEnabled(guildId: string): Promise<boolean> {
+  const cached = enabledCache.get(guildId);
+  const now = Date.now();
+  if (cached && cached.expiresAt > now) return cached.enabled;
 
   const { default: prisma } = await import('../utils/db.js');
   const guild = await prisma.guild.findUnique({
     where: { id: guildId },
-    select: {
-      autoNicknameModerationEnabled: true,
-      autoNicknameModerationWords: true,
-    },
+    select: { autoNicknameModerationEnabled: true },
   });
 
   const enabled = guild?.autoNicknameModerationEnabled ?? false;
-  const customWords = guild?.autoNicknameModerationWords ?? [];
-
-  configCache.set(guildId, { enabled, customWords, expiresAt: now + CACHE_TTL_MS });
-  return { enabled, customWords };
+  enabledCache.set(guildId, { enabled, expiresAt: now + CACHE_TTL_MS });
+  return enabled;
 }
 
 // ---------------------------------------------------------------------------
@@ -55,7 +52,7 @@ async function checkAndRename(member: GuildMember): Promise<void> {
   if (member.user.bot) return;
 
   const guildId = member.guild.id;
-  const { enabled, customWords } = await getNicknameModerationConfig(guildId);
+  const enabled = await isNicknameModerationEnabled(guildId);
   if (!enabled) return;
 
   // Vérification des permissions du bot
@@ -69,7 +66,10 @@ async function checkAndRename(member: GuildMember): Promise<void> {
   const effectiveName = member.nickname ?? member.user.globalName ?? member.user.username;
   if (!effectiveName) return;
 
-  if (!isNicknameProblematic(effectiveName, customWords)) return;
+  // Chargement des mots bannis depuis le service générique (global + serveur)
+  const bannedWords = await loadBannedWords(guildId);
+
+  if (!isNicknameProblematic(effectiveName, bannedWords)) return;
 
   try {
     await member.setNickname(SAFE_NICKNAME, buildRenameReason(effectiveName));
@@ -124,25 +124,24 @@ async function checkAndRename(member: GuildMember): Promise<void> {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Enregistrement des listeners
+// ---------------------------------------------------------------------------
+
 export function registerNicknameModerationListener(client: Client): void {
-  // Nouveau membre qui rejoint
   client.on(Events.GuildMemberAdd, async (member) => {
     await checkAndRename(member).catch((err) => {
       logger.error('NicknameAutomod', 'Erreur GuildMemberAdd:', err);
     });
   });
 
-  // Membre qui change son pseudo (ou dont le pseudo global change)
   client.on(Events.GuildMemberUpdate, async (oldMember, newMember) => {
     if (oldMember.partial || newMember.partial) return;
 
     const oldName = oldMember.nickname ?? oldMember.user.globalName ?? oldMember.user.username;
     const newName = newMember.nickname ?? newMember.user.globalName ?? newMember.user.username;
 
-    // Ne rien faire si le pseudo n'a pas changé
     if (oldName === newName) return;
-
-    // Éviter une boucle infinie si le bot vient de poser le pseudo safe
     if (newName === SAFE_NICKNAME) return;
 
     await checkAndRename(newMember).catch((err) => {

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -51,6 +51,7 @@ import { registerCodePoliceListener } from './events/codePolice.js';
 import { registerModerationAuditListener } from './events/moderation.js';
 import { registerAdvancedLogsListener } from './events/advancedLogs.js';
 import { registerCloseSourceWarningListener } from './events/closeSourceWarning.js';
+import { registerNicknameModerationListener } from './events/nicknameModeration.js';
 import { registerDailyAlgoHandlers } from './handlers/dailyAlgoHandler.js';
 import { registerMeetingEvents } from './events/meetingEvents.js';
 import { registerAnalyticsListeners } from './events/analyticsEvents.js';
@@ -233,6 +234,7 @@ client.once(Events.ClientReady, async (c) => {
   registerModerationAuditListener(client);
   registerAdvancedLogsListener(client);
   registerCloseSourceWarningListener(client);
+  registerNicknameModerationListener(client);
   registerDailyAlgoHandlers(client);
   registerMeetingEvents(client);
   registerAnalyticsListeners(client);

--- a/apps/bot/src/services/bannedWordsService.ts
+++ b/apps/bot/src/services/bannedWordsService.ts
@@ -1,0 +1,125 @@
+/**
+ * Service générique de gestion des mots bannis.
+ *
+ * Utilisable par plusieurs modules :
+ *  - Modération des pseudos (nicknameModeration.ts)
+ *  - Modération des messages (future automod)
+ *  - Tout autre système nécessitant un filtre de contenu
+ *
+ * Les mots sont stockés en BDD (table `banned_words`) :
+ *  - guildId = null → mots globaux (liste de base, read-only côté dashboard serveur)
+ *  - guildId = <id> → mots personnalisés par serveur
+ */
+
+import prisma from '../utils/db.js';
+import { logger } from '../utils/logger.js';
+
+// ---------------------------------------------------------------------------
+// Regex — caractères invisibles/non affichables
+// ---------------------------------------------------------------------------
+
+/**
+ * Regex partagée pour détecter les textes composés uniquement de caractères
+ * invisibles ou non affichables (espaces zero-width, soft hyphen, BOM, etc.)
+ */
+export const INVISIBLE_ONLY_REGEX =
+  /^[\s\u200B\u200C\u200D\u00AD\uFEFF\u2060\u180E\u00A0\u2000-\u200A\u202F\u205F\u3000]+$/;
+
+// ---------------------------------------------------------------------------
+// Cache
+// ---------------------------------------------------------------------------
+
+type CacheEntry = {
+  words: string[];
+  expiresAt: number;
+};
+
+/** Cache par guildId (ou '__global__' pour les mots globaux) */
+const cache = new Map<string, CacheEntry>();
+const CACHE_TTL_MS = 60_000;
+
+const GLOBAL_KEY = '__global__';
+
+/**
+ * Invalide le cache pour un serveur donné.
+ * Si aucun guildId n'est fourni, vide entièrement le cache.
+ */
+export function invalidateBannedWordsCache(guildId?: string): void {
+  if (guildId) {
+    cache.delete(guildId);
+    cache.delete(GLOBAL_KEY); // les mots globaux font partie du résultat, on les re-fetch aussi
+    return;
+  }
+  cache.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Chargement
+// ---------------------------------------------------------------------------
+
+/** Charge les mots globaux (guildId = null) depuis la BDD, avec cache. */
+async function loadGlobalWords(): Promise<string[]> {
+  const cached = cache.get(GLOBAL_KEY);
+  const now = Date.now();
+  if (cached && cached.expiresAt > now) return cached.words;
+
+  try {
+    const rows = await prisma.bannedWord.findMany({
+      where: { guildId: null, enabled: true },
+      select: { word: true },
+    });
+    const words = rows.map((r) => r.word.toLowerCase());
+    cache.set(GLOBAL_KEY, { words, expiresAt: now + CACHE_TTL_MS });
+    return words;
+  } catch (err) {
+    logger.error('BannedWords', 'Erreur lors du chargement des mots globaux:', err);
+    return [];
+  }
+}
+
+/**
+ * Charge la liste fusionnée des mots bannis pour un serveur :
+ * mots globaux + mots personnalisés du serveur.
+ * Le résultat est mis en cache 60 secondes.
+ */
+export async function loadBannedWords(guildId: string): Promise<string[]> {
+  const cached = cache.get(guildId);
+  const now = Date.now();
+  if (cached && cached.expiresAt > now) return cached.words;
+
+  try {
+    const [globalWords, guildRows] = await Promise.all([
+      loadGlobalWords(),
+      prisma.bannedWord.findMany({
+        where: { guildId, enabled: true },
+        select: { word: true },
+      }),
+    ]);
+
+    const guildWords = guildRows.map((r) => r.word.toLowerCase());
+    // Dédoublonnage global + serveur
+    const merged = [...new Set([...globalWords, ...guildWords])];
+    cache.set(guildId, { words: merged, expiresAt: now + CACHE_TTL_MS });
+    return merged;
+  } catch (err) {
+    logger.error('BannedWords', `Erreur lors du chargement pour le serveur ${guildId}:`, err);
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Détection
+// ---------------------------------------------------------------------------
+
+/**
+ * Vérifie si un texte contient au moins un mot banni.
+ * La comparaison est insensible à la casse.
+ *
+ * @param text  Le texte à analyser (pseudo, message, etc.)
+ * @param words Liste de mots bannis déjà chargée via `loadBannedWords`
+ */
+export function containsBannedWord(text: string, words: string[]): boolean {
+  if (!text || text.trim().length === 0) return false;
+  const normalized = text.toLowerCase();
+  return words.some((word) => word.trim() && normalized.includes(word));
+}

--- a/apps/bot/src/services/nicknameModerationService.ts
+++ b/apps/bot/src/services/nicknameModerationService.ts
@@ -1,0 +1,73 @@
+/**
+ * Service de modération automatique des pseudos Discord.
+ * Détecte les pseudos problématiques (racisme, menaces, insultes, caractères invisibles)
+ * et fournit un pseudo de remplacement neutre.
+ */
+
+// Pseudo de remplacement affiché aux modérateurs et dans les logs
+export const SAFE_NICKNAME = 'pseudo non conforme | automod';
+
+/**
+ * Liste de base de mots/fragments interdits.
+ * Cette liste est complétée par les mots personnalisés définis par chaque serveur.
+ * Les termes sont en minuscules ; la comparaison est insensible à la casse.
+ */
+const BASE_BANNED_WORDS: string[] = [
+  // Racisme / haine ethnique (FR)
+  'nègre', 'négro', 'neger', 'niggr', 'nigger', 'nigga',
+  'youpin', 'youpine', 'feuj', 'juif de merde', 'sale juif',
+  'arabe de merde', 'sale arabe', 'bougnoule', 'bicot', 'crouille',
+  'chinetoque', 'jap', 'asiatic', 'ritale', 'polak',
+  'raton', 'bamboula', 'nègresse', 'noiraud',
+  'renoi', 'kebla', 'reubeu', 'gitan de merde', 'romanichel',
+  // Menaces
+  'je vais te tuer', 'je vais te crever', 'je vais te défoncer',
+  'death threat', 'kill yourself', 'kys', 'go die',
+  // Insultes graves
+  'pédophile', 'pedo', 'nazi', 'führer', 'hitler', 'heil',
+  'génocide', 'extermination', 'zyklon',
+  // LGBTQ+ phobic
+  'pédé', 'pede', 'tapette', 'gouine', 'fiotte', 'travelo',
+  'transphobe', 'homophobe',
+  // Termes sexuels explicites souvent utilisés comme pseudos provocateurs
+  'bite', 'queue', 'pénis', 'vagin', 'chatte', 'couilles',
+  'enculé', 'encule', 'baise-moi', 'suce moi', 'lèche moi',
+  // EN — insultes courantes
+  'fuck you', 'motherfucker', 'cunt', 'faggot', 'retard',
+  'whore', 'slut', 'bitch ass',
+];
+
+/**
+ * Regex
+ */
+const INVISIBLE_ONLY_REGEX = /^[\s\u200B\u200C\u200D\u00AD\uFEFF\u2060\u180E\u00A0\u2000-\u200A\u202F\u205F\u3000]+$/;
+
+/**
+ * Vérifie si un pseudo est problématique.
+ *
+ * @param name        Le pseudo brut (nickname ou username) à analyser.
+ * @param customWords Liste de mots/fragments supplémentaires définis par le serveur.
+ * @returns `true` si le pseudo doit être remplacé, `false` sinon.
+ */
+export function isNicknameProblematic(name: string, customWords: string[] = []): boolean {
+  if (!name || name.trim().length === 0) return true;
+
+  // Pseudos entièrement composés de caractères invisibles
+  if (INVISIBLE_ONLY_REGEX.test(name)) return true;
+
+  const normalized = name.toLowerCase();
+  const allBanned = [...BASE_BANNED_WORDS, ...customWords.map((w) => w.toLowerCase())];
+
+  return allBanned.some((word) => {
+    if (!word.trim()) return false;
+    // Vérification basique : le fragment est contenu dans le pseudo normalisé
+    return normalized.includes(word);
+  });
+}
+
+/**
+ * Retourne une raison lisible pour le log du renommage automatique.
+ */
+export function buildRenameReason(originalName: string): string {
+  return `Automod: pseudo non conforme détecté — original: "${originalName}"`;
+}

--- a/apps/bot/src/services/nicknameModerationService.ts
+++ b/apps/bot/src/services/nicknameModerationService.ts
@@ -1,73 +1,31 @@
 /**
  * Service de modération automatique des pseudos Discord.
- * Détecte les pseudos problématiques (racisme, menaces, insultes, caractères invisibles)
- * et fournit un pseudo de remplacement neutre.
+ * Délègue la détection des mots bannis à bannedWordsService (service générique partagé).
  */
 
-// Pseudo de remplacement affiché aux modérateurs et dans les logs
+import { containsBannedWord, INVISIBLE_ONLY_REGEX } from './bannedWordsService.js';
+
+export { loadBannedWords, invalidateBannedWordsCache } from './bannedWordsService.js';
+
+/** Pseudo de remplacement appliqué automatiquement. */
 export const SAFE_NICKNAME = 'pseudo non conforme | automod';
 
 /**
- * Liste de base de mots/fragments interdits.
- * Cette liste est complétée par les mots personnalisés définis par chaque serveur.
- * Les termes sont en minuscules ; la comparaison est insensible à la casse.
- */
-const BASE_BANNED_WORDS: string[] = [
-  // Racisme / haine ethnique (FR)
-  'nègre', 'négro', 'neger', 'niggr', 'nigger', 'nigga',
-  'youpin', 'youpine', 'feuj', 'juif de merde', 'sale juif',
-  'arabe de merde', 'sale arabe', 'bougnoule', 'bicot', 'crouille',
-  'chinetoque', 'jap', 'asiatic', 'ritale', 'polak',
-  'raton', 'bamboula', 'nègresse', 'noiraud',
-  'renoi', 'kebla', 'reubeu', 'gitan de merde', 'romanichel',
-  // Menaces
-  'je vais te tuer', 'je vais te crever', 'je vais te défoncer',
-  'death threat', 'kill yourself', 'kys', 'go die',
-  // Insultes graves
-  'pédophile', 'pedo', 'nazi', 'führer', 'hitler', 'heil',
-  'génocide', 'extermination', 'zyklon',
-  // LGBTQ+ phobic
-  'pédé', 'pede', 'tapette', 'gouine', 'fiotte', 'travelo',
-  'transphobe', 'homophobe',
-  // Termes sexuels explicites souvent utilisés comme pseudos provocateurs
-  'bite', 'queue', 'pénis', 'vagin', 'chatte', 'couilles',
-  'enculé', 'encule', 'baise-moi', 'suce moi', 'lèche moi',
-  // EN — insultes courantes
-  'fuck you', 'motherfucker', 'cunt', 'faggot', 'retard',
-  'whore', 'slut', 'bitch ass',
-];
-
-/**
- * Regex
- */
-const INVISIBLE_ONLY_REGEX = /^[\s\u200B\u200C\u200D\u00AD\uFEFF\u2060\u180E\u00A0\u2000-\u200A\u202F\u205F\u3000]+$/;
-
-/**
- * Vérifie si un pseudo est problématique.
+ * Vérifie si un pseudo est non conforme.
  *
- * @param name        Le pseudo brut (nickname ou username) à analyser.
- * @param customWords Liste de mots/fragments supplémentaires définis par le serveur.
- * @returns `true` si le pseudo doit être remplacé, `false` sinon.
+ * @param name  Le pseudo brut (nickname, globalName ou username) à analyser.
+ * @param words Liste de mots bannis chargée via `loadBannedWords(guildId)`.
+ * @returns `true` si le pseudo doit être remplacé.
  */
-export function isNicknameProblematic(name: string, customWords: string[] = []): boolean {
+export function isNicknameProblematic(name: string, words: string[]): boolean {
   if (!name || name.trim().length === 0) return true;
-
-  // Pseudos entièrement composés de caractères invisibles
   if (INVISIBLE_ONLY_REGEX.test(name)) return true;
-
-  const normalized = name.toLowerCase();
-  const allBanned = [...BASE_BANNED_WORDS, ...customWords.map((w) => w.toLowerCase())];
-
-  return allBanned.some((word) => {
-    if (!word.trim()) return false;
-    // Vérification basique : le fragment est contenu dans le pseudo normalisé
-    return normalized.includes(word);
-  });
+  return containsBannedWord(name, words);
 }
 
 /**
- * Retourne une raison lisible pour le log du renommage automatique.
+ * Retourne une raison de renommage lisible pour les logs Discord.
  */
 export function buildRenameReason(originalName: string): string {
-  return `Automod: pseudo non conforme détecté — original: "${originalName}"`;
+  return `Automod: pseudo non conforme — original: "${originalName}"`;
 }

--- a/apps/bot/src/utils/prismaToggles.ts
+++ b/apps/bot/src/utils/prismaToggles.ts
@@ -2,7 +2,7 @@ import prisma from './db.js';
 
 export async function toggleGuildBoolean(
   guildId: string,
-  field: 'translationEnabled' | 'codePoliceEnabled' | 'dailyAlgoEnabled' | 'githubReleasesEnabled' | 'sanctionSyncEnabled',
+  field: 'translationEnabled' | 'codePoliceEnabled' | 'dailyAlgoEnabled' | 'githubReleasesEnabled' | 'sanctionSyncEnabled' | 'autoNicknameModerationEnabled',
 ): Promise<boolean | null> {
   const guild = await prisma.guild.findUnique({ where: { id: guildId } });
   if (!guild) return null;

--- a/apps/dashboard/src/App.svelte
+++ b/apps/dashboard/src/App.svelte
@@ -35,6 +35,7 @@
   import Inbox from './pages/Inbox.svelte';
   import Tutoring from './pages/Tutoring.svelte';
   import DoubleAccounts from './pages/DoubleAccounts.svelte';
+  import NicknameModeration from './pages/NicknameModeration.svelte';
   import GeneralSettings from './pages/GeneralSettings.svelte';
   import DailyAlgo from './pages/DailyAlgo.svelte';
   import DailyAlgoIDE from './pages/DailyAlgoIDE.svelte';
@@ -66,6 +67,7 @@
     if (path.startsWith('/events')) return 'events';
     if (path.startsWith('/members') || path.startsWith('/invitations')) return 'members';
     if (path.startsWith('/sanctions')) return 'sanctions';
+    if (path.startsWith('/nickname-moderation')) return 'nickname_moderation';
     if (path.startsWith('/double-accounts')) return 'double_accounts';
     if (path.startsWith('/logs')) return 'logs';
     if (path.startsWith('/activity')) return 'activity';
@@ -261,6 +263,9 @@
       </Route>
       <Route path="/double-accounts">
         <DoubleAccounts />
+      </Route>
+      <Route path="/nickname-moderation">
+        <NicknameModeration />
       </Route>
       <Route path="/invitations">
         <Invitations />

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -1085,4 +1085,26 @@ export async function purgeInviterMembers(userId: string, guildId = authStore.se
   });
 }
 
+// ==========================================
+// MODÉRATION DES PSEUDOS
+// ==========================================
 
+export async function fetchNicknameModerationConfig(guildId = authStore.selectedGuildId) {
+  return dashboardRequest('/nickname-moderation', {
+    method: 'GET',
+    guildId,
+    errorContext: 'API Error (Fetch Nickname Moderation Config):'
+  });
+}
+
+export async function updateNicknameModerationConfig(
+  payload: { enabled?: boolean; bannedWords?: string[] },
+  guildId = authStore.selectedGuildId
+) {
+  return dashboardMutation('/nickname-moderation', {
+    method: 'PATCH',
+    payload,
+    guildId,
+    errorContext: 'API Error (Update Nickname Moderation Config):'
+  });
+}

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -1098,7 +1098,7 @@ export async function fetchNicknameModerationConfig(guildId = authStore.selected
 }
 
 export async function updateNicknameModerationConfig(
-  payload: { enabled?: boolean; bannedWords?: string[] },
+  payload: { enabled: boolean },
   guildId = authStore.selectedGuildId
 ) {
   return dashboardMutation('/nickname-moderation', {
@@ -1106,5 +1106,55 @@ export async function updateNicknameModerationConfig(
     payload,
     guildId,
     errorContext: 'API Error (Update Nickname Moderation Config):'
+  });
+}
+
+// ==========================================
+// MOTS BANNIS (service générique partagé)
+// ==========================================
+
+/** Retourne { global: BannedWord[], custom: BannedWord[] } */
+export async function fetchBannedWords(guildId = authStore.selectedGuildId) {
+  return dashboardRequest('/banned-words', {
+    method: 'GET',
+    guildId,
+    errorContext: 'API Error (Fetch Banned Words):'
+  });
+}
+
+/** Ajoute un mot personnalisé pour le serveur */
+export async function addBannedWord(
+  word: string,
+  category = 'custom',
+  guildId = authStore.selectedGuildId
+) {
+  return dashboardMutation('/banned-words', {
+    method: 'POST',
+    payload: { word, category },
+    guildId,
+    errorContext: 'API Error (Add Banned Word):'
+  });
+}
+
+/** Active ou désactive un mot personnalisé */
+export async function toggleBannedWord(
+  id: string,
+  enabled: boolean,
+  guildId = authStore.selectedGuildId
+) {
+  return dashboardMutation(`/banned-words/${id}`, {
+    method: 'PATCH',
+    payload: { enabled },
+    guildId,
+    errorContext: 'API Error (Toggle Banned Word):'
+  });
+}
+
+/** Supprime un mot personnalisé */
+export async function deleteBannedWord(id: string, guildId = authStore.selectedGuildId) {
+  return dashboardMutation(`/banned-words/${id}`, {
+    method: 'DELETE',
+    guildId,
+    errorContext: 'API Error (Delete Banned Word):'
   });
 }

--- a/apps/dashboard/src/lib/components/Sidebar.svelte
+++ b/apps/dashboard/src/lib/components/Sidebar.svelte
@@ -16,6 +16,7 @@
     { name: "Daily Algo", icon: "code", href: "/dailyalgo", featureKey: "daily_algo" },
     { name: "Membres", icon: "user", href: "/members", featureKey: "members" },
     { name: "Sanctions", icon: "alert-triangle", href: "/sanctions", featureKey: "sanctions" },
+    { name: "Pseudos", icon: "tag", href: "/nickname-moderation", featureKey: "nickname_moderation" },
     { name: "Doubles Comptes", icon: "users", href: "/double-accounts", featureKey: "double_accounts" },
     { name: "Invitations", icon: "link", href: "/invitations", featureKey: "members" },
     { name: "Logs Discord", icon: "file-text", href: "/logs", featureKey: "logs" },

--- a/apps/dashboard/src/lib/components/Sidebar.svelte
+++ b/apps/dashboard/src/lib/components/Sidebar.svelte
@@ -16,7 +16,7 @@
     { name: "Daily Algo", icon: "code", href: "/dailyalgo", featureKey: "daily_algo" },
     { name: "Membres", icon: "user", href: "/members", featureKey: "members" },
     { name: "Sanctions", icon: "alert-triangle", href: "/sanctions", featureKey: "sanctions" },
-    { name: "Pseudos", icon: "tag", href: "/nickname-moderation", featureKey: "nickname_moderation" },
+    { name: "Pseudos", icon: "filter", href: "/nickname-moderation", featureKey: "nickname_moderation" },
     { name: "Doubles Comptes", icon: "users", href: "/double-accounts", featureKey: "double_accounts" },
     { name: "Invitations", icon: "link", href: "/invitations", featureKey: "members" },
     { name: "Logs Discord", icon: "file-text", href: "/logs", featureKey: "logs" },

--- a/apps/dashboard/src/pages/NicknameModeration.svelte
+++ b/apps/dashboard/src/pages/NicknameModeration.svelte
@@ -6,27 +6,74 @@
   import InlineFeedback from '../lib/components/InlineFeedback.svelte';
   import Papicon from '../lib/components/Papicon.svelte';
   import { createAsyncActionState } from '../lib/asyncAction.svelte';
-  import { fetchNicknameModerationConfig, updateNicknameModerationConfig } from '../lib/api';
+  import {
+    fetchNicknameModerationConfig,
+    updateNicknameModerationConfig,
+    fetchBannedWords,
+    addBannedWord,
+    deleteBannedWord,
+    toggleBannedWord,
+  } from '../lib/api';
 
-  // ---- State ---------------------------------------------------------------
+  // ---------------------------------------------------------------------------
+  // Types
+  // ---------------------------------------------------------------------------
+
+  type BannedWordEntry = {
+    id: string;
+    word: string;
+    category: string;
+    enabled: boolean;
+    guildId: string | null;
+  };
+
+  type CategoryMeta = {
+    label: string;
+    color: string;
+    bg: string;
+  };
+
+  const CATEGORIES: Record<string, CategoryMeta> = {
+    custom:     { label: 'Personnalisé', color: 'text-primary',      bg: 'bg-primary/10 border-primary/20' },
+    racism:     { label: 'Racisme',      color: 'text-error',        bg: 'bg-error/10 border-error/20' },
+    threat:     { label: 'Menace',       color: 'text-orange-400',   bg: 'bg-orange-400/10 border-orange-400/20' },
+    sexual:     { label: 'Sexuel',       color: 'text-pink-400',     bg: 'bg-pink-400/10 border-pink-400/20' },
+    lgbtphobia: { label: 'LGBTphobie',  color: 'text-purple-400',   bg: 'bg-purple-400/10 border-purple-400/20' },
+    hate:       { label: 'Haine',        color: 'text-red-600',      bg: 'bg-red-600/10 border-red-600/20' },
+    insult:     { label: 'Insulte',      color: 'text-yellow-400',   bg: 'bg-yellow-400/10 border-yellow-400/20' },
+  };
+
+  // ---------------------------------------------------------------------------
+  // State
+  // ---------------------------------------------------------------------------
+
   let enabled = $state(false);
-  let bannedWords = $state<string[]>([]);
-
-  /** Mot en cours de saisie dans l'input */
-  let newWord = $state('');
-
+  let globalWords = $state<BannedWordEntry[]>([]);
+  let customWords = $state<BannedWordEntry[]>([]);
   let loading = $state(true);
   let loadError = $state('');
 
-  const saveAction = createAsyncActionState();
+  let newWord = $state('');
+  let newCategory = $state('custom');
+  let activeTab = $state<'custom' | 'global'>('custom');
 
-  // ---- Lifecycle -----------------------------------------------------------
+  const saveToggleAction = createAsyncActionState();
+  const wordAction = createAsyncActionState();
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
   onMount(async () => {
     try {
-      const data = await fetchNicknameModerationConfig();
-      if (data) {
-        enabled = data.enabled ?? false;
-        bannedWords = Array.isArray(data.bannedWords) ? [...data.bannedWords] : [];
+      const [config, words] = await Promise.all([
+        fetchNicknameModerationConfig(),
+        fetchBannedWords(),
+      ]);
+      if (config) enabled = config.enabled ?? false;
+      if (words) {
+        globalWords = words.global ?? [];
+        customWords = words.custom ?? [];
       }
     } catch (err) {
       loadError = err instanceof Error ? err.message : 'Impossible de charger la configuration.';
@@ -35,172 +82,282 @@
     }
   });
 
-  // ---- Actions -------------------------------------------------------------
+  // ---------------------------------------------------------------------------
+  // Actions
+  // ---------------------------------------------------------------------------
 
-  function addWord() {
-    const trimmed = newWord.trim().toLowerCase();
-    if (!trimmed || bannedWords.includes(trimmed) || trimmed.length > 100) return;
-    bannedWords = [...bannedWords, trimmed];
-    newWord = '';
+  async function saveToggle() {
+    await saveToggleAction.run(
+      async () => {
+        const ok = await updateNicknameModerationConfig({ enabled });
+        if (!ok) throw new Error('Erreur API');
+        return true;
+      },
+      { successMessage: `Module ${enabled ? 'activé' : 'désactivé'}.` }
+    );
   }
 
-  function removeWord(word: string) {
-    bannedWords = bannedWords.filter((w) => w !== word);
+  async function addWord() {
+    const trimmed = newWord.trim().toLowerCase();
+    if (!trimmed) return;
+    if (customWords.some((w) => w.word === trimmed)) {
+      wordAction.setError('Ce mot est déjà dans votre liste.');
+      return;
+    }
+
+    await wordAction.run(
+      async () => {
+        const res = await addBannedWord(trimmed, newCategory);
+        if (!res?.id) throw new Error('Erreur lors de l\'ajout');
+        customWords = [...customWords, { id: res.id, word: trimmed, category: newCategory, enabled: true, guildId: null }];
+        newWord = '';
+        return true;
+      },
+      { successMessage: `"${trimmed}" ajouté.` }
+    );
+  }
+
+  async function handleDelete(entry: BannedWordEntry) {
+    await wordAction.run(
+      async () => {
+        const ok = await deleteBannedWord(entry.id);
+        if (!ok) throw new Error('Erreur lors de la suppression');
+        customWords = customWords.filter((w) => w.id !== entry.id);
+        return true;
+      },
+      { successMessage: `"${entry.word}" supprimé.` }
+    );
+  }
+
+  async function handleToggle(entry: BannedWordEntry) {
+    const newEnabled = !entry.enabled;
+    await wordAction.run(
+      async () => {
+        const ok = await toggleBannedWord(entry.id, newEnabled);
+        if (!ok) throw new Error('Erreur');
+        customWords = customWords.map((w) => w.id === entry.id ? { ...w, enabled: newEnabled } : w);
+        return true;
+      },
+      {}
+    );
   }
 
   function handleKeydown(e: KeyboardEvent) {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      addWord();
-    }
+    if (e.key === 'Enter') { e.preventDefault(); addWord(); }
   }
 
-  async function save() {
-    await saveAction.run(
-      async () => {
-        const ok = await updateNicknameModerationConfig({ enabled, bannedWords });
-        if (!ok) throw new Error('La sauvegarde a échoué.');
-        return true;
-      },
-      { successMessage: 'Configuration sauvegardée avec succès.' }
-    );
+  function getCat(key: string): CategoryMeta {
+    return CATEGORIES[key] ?? CATEGORIES.custom;
   }
 </script>
 
 <ModulePage
   title="Modération des pseudos"
   description="Renomme automatiquement les pseudos non conformes dès qu'un membre rejoint ou modifie son pseudo."
-  icon="tag"
+  icon="filter"
   featureKey="nickname_moderation"
 >
   {#snippet actions()}
-    <ActionButton onclick={save} loading={saveAction.state.loading} disabled={loading}>
-      Sauvegarder
-    </ActionButton>
-  {/snippet}
+    <ActionButton onClick={saveToggle} label={enabled ? 'Désactiver' : 'Activer'} disabled={loading || saveToggleAction.state.loading} />
 
-  <InlineFeedback state={saveAction} />
+  <InlineFeedback state={saveToggleAction} />
 
   {#if loading}
-    <!-- Skeleton loader -->
     <div class="flex flex-col gap-6 animate-pulse">
       {#each [1, 2] as _}
-        <div class="h-24 rounded-3xl bg-surface-container-low/60"></div>
+        <div class="h-32 rounded-3xl bg-surface-container-low/60"></div>
       {/each}
     </div>
   {:else if loadError}
     <div class="rounded-3xl bg-error/10 border border-error/20 p-6 text-error text-sm font-semibold">
-      {loadError}
+      ⚠️ {loadError}
     </div>
   {:else}
-    <!-- ================================================================ -->
-    <!-- Section 1 — Toggle principal                                      -->
-    <!-- ================================================================ -->
+    <!-- ============================================================ -->
+    <!-- Section 1 — Toggle principal                                   -->
+    <!-- ============================================================ -->
     <section class="bg-surface-container-low/40 backdrop-blur-xl rounded-4xl border border-outline-variant/30 p-8 flex flex-col gap-6">
       <div class="flex items-start justify-between gap-6">
         <div class="flex flex-col gap-1">
           <h2 class="text-base font-black tracking-tight text-on-surface">Activation</h2>
           <p class="text-sm text-on-surface-variant/70">
-            Lorsqu'activé, le bot vérifie automatiquement les pseudos des nouveaux membres et des
-            membres qui modifient leur pseudo. Si un pseudo est non conforme, il est remplacé
-            par <code class="font-mono text-primary bg-primary/10 px-1.5 py-0.5 rounded-lg text-xs">pseudo non conforme | automod</code>.
+            Lorsqu'activé, le bot vérifie les pseudos à l'arrivée et lors des modifications.
+            Un pseudo non conforme est remplacé par
+            <code class="font-mono text-primary bg-primary/10 px-1.5 py-0.5 rounded-lg text-xs">pseudo non conforme | automod</code>.
           </p>
         </div>
         <div class="flex-shrink-0">
-          <ToggleSwitch checked={enabled} onToggle={() => (enabled = !enabled)} />
+          <ToggleSwitch checked={enabled} onToggle={() => { enabled = !enabled; saveToggle(); }} disabled={saveToggleAction.state.loading} />
         </div>
       </div>
 
-      <div class="flex flex-col gap-3 p-4 rounded-2xl bg-surface-container/30 border border-outline-variant/20">
-        <div class="flex items-center gap-2 text-xs font-black uppercase tracking-widest text-on-surface-variant/60">
-          <Papicon icon="info" size={14} />
-          <span>Ce que le bot surveille</span>
-        </div>
-        <ul class="text-sm text-on-surface-variant/80 flex flex-col gap-1.5 list-none">
+      <div class="p-4 rounded-2xl bg-surface-container/30 border border-outline-variant/20 flex flex-col gap-2">
+        <p class="text-xs font-black uppercase tracking-widest text-on-surface-variant/50">Ce que le bot surveille</p>
+        <ul class="text-sm text-on-surface-variant/70 flex flex-col gap-1.5">
           <li class="flex items-center gap-2"><span class="text-primary">→</span> Nouveaux membres rejoignant le serveur</li>
-          <li class="flex items-center gap-2"><span class="text-primary">→</span> Membres modifiant leur pseudo sur le serveur</li>
-          <li class="flex items-center gap-2"><span class="text-primary">→</span> Pseudos composés de caractères invisibles ou non affichables</li>
-          <li class="flex items-center gap-2"><span class="text-primary">→</span> Une liste de mots problématiques par défaut (racisme, menaces, insultes...)</li>
-          <li class="flex items-center gap-2"><span class="text-primary">→</span> Vos mots personnalisés ajoutés ci-dessous</li>
+          <li class="flex items-center gap-2"><span class="text-primary">→</span> Membres modifiant leur pseudo</li>
+          <li class="flex items-center gap-2"><span class="text-primary">→</span> Pseudos composés uniquement de caractères invisibles</li>
+          <li class="flex items-center gap-2"><span class="text-primary">→</span> Mots de la liste globale (racisme, menaces, insultes…)</li>
+          <li class="flex items-center gap-2"><span class="text-primary">→</span> Vos mots personnalisés ci-dessous</li>
         </ul>
-        <p class="text-xs text-on-surface-variant/50 mt-1 italic">
-          Note : Le bot ne peut pas renommer le propriétaire du serveur (limitation Discord).
+        <p class="text-xs text-on-surface-variant/40 italic mt-1">
+          Le bot ne peut pas renommer le propriétaire du serveur (limitation Discord).
         </p>
       </div>
     </section>
 
-    <!-- ================================================================ -->
-    <!-- Section 2 — Liste de mots personnalisés                           -->
-    <!-- ================================================================ -->
+    <!-- ============================================================ -->
+    <!-- Section 2 — Mots bannis                                       -->
+    <!-- ============================================================ -->
     <section class="bg-surface-container-low/40 backdrop-blur-xl rounded-4xl border border-outline-variant/30 p-8 flex flex-col gap-6">
       <div class="flex flex-col gap-1">
-        <h2 class="text-base font-black tracking-tight text-on-surface">Mots interdits personnalisés</h2>
+        <h2 class="text-base font-black tracking-tight text-on-surface">Mots bannis</h2>
         <p class="text-sm text-on-surface-variant/70">
-          Ajoutez ici les mots ou fragments que vous souhaitez interdire sur votre serveur, en plus de la liste de base. 
-          La comparaison est insensible à la casse.
-          Maximum <strong>200 mots</strong>, 100 caractères par mot.
+          Gérez les mots déclenchant un renommage automatique. Les mots <strong>globaux</strong> sont partagés
+          entre tous les serveurs et sont en lecture seule. Vos mots <strong>personnalisés</strong> sont
+          spécifiques à ce serveur.
         </p>
       </div>
 
-      <!-- Input d'ajout -->
-      <div class="flex gap-3 items-center">
-        <div class="flex-1 relative">
-          <input
-            id="nickname-word-input"
-            type="text"
-            bind:value={newWord}
-            onkeydown={handleKeydown}
-            maxlength={100}
-            placeholder="Ajouter un mot ou fragment..."
-            class="w-full bg-surface-container/60 border border-outline-variant/30 rounded-2xl px-5 py-3.5 text-sm text-on-surface placeholder:text-on-surface-variant/30 focus:outline-none focus:border-primary/60 focus:ring-1 focus:ring-primary/20 transition-all"
-          />
-          {#if newWord.length > 80}
-            <span class="absolute right-4 top-1/2 -translate-y-1/2 text-xs text-on-surface-variant/40">
-              {newWord.length}/100
-            </span>
-          {/if}
-        </div>
-        <button
-          onclick={addWord}
-          disabled={!newWord.trim() || bannedWords.includes(newWord.trim().toLowerCase())}
-          class="flex items-center gap-2 px-5 py-3.5 bg-primary text-white rounded-2xl text-sm font-bold tracking-wide transition-all hover:bg-primary/90 active:scale-95 disabled:opacity-40 disabled:cursor-not-allowed"
-        >
-          <Papicon icon="plus" size={16} />
-          Ajouter
-        </button>
+      <!-- Tabs -->
+      <div class="flex gap-1 p-1 bg-surface-container/40 rounded-2xl w-fit">
+        {#each [{ key: 'custom', label: `Personnalisés (${customWords.length})` }, { key: 'global', label: `Globaux (${globalWords.length})` }] as tab}
+          <button
+            onclick={() => activeTab = tab.key as 'custom' | 'global'}
+            class="px-4 py-2 rounded-xl text-sm font-bold transition-all {activeTab === tab.key ? 'bg-primary text-white shadow-sm' : 'text-on-surface-variant/60 hover:text-on-surface'}"
+          >
+            {tab.label}
+          </button>
+        {/each}
       </div>
 
-      <!-- Tags des mots ajoutés -->
-      {#if bannedWords.length > 0}
-        <div class="flex flex-wrap gap-2.5">
-          {#each bannedWords as word (word)}
-            <span
-              class="group flex items-center gap-2 px-3.5 py-1.5 bg-error/10 border border-error/20 text-error rounded-xl text-sm font-semibold transition-all hover:bg-error/15"
-            >
-              <span class="font-mono text-xs">{word}</span>
-              <button
-                onclick={() => removeWord(word)}
-                aria-label="Supprimer {word}"
-                class="opacity-50 group-hover:opacity-100 transition-opacity hover:text-error ml-0.5"
-              >
-                <Papicon icon="x" size={13} />
-              </button>
-            </span>
-          {/each}
+      {#if activeTab === 'custom'}
+        <!-- Formulaire d'ajout -->
+        <div class="flex gap-3 items-start flex-wrap">
+          <div class="flex-1 min-w-[200px] relative">
+            <input
+              id="banned-word-input"
+              type="text"
+              bind:value={newWord}
+              onkeydown={handleKeydown}
+              maxlength={100}
+              placeholder="Entrer un mot ou fragment..."
+              class="w-full bg-surface-container/60 border border-outline-variant/30 rounded-2xl px-5 py-3.5 text-sm text-on-surface placeholder:text-on-surface-variant/30 focus:outline-none focus:border-primary/60 focus:ring-1 focus:ring-primary/20 transition-all"
+            />
+          </div>
+          <select
+            bind:value={newCategory}
+            class="bg-surface-container/60 border border-outline-variant/30 rounded-2xl px-4 py-3.5 text-sm text-on-surface focus:outline-none focus:border-primary/60 transition-all"
+          >
+            {#each Object.entries(CATEGORIES) as [key, meta]}
+              <option value={key}>{meta.label}</option>
+            {/each}
+          </select>
+          <button
+            onclick={addWord}
+            disabled={!newWord.trim() || wordAction.state.loading}
+            class="flex items-center gap-2 px-5 py-3.5 bg-primary text-white rounded-2xl text-sm font-bold transition-all hover:bg-primary/90 active:scale-95 disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            <Papicon icon="plus" size={16} />
+            Ajouter
+          </button>
         </div>
+
+        <InlineFeedback state={wordAction} />
+
+        <!-- Liste des mots personnalisés -->
+        {#if customWords.length > 0}
+          <div class="rounded-2xl border border-outline-variant/20 overflow-hidden">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="bg-surface-container/40 text-left">
+                  <th class="px-5 py-3 text-xs font-black uppercase tracking-widest text-on-surface-variant/50">Mot</th>
+                  <th class="px-5 py-3 text-xs font-black uppercase tracking-widest text-on-surface-variant/50">Catégorie</th>
+                  <th class="px-5 py-3 text-xs font-black uppercase tracking-widest text-on-surface-variant/50 text-center">Actif</th>
+                  <th class="px-3 py-3"></th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-outline-variant/10">
+                {#each customWords as entry (entry.id)}
+                  {@const cat = getCat(entry.category)}
+                  <tr class="hover:bg-surface-container/20 transition-colors {entry.enabled ? '' : 'opacity-40'}">
+                    <td class="px-5 py-3 font-mono font-semibold text-on-surface">{entry.word}</td>
+                    <td class="px-5 py-3">
+                      <span class="inline-flex items-center px-2.5 py-1 rounded-lg text-xs font-bold border {cat.bg} {cat.color}">
+                        {cat.label}
+                      </span>
+                    </td>
+                    <td class="px-5 py-3 text-center">
+                      <ToggleSwitch checked={entry.enabled} onToggle={() => handleToggle(entry)} disabled={wordAction.state.loading} />
+                    </td>
+                    <td class="px-3 py-3 text-right">
+                      <button
+                        onclick={() => handleDelete(entry)}
+                        disabled={wordAction.state.loading}
+                        aria-label="Supprimer {entry.word}"
+                        class="p-2 rounded-xl text-on-surface-variant/40 hover:text-error hover:bg-error/10 transition-all disabled:opacity-30"
+                      >
+                        <Papicon icon="trash" size={15} />
+                      </button>
+                    </td>
+                  </tr>
+                {/each}
+              </tbody>
+            </table>
+          </div>
+          <p class="text-xs text-on-surface-variant/40 text-right">{customWords.length} mot(s) personnalisé(s)</p>
+        {:else}
+          <div class="flex flex-col items-center gap-3 py-10 text-on-surface-variant/30">
+            <Papicon icon="filter" size={36} class="opacity-20" />
+            <p class="text-sm font-semibold">Aucun mot personnalisé.</p>
+            <p class="text-xs">La liste globale est toujours active.</p>
+          </div>
+        {/if}
+
       {:else}
-        <div class="flex flex-col items-center gap-3 py-8 text-on-surface-variant/40">
-          <Papicon icon="tag" size={32} class="opacity-30" />
-          <p class="text-sm font-medium">Aucun mot personnalisé ajouté.</p>
-          <p class="text-xs">La liste de base est toujours active.</p>
-        </div>
-      {/if}
-
-      <!-- Compteur -->
-      {#if bannedWords.length > 0}
-        <p class="text-xs text-on-surface-variant/50 text-right">
-          {bannedWords.length} / 200 mots personnalisés
-        </p>
+        <!-- Liste globale (read-only) -->
+        {#if globalWords.length > 0}
+          <div class="rounded-2xl border border-outline-variant/20 overflow-hidden">
+            <div class="bg-surface-container/30 px-5 py-3 flex items-center gap-2 text-xs text-on-surface-variant/50 border-b border-outline-variant/10">
+              <Papicon icon="lock" size={12} />
+              <span>Ces mots sont gérés globalement et ne peuvent pas être modifiés ici.</span>
+            </div>
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="bg-surface-container/40 text-left">
+                  <th class="px-5 py-3 text-xs font-black uppercase tracking-widest text-on-surface-variant/50">Mot</th>
+                  <th class="px-5 py-3 text-xs font-black uppercase tracking-widest text-on-surface-variant/50">Catégorie</th>
+                  <th class="px-5 py-3 text-xs font-black uppercase tracking-widest text-on-surface-variant/50 text-center">Actif</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-outline-variant/10">
+                {#each globalWords as entry (entry.id)}
+                  {@const cat = getCat(entry.category)}
+                  <tr class="hover:bg-surface-container/20 transition-colors {entry.enabled ? '' : 'opacity-40'}">
+                    <td class="px-5 py-3 font-mono font-semibold text-on-surface">{entry.word}</td>
+                    <td class="px-5 py-3">
+                      <span class="inline-flex items-center px-2.5 py-1 rounded-lg text-xs font-bold border {cat.bg} {cat.color}">
+                        {cat.label}
+                      </span>
+                    </td>
+                    <td class="px-5 py-3 text-center">
+                      <span class="inline-flex items-center gap-1.5 text-xs font-bold {entry.enabled ? 'text-primary' : 'text-on-surface-variant/30'}">
+                        <span class="w-2 h-2 rounded-full {entry.enabled ? 'bg-primary' : 'bg-on-surface-variant/20'}"></span>
+                        {entry.enabled ? 'Actif' : 'Inactif'}
+                      </span>
+                    </td>
+                  </tr>
+                {/each}
+              </tbody>
+            </table>
+          </div>
+          <p class="text-xs text-on-surface-variant/40 text-right">{globalWords.length} mot(s) global/globaux</p>
+        {:else}
+          <div class="flex flex-col items-center gap-3 py-10 text-on-surface-variant/30">
+            <Papicon icon="filter" size={36} class="opacity-20" />
+            <p class="text-sm font-semibold">Aucun mot global configuré.</p>
+          </div>
+        {/if}
       {/if}
     </section>
   {/if}

--- a/apps/dashboard/src/pages/NicknameModeration.svelte
+++ b/apps/dashboard/src/pages/NicknameModeration.svelte
@@ -1,0 +1,207 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import ModulePage from '../lib/components/ModulePage.svelte';
+  import ActionButton from '../lib/components/ActionButton.svelte';
+  import ToggleSwitch from '../lib/components/ToggleSwitch.svelte';
+  import InlineFeedback from '../lib/components/InlineFeedback.svelte';
+  import Papicon from '../lib/components/Papicon.svelte';
+  import { createAsyncActionState } from '../lib/asyncAction.svelte';
+  import { fetchNicknameModerationConfig, updateNicknameModerationConfig } from '../lib/api';
+
+  // ---- State ---------------------------------------------------------------
+  let enabled = $state(false);
+  let bannedWords = $state<string[]>([]);
+
+  /** Mot en cours de saisie dans l'input */
+  let newWord = $state('');
+
+  let loading = $state(true);
+  let loadError = $state('');
+
+  const saveAction = createAsyncActionState();
+
+  // ---- Lifecycle -----------------------------------------------------------
+  onMount(async () => {
+    try {
+      const data = await fetchNicknameModerationConfig();
+      if (data) {
+        enabled = data.enabled ?? false;
+        bannedWords = Array.isArray(data.bannedWords) ? [...data.bannedWords] : [];
+      }
+    } catch (err) {
+      loadError = err instanceof Error ? err.message : 'Impossible de charger la configuration.';
+    } finally {
+      loading = false;
+    }
+  });
+
+  // ---- Actions -------------------------------------------------------------
+
+  function addWord() {
+    const trimmed = newWord.trim().toLowerCase();
+    if (!trimmed || bannedWords.includes(trimmed) || trimmed.length > 100) return;
+    bannedWords = [...bannedWords, trimmed];
+    newWord = '';
+  }
+
+  function removeWord(word: string) {
+    bannedWords = bannedWords.filter((w) => w !== word);
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      addWord();
+    }
+  }
+
+  async function save() {
+    await saveAction.run(
+      async () => {
+        const ok = await updateNicknameModerationConfig({ enabled, bannedWords });
+        if (!ok) throw new Error('La sauvegarde a échoué.');
+        return true;
+      },
+      { successMessage: 'Configuration sauvegardée avec succès.' }
+    );
+  }
+</script>
+
+<ModulePage
+  title="Modération des pseudos"
+  description="Renomme automatiquement les pseudos non conformes dès qu'un membre rejoint ou modifie son pseudo."
+  icon="tag"
+  featureKey="nickname_moderation"
+>
+  {#snippet actions()}
+    <ActionButton onclick={save} loading={saveAction.state.loading} disabled={loading}>
+      Sauvegarder
+    </ActionButton>
+  {/snippet}
+
+  <InlineFeedback state={saveAction} />
+
+  {#if loading}
+    <!-- Skeleton loader -->
+    <div class="flex flex-col gap-6 animate-pulse">
+      {#each [1, 2] as _}
+        <div class="h-24 rounded-3xl bg-surface-container-low/60"></div>
+      {/each}
+    </div>
+  {:else if loadError}
+    <div class="rounded-3xl bg-error/10 border border-error/20 p-6 text-error text-sm font-semibold">
+      {loadError}
+    </div>
+  {:else}
+    <!-- ================================================================ -->
+    <!-- Section 1 — Toggle principal                                      -->
+    <!-- ================================================================ -->
+    <section class="bg-surface-container-low/40 backdrop-blur-xl rounded-4xl border border-outline-variant/30 p-8 flex flex-col gap-6">
+      <div class="flex items-start justify-between gap-6">
+        <div class="flex flex-col gap-1">
+          <h2 class="text-base font-black tracking-tight text-on-surface">Activation</h2>
+          <p class="text-sm text-on-surface-variant/70">
+            Lorsqu'activé, le bot vérifie automatiquement les pseudos des nouveaux membres et des
+            membres qui modifient leur pseudo. Si un pseudo est non conforme, il est remplacé
+            par <code class="font-mono text-primary bg-primary/10 px-1.5 py-0.5 rounded-lg text-xs">pseudo non conforme | automod</code>.
+          </p>
+        </div>
+        <div class="flex-shrink-0">
+          <ToggleSwitch checked={enabled} onToggle={() => (enabled = !enabled)} />
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-3 p-4 rounded-2xl bg-surface-container/30 border border-outline-variant/20">
+        <div class="flex items-center gap-2 text-xs font-black uppercase tracking-widest text-on-surface-variant/60">
+          <Papicon icon="info" size={14} />
+          <span>Ce que le bot surveille</span>
+        </div>
+        <ul class="text-sm text-on-surface-variant/80 flex flex-col gap-1.5 list-none">
+          <li class="flex items-center gap-2"><span class="text-primary">→</span> Nouveaux membres rejoignant le serveur</li>
+          <li class="flex items-center gap-2"><span class="text-primary">→</span> Membres modifiant leur pseudo sur le serveur</li>
+          <li class="flex items-center gap-2"><span class="text-primary">→</span> Pseudos composés de caractères invisibles ou non affichables</li>
+          <li class="flex items-center gap-2"><span class="text-primary">→</span> Une liste de mots problématiques par défaut (racisme, menaces, insultes...)</li>
+          <li class="flex items-center gap-2"><span class="text-primary">→</span> Vos mots personnalisés ajoutés ci-dessous</li>
+        </ul>
+        <p class="text-xs text-on-surface-variant/50 mt-1 italic">
+          Note : Le bot ne peut pas renommer le propriétaire du serveur (limitation Discord).
+        </p>
+      </div>
+    </section>
+
+    <!-- ================================================================ -->
+    <!-- Section 2 — Liste de mots personnalisés                           -->
+    <!-- ================================================================ -->
+    <section class="bg-surface-container-low/40 backdrop-blur-xl rounded-4xl border border-outline-variant/30 p-8 flex flex-col gap-6">
+      <div class="flex flex-col gap-1">
+        <h2 class="text-base font-black tracking-tight text-on-surface">Mots interdits personnalisés</h2>
+        <p class="text-sm text-on-surface-variant/70">
+          Ajoutez ici les mots ou fragments que vous souhaitez interdire sur votre serveur, en plus de la liste de base. 
+          La comparaison est insensible à la casse.
+          Maximum <strong>200 mots</strong>, 100 caractères par mot.
+        </p>
+      </div>
+
+      <!-- Input d'ajout -->
+      <div class="flex gap-3 items-center">
+        <div class="flex-1 relative">
+          <input
+            id="nickname-word-input"
+            type="text"
+            bind:value={newWord}
+            onkeydown={handleKeydown}
+            maxlength={100}
+            placeholder="Ajouter un mot ou fragment..."
+            class="w-full bg-surface-container/60 border border-outline-variant/30 rounded-2xl px-5 py-3.5 text-sm text-on-surface placeholder:text-on-surface-variant/30 focus:outline-none focus:border-primary/60 focus:ring-1 focus:ring-primary/20 transition-all"
+          />
+          {#if newWord.length > 80}
+            <span class="absolute right-4 top-1/2 -translate-y-1/2 text-xs text-on-surface-variant/40">
+              {newWord.length}/100
+            </span>
+          {/if}
+        </div>
+        <button
+          onclick={addWord}
+          disabled={!newWord.trim() || bannedWords.includes(newWord.trim().toLowerCase())}
+          class="flex items-center gap-2 px-5 py-3.5 bg-primary text-white rounded-2xl text-sm font-bold tracking-wide transition-all hover:bg-primary/90 active:scale-95 disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          <Papicon icon="plus" size={16} />
+          Ajouter
+        </button>
+      </div>
+
+      <!-- Tags des mots ajoutés -->
+      {#if bannedWords.length > 0}
+        <div class="flex flex-wrap gap-2.5">
+          {#each bannedWords as word (word)}
+            <span
+              class="group flex items-center gap-2 px-3.5 py-1.5 bg-error/10 border border-error/20 text-error rounded-xl text-sm font-semibold transition-all hover:bg-error/15"
+            >
+              <span class="font-mono text-xs">{word}</span>
+              <button
+                onclick={() => removeWord(word)}
+                aria-label="Supprimer {word}"
+                class="opacity-50 group-hover:opacity-100 transition-opacity hover:text-error ml-0.5"
+              >
+                <Papicon icon="x" size={13} />
+              </button>
+            </span>
+          {/each}
+        </div>
+      {:else}
+        <div class="flex flex-col items-center gap-3 py-8 text-on-surface-variant/40">
+          <Papicon icon="tag" size={32} class="opacity-30" />
+          <p class="text-sm font-medium">Aucun mot personnalisé ajouté.</p>
+          <p class="text-xs">La liste de base est toujours active.</p>
+        </div>
+      {/if}
+
+      <!-- Compteur -->
+      {#if bannedWords.length > 0}
+        <p class="text-xs text-on-surface-variant/50 text-right">
+          {bannedWords.length} / 200 mots personnalisés
+        </p>
+      {/if}
+    </section>
+  {/if}
+</ModulePage>

--- a/packages/database/prisma/migrations/20260518000000_add_auto_nickname_moderation/migration.sql
+++ b/packages/database/prisma/migrations/20260518000000_add_auto_nickname_moderation/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "guilds" ADD COLUMN IF NOT EXISTS "autoNicknameModerationEnabled" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "guilds" ADD COLUMN IF NOT EXISTS "autoNicknameModerationWords" TEXT[] NOT NULL DEFAULT '{}';

--- a/packages/database/prisma/migrations/20260523000000_add_banned_words_table/migration.sql
+++ b/packages/database/prisma/migrations/20260523000000_add_banned_words_table/migration.sql
@@ -1,0 +1,123 @@
+-- Migration: add_banned_words_table
+-- Remplace autoNicknameModerationWords String[] sur guilds par une table dédiée banned_words
+
+-- 1. Création de la table banned_words
+CREATE TABLE IF NOT EXISTS "banned_words" (
+  "id"        TEXT NOT NULL,
+  "guildId"   TEXT,
+  "word"      TEXT NOT NULL,
+  "category"  TEXT NOT NULL DEFAULT 'custom',
+  "enabled"   BOOLEAN NOT NULL DEFAULT true,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "banned_words_pkey" PRIMARY KEY ("id")
+);
+
+-- 2. Index de recherche par serveur + état
+CREATE INDEX IF NOT EXISTS "banned_words_guildId_enabled_idx" ON "banned_words"("guildId", "enabled");
+CREATE INDEX IF NOT EXISTS "banned_words_guildId_word_idx" ON "banned_words"("guildId", "word");
+
+-- 3. Index d'unicité partiels (gère correctement les NULL PostgreSQL)
+--    Unicité sur (word) pour les mots globaux (guildId IS NULL)
+CREATE UNIQUE INDEX IF NOT EXISTS "banned_words_global_word_unique"
+  ON "banned_words"("word")
+  WHERE "guildId" IS NULL;
+
+--    Unicité sur (guildId, word) pour les mots de serveur (guildId IS NOT NULL)
+CREATE UNIQUE INDEX IF NOT EXISTS "banned_words_guild_word_unique"
+  ON "banned_words"("guildId", "word")
+  WHERE "guildId" IS NOT NULL;
+
+-- 4. Clé étrangère vers guilds
+ALTER TABLE "banned_words"
+  ADD CONSTRAINT "banned_words_guildId_fkey"
+  FOREIGN KEY ("guildId") REFERENCES "guilds"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- 5. Migration des mots existants depuis autoNicknameModerationWords
+--    Chaque mot du tableau devient une ligne avec le guildId du serveur
+INSERT INTO "banned_words" ("id", "guildId", "word", "category", "enabled", "createdAt", "updatedAt")
+SELECT
+  gen_random_uuid()::text,
+  g."id",
+  TRIM(LOWER(word)),
+  'custom',
+  true,
+  NOW(),
+  NOW()
+FROM "guilds" g,
+     UNNEST(g."autoNicknameModerationWords") AS word
+WHERE TRIM(LOWER(word)) != ''
+ON CONFLICT DO NOTHING;
+
+-- 6. Suppression de l'ancienne colonne
+ALTER TABLE "guilds" DROP COLUMN IF EXISTS "autoNicknameModerationWords";
+
+-- 7. Seed des mots globaux (guildId = NULL) — liste de base
+--    Ces mots sont partagés entre tous les serveurs, gérables uniquement par les admins globaux
+INSERT INTO "banned_words" ("id", "guildId", "word", "category", "enabled", "createdAt", "updatedAt")
+VALUES
+  -- Racisme / haine ethnique FR
+  (gen_random_uuid()::text, NULL, 'nègre',             'racism',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'négro',             'racism',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'neger',             'racism',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'niggr',             'racism',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'nigger',            'racism',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'nigga',             'racism',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'youpin',            'racism',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'youpine',           'racism',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'feuj',              'racism',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'juif de merde',     'racism',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'sale juif',         'racism',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'arabe de merde',    'racism',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'sale arabe',        'racism',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'bougnoule',         'racism',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'bicot',             'racism',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'crouille',          'racism',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'chinetoque',        'racism',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'ritale',            'racism',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'polak',             'racism',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'raton',             'racism',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'bamboula',          'racism',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'nègresse',          'racism',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'noiraud',           'racism',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'renoi',             'racism',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'kebla',             'racism',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'reubeu',            'racism',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'gitan de merde',    'racism',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'romanichel',        'racism',    true, NOW(), NOW()),
+  -- Menaces
+  (gen_random_uuid()::text, NULL, 'je vais te tuer',   'threat',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'je vais te crever', 'threat',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'death threat',      'threat',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'kill yourself',     'threat',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'kys',               'threat',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'go die',            'threat',    true, NOW(), NOW()),
+  -- Idéologie haineuse
+  (gen_random_uuid()::text, NULL, 'pédophile',         'hate',      true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'pedo',              'hate',      true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'nazi',              'hate',      true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'führer',            'hate',      true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'hitler',            'hate',      true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'heil',              'hate',      true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'génocide',          'hate',      true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'zyklon',            'hate',      true, NOW(), NOW()),
+  -- LGBTphobie
+  (gen_random_uuid()::text, NULL, 'pédé',              'lgbtphobia',true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'pede',              'lgbtphobia',true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'tapette',           'lgbtphobia',true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'gouine',            'lgbtphobia',true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'fiotte',            'lgbtphobia',true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'travelo',           'lgbtphobia',true, NOW(), NOW()),
+  -- Sexuel explicite
+  (gen_random_uuid()::text, NULL, 'bite',              'sexual',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'pénis',             'sexual',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'vagin',             'sexual',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'enculé',            'sexual',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'encule',            'sexual',    true, NOW(), NOW()),
+  -- Insultes EN
+  (gen_random_uuid()::text, NULL, 'motherfucker',      'insult',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'cunt',              'insult',    true, NOW(), NOW()),
+  (gen_random_uuid()::text, NULL, 'faggot',            'insult',    true, NOW(), NOW())
+ON CONFLICT DO NOTHING;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -48,6 +48,9 @@ model Guild {
 
   codePoliceEnabled        Boolean @default(false)
   codePoliceRules          CodePoliceRule[]
+
+  autoNicknameModerationEnabled Boolean   @default(false)
+  autoNicknameModerationWords   String[]  @default([])
   
   dailyAlgoEnabled         Boolean @default(false)
   dailyAlgoChannelId       String?

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -50,7 +50,7 @@ model Guild {
   codePoliceRules          CodePoliceRule[]
 
   autoNicknameModerationEnabled Boolean   @default(false)
-  autoNicknameModerationWords   String[]  @default([])
+  bannedWords              BannedWord[]
   
   dailyAlgoEnabled         Boolean @default(false)
   dailyAlgoChannelId       String?
@@ -174,6 +174,23 @@ model DashboardAuditLog {
 
   @@index([guildId, dateIso])
   @@map("dashboard_audit_logs")
+}
+
+model BannedWord {
+  id       String  @id @default(cuid())
+  guildId  String? // null = global (visible par tous les serveurs, read-only dashboard)
+  word     String
+  category String  @default("custom") // custom | racism | threat | sexual | lgbtphobia | etc.
+  enabled  Boolean @default(true)
+
+  guild Guild? @relation(fields: [guildId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([guildId, word])
+  @@index([guildId, enabled])
+  @@map("banned_words")
 }
 
 model CodePoliceRule {


### PR DESCRIPTION
- Add `autoNicknameModerationEnabled` and `autoNicknameModerationWords` fields to Guild schema
- Add SQL migration for new guild columns
- Add `nicknameModerationService` with built-in banned words list (FR/EN)
- Add `nicknameModeration` event listener on GuildMemberAdd and GuildMemberUpdate
- Add GET/PATCH `/nickname-moderation` API endpoints with 60s cache invalidation
- Add dashboard page with enable toggle and custom banned words tag editor
- Register listener in bot index and expose toggle in prismaToggles
- Add "Pseudos" entry in dashboard sidebar under Moderation section