### PR TITLE
Rate-limit and sanitize dashboard error reports

### DIFF
--- a/apps/bot/package.json
+++ b/apps/bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kotbo/bot",
-  "version": "7.8",
+  "version": "7.9",
   "private": true,
   "scripts": {
     "migrate:deploy": "cd ../.. && bun run db:migrate:deploy",

--- a/apps/bot/src/api/dashboardApi.ts
+++ b/apps/bot/src/api/dashboardApi.ts
@@ -2637,6 +2637,50 @@ export const startDashboardApi = (client: Client) => {
 
   dashboardStateBroadcaster = broadcastDashboardStateChange;
 
+  const getClientIp = (req: IncomingMessage): string => {
+    const forwarded = req.headers['x-forwarded-for'];
+    if (forwarded) {
+      if (typeof forwarded === 'string') {
+        return forwarded.split(',')[0].trim();
+      } else if (Array.isArray(forwarded) && forwarded.length > 0) {
+        return forwarded[0].trim();
+      }
+    }
+    return req.socket.remoteAddress || '127.0.0.1';
+  };
+
+  const configRateLimiter = new Map<string, number[]>();
+  const errorReportRateLimiter = new Map<string, number[]>();
+
+  const checkRateLimit = (limiterMap: Map<string, number[]>, ip: string, limit: number, windowMs: number): boolean => {
+    const now = Date.now();
+    const timestamps = limiterMap.get(ip) || [];
+    const validTimestamps = timestamps.filter(t => now - t < windowMs);
+    if (validTimestamps.length >= limit) {
+      return false;
+    }
+    validTimestamps.push(now);
+    limiterMap.set(ip, validTimestamps);
+    return true;
+  };
+
+  // Clean up expired entries every 10 minutes
+  setInterval(() => {
+    const now = Date.now();
+    const cleanLimiter = (limiterMap: Map<string, number[]>, windowMs: number) => {
+      for (const [ip, timestamps] of limiterMap.entries()) {
+        const valid = timestamps.filter(t => now - t < windowMs);
+        if (valid.length === 0) {
+          limiterMap.delete(ip);
+        } else {
+          limiterMap.set(ip, valid);
+        }
+      }
+    };
+    cleanLimiter(configRateLimiter, 60 * 1000);
+    cleanLimiter(errorReportRateLimiter, 15 * 60 * 1000);
+  }, 10 * 60 * 1000).unref();
+
   const server = createServer(async (req, res) => {
     // Standard CORS headers for all responses
     const origin = req.headers.origin;
@@ -2977,6 +3021,12 @@ export const startDashboardApi = (client: Client) => {
       }
 
       if (url.pathname === '/api/config' && req.method === 'GET') {
+        const ip = getClientIp(req);
+        if (!checkRateLimit(configRateLimiter, ip, 30, 60 * 1000)) {
+          json(res, 429, { error: 'Trop de requêtes. Veuillez réessayer plus tard.' });
+          return;
+        }
+
         const missingOAuth = getMissingOAuthConfig();
         if (missingOAuth.length > 0) {
           json(res, 500, {
@@ -3074,19 +3124,50 @@ export const startDashboardApi = (client: Client) => {
         }
       }
       if (parts[0] === 'api' && parts[1] === 'report-error' && req.method === 'POST') {
+        const ip = getClientIp(req);
+        if (!checkRateLimit(errorReportRateLimiter, ip, 5, 15 * 60 * 1000)) {
+          json(res, 429, { error: 'Trop de rapports d\'erreur envoyés. Veuillez réessayer plus tard.' });
+          return;
+        }
+
         try {
           const payload = await readJsonBody<{
-            error: string;
-            stack?: string;
-            url: string;
-            userAgent: string;
-            guildId?: string | null;
+            error: any;
+            stack?: any;
+            url: any;
+            userAgent: any;
+            guildId?: any;
           }>(req);
 
-          if (!payload || !payload.error) {
+          if (
+            !payload ||
+            typeof payload.error !== 'string' ||
+            payload.error.trim() === '' ||
+            (payload.stack !== undefined && typeof payload.stack !== 'string') ||
+            (payload.url !== undefined && typeof payload.url !== 'string') ||
+            (payload.userAgent !== undefined && typeof payload.userAgent !== 'string') ||
+            (payload.guildId !== undefined && payload.guildId !== null && typeof payload.guildId !== 'string')
+          ) {
             json(res, 400, { error: 'Payload invalide' });
             return;
           }
+
+          // Enforce string limit sizes
+          const errorStr = payload.error.slice(0, 1000);
+          const stackStr = payload.stack ? payload.stack.slice(0, 2000) : undefined;
+          const urlStr = payload.url ? payload.url.slice(0, 500) : 'Inconnu';
+          const userAgentStr = payload.userAgent ? payload.userAgent.slice(0, 250) : 'Inconnu';
+          const guildIdStr = payload.guildId ? payload.guildId.slice(0, 50) : 'Aucun';
+
+          // Validate URL origin to avoid spamming/spoofing irrelevant URLs
+          const allowedOriginPattern = /^(https?:\/\/)?([a-zA-Z0-9-]+\.)*(nathaan\.me|localhost)(:\d+)?(\/.*)?$/;
+          if (payload.url && !allowedOriginPattern.test(payload.url)) {
+            json(res, 400, { error: 'URL non autorisée' });
+            return;
+          }
+
+          // Sanitize backticks to prevent escaping markdown code blocks in Discord Embeds
+          const sanitizeMarkdown = (str: string) => str.replace(/`/g, '\\`');
 
           const user = verifyAuth(req);
           const userInfo = user
@@ -3114,17 +3195,14 @@ export const startDashboardApi = (client: Client) => {
             .setTimestamp()
             .addFields(
               { name: '👤 Utilisateur', value: userInfo },
-              { name: '🌐 Page / URL', value: `\`${payload.url}\`` },
-              { name: '💻 Navigateur', value: `\`${payload.userAgent || 'Inconnu'}\`` },
-              { name: '🏰 Serveur sélectionné (Guild ID)', value: `\`${payload.guildId || 'Aucun'}\`` },
-              { name: '❌ Erreur', value: `\`\`\`\n${payload.error}\n\`\`\`` }
+              { name: '🌐 Page / URL', value: `\`${sanitizeMarkdown(urlStr)}\`` },
+              { name: '💻 Navigateur', value: `\`${sanitizeMarkdown(userAgentStr)}\`` },
+              { name: '🏰 Serveur sélectionné (Guild ID)', value: `\`${sanitizeMarkdown(guildIdStr)}\`` },
+              { name: '❌ Erreur', value: `\`\`\`\n${sanitizeMarkdown(errorStr)}\n\`\`\`` }
             );
 
-          if (payload.stack) {
-            const truncatedStack = payload.stack.length > 1000 
-              ? payload.stack.slice(0, 1000) + '...' 
-              : payload.stack;
-            embed.addFields({ name: '🥞 Stack Trace', value: `\`\`\`javascript\n${truncatedStack}\n\`\`\`` });
+          if (stackStr) {
+            embed.addFields({ name: '🥞 Stack Trace', value: `\`\`\`javascript\n${sanitizeMarkdown(stackStr)}\n\`\`\`` });
           }
 
           await owner.send({ embeds: [embed] });

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kotbo/dashboard",
   "private": true,
-  "version": "4.8",
+  "version": "4.12",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Add IP extraction and in-memory rate limiting for dashboard endpoints to prevent abuse: 30 requests/min for GET /api/config and 5 reports per 15 minutes for POST /api/report-error. Implement checkRateLimit helpers, periodic cleanup of expired entries (every 10 minutes, unref'd), and use client IP from X-Forwarded-For or socket as fallback. Validate and enforce payload types and max string lengths for error, stack, url, userAgent, and guildId; restrict reported URLs to allowed origins; sanitize backticks to avoid markdown escaping in Discord embeds; truncate fields and update embed construction accordingly. Also bump package versions: @kotbo/bot -> 7.9 and @kotbo/dashboard -> 4.12.