### PR TITLE
Harden dashboard API auth and security

### DIFF
--- a/apps/bot/package.json
+++ b/apps/bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kotbo/bot",
-  "version": "7.8",
+  "version": "7.10",
   "private": true,
   "scripts": {
     "migrate:deploy": "cd ../.. && bun run db:migrate:deploy",

--- a/apps/bot/src/api/dashboardApi.ts
+++ b/apps/bot/src/api/dashboardApi.ts
@@ -117,10 +117,16 @@ import { publishOrUpdateRegulationMessage } from '../services/regulationService.
 import { publishNewsArticle, generateRssXml } from '../services/newsService.js';
 import { env } from 'node:process';
 
+import crypto from 'node:crypto';
+
 const DISCORD_CLIENT_ID = process.env.DISCORD_CLIENT_ID;
 const DISCORD_CLIENT_SECRET = process.env.DISCORD_CLIENT_SECRET;
 const DISCORD_REDIRECT_URI = process.env.DISCORD_REDIRECT_URI;
-const JWT_SECRET = process.env.JWT_SECRET || 'kotbo-secret-key-123';
+let JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+  logger.warn('DashboardAPI', 'JWT_SECRET variable is not set. Generating ephemeral secret. Instance-isolated!');
+  JWT_SECRET = crypto.randomBytes(32).toString('hex');
+}
 const DASHBOARD_URL = process.env.DASHBOARD_URL || 'http://localhost:5173';
 const DEFAULT_TRANSLATION_TARGET_LANG = 'FR';
 const DISCORD_CLIENT_OWNER_ID = process.env.DISCORD_CLIENT_OWNER_ID;
@@ -1137,14 +1143,30 @@ async function resolveAdminAccess(client: Client, userId: string): Promise<boole
 
 
 
+class HttpError extends Error {
+  statusCode: number;
+  constructor(statusCode: number, message: string) {
+    super(message);
+    this.statusCode = statusCode;
+  }
+}
+
 const readJsonBody = async <T>(req: IncomingMessage): Promise<T | null> => {
+  const contentType = req.headers['content-type'];
+  if (!contentType || !contentType.includes('application/json')) {
+    throw new HttpError(415, 'Content-Type doit être application/json');
+  }
   const chunks: Buffer[] = [];
   for await (const chunk of req) {
     chunks.push(Buffer.from(chunk));
   }
   if (chunks.length === 0) return null;
   const raw = Buffer.concat(chunks).toString('utf8');
-  return JSON.parse(raw) as T;
+  try {
+    return JSON.parse(raw) as T;
+  } catch (err) {
+    throw new HttpError(400, 'Format JSON invalide');
+  }
 };
 
 const truncate = (value?: string | null, length = 160) => {
@@ -2629,7 +2651,7 @@ export const startDashboardApi = (client: Client) => {
     });
 
     wsServer.clients.forEach((socket) => {
-      if (socket.readyState === WebSocket.OPEN) {
+      if (socket.readyState === WebSocket.OPEN && (socket as any).isAuthenticated) {
         socket.send(payload);
       }
     });
@@ -2638,17 +2660,35 @@ export const startDashboardApi = (client: Client) => {
   dashboardStateBroadcaster = broadcastDashboardStateChange;
 
   const server = createServer(async (req, res) => {
-    // Standard CORS headers for all responses
+    // CORS whitelist verification
+    const allowedOrigins = new Set([
+      DASHBOARD_URL.replace(/\/$/, ''),
+      'http://localhost:5173',
+      'http://localhost:3000'
+    ]);
     const origin = req.headers.origin;
     if (origin) {
-      res.setHeader('Access-Control-Allow-Origin', origin);
-      res.setHeader('Access-Control-Allow-Credentials', 'true');
+      const sanitizedOrigin = origin.replace(/\/$/, '');
+      if (allowedOrigins.has(sanitizedOrigin)) {
+        res.setHeader('Access-Control-Allow-Origin', origin);
+        res.setHeader('Access-Control-Allow-Credentials', 'true');
+      } else {
+        res.setHeader('Access-Control-Allow-Origin', DASHBOARD_URL);
+      }
     } else {
-      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader('Access-Control-Allow-Origin', DASHBOARD_URL);
     }
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, Accept, Origin, X-Requested-With, Cache-Control, Pragma');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, Accept, Origin, X-Requested-With, Cache-Control, Pragma, X-Kotbo-API-Key, X-API-Key');
     res.setHeader('Access-Control-Max-Age', '86400');
+
+    // Security response headers
+    res.setHeader('Content-Security-Policy', "default-src 'self';");
+    res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+    res.setHeader('X-Frame-Options', 'DENY');
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+    res.setHeader('Permissions-Policy', 'geolocation=(), camera=(), microphone=()');
 
     try {
       if (!req.url) {
@@ -2667,6 +2707,10 @@ export const startDashboardApi = (client: Client) => {
 
       if (parts[0] === 'api' && parts[1] === 'public' && parts[2] === 'profile' && parts[3] && req.method === 'GET') {
         const userId = parts[3];
+        if (!/^\d{17,19}$/.test(userId)) {
+          json(res, 400, { error: 'ID utilisateur invalide' });
+          return;
+        }
         try {
           let snapshot = await getPublicProfileSnapshot(userId);
           let profile = snapshot?.memberProfile;
@@ -2808,6 +2852,10 @@ export const startDashboardApi = (client: Client) => {
 
       if (parts[0] === 'api' && parts[1] === 'public' && parts[2] === 'profile' && parts[3] && req.method === 'PATCH') {
         const userId = parts[3];
+        if (!/^\d{17,19}$/.test(userId)) {
+          json(res, 400, { error: 'ID utilisateur invalide' });
+          return;
+        }
         const authUser = verifyAuth(req);
         if (!authUser) {
           json(res, 401, { error: 'Non authentifié' });
@@ -2861,6 +2909,10 @@ export const startDashboardApi = (client: Client) => {
         req.method === 'GET'
       ) {
         const userId = parts[3];
+        if (!/^\d{17,19}$/.test(userId)) {
+          json(res, 400, { error: 'ID utilisateur invalide' });
+          return;
+        }
         const url = new URL(req.url, `http://${req.headers.host}`);
         const days = parseInt(url.searchParams.get('days') || '14', 10);
         try {
@@ -2904,6 +2956,10 @@ export const startDashboardApi = (client: Client) => {
 
       if (parts[0] === 'api' && parts[1] === 'public' && parts[2] === 'rss' && parts[3] && req.method === 'GET') {
         const guildId = parts[3];
+        if (!/^\d{17,19}$/.test(guildId)) {
+          json(res, 400, { error: 'ID de guilde invalide' });
+          return;
+        }
         const category = parts[4] ? decodeURIComponent(parts[4]) : url.searchParams.get('category');
         const subcategory = parts[5] ? decodeURIComponent(parts[5]) : url.searchParams.get('subcategory');
         
@@ -2951,6 +3007,10 @@ export const startDashboardApi = (client: Client) => {
 
       if (parts[0] === 'api' && parts[1] === 'public' && parts[2] === 'transcripts' && parts[3] && req.method === 'GET') {
         const transcriptId = parts[3];
+        if (!/^[a-zA-Z0-9_\-]+$/.test(transcriptId)) {
+          json(res, 400, { error: 'ID de transcription invalide' });
+          return;
+        }
         try {
           const transcript = await prisma.transcript.findUnique({
             where: { id: transcriptId }
@@ -3004,7 +3064,10 @@ export const startDashboardApi = (client: Client) => {
               return;
             }
 
-            const discordUrl = `https://discord.com/api/oauth2/authorize?client_id=${DISCORD_CLIENT_ID}&redirect_uri=${encodeURIComponent(DISCORD_REDIRECT_URI!)}&response_type=code&scope=identify%20guilds`;
+            const state = crypto.randomBytes(16).toString('hex');
+            res.setHeader('Set-Cookie', `kotbo_oauth_state=${state}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=300`);
+
+            const discordUrl = `https://discord.com/api/oauth2/authorize?client_id=${DISCORD_CLIENT_ID}&redirect_uri=${encodeURIComponent(DISCORD_REDIRECT_URI!)}&response_type=code&scope=identify%20guilds&state=${state}`;
             res.writeHead(302, { Location: discordUrl });
             res.end();
             return;
@@ -3019,6 +3082,21 @@ export const startDashboardApi = (client: Client) => {
               });
               return;
             }
+
+            // Verify state
+            const cookies = req.headers.cookie ? Object.fromEntries(req.headers.cookie.split(';').map(c => c.trim().split('='))) : {};
+            const cookieState = cookies['kotbo_oauth_state'];
+            const urlState = url.searchParams.get('state');
+
+            if (!cookieState || !urlState || cookieState !== urlState) {
+              logger.warn('Auth', 'OAuth state verification failed');
+              res.writeHead(302, { Location: `${DASHBOARD_URL}/login?error=invalid_state` });
+              res.end();
+              return;
+            }
+
+            // Clear state cookie
+            res.setHeader('Set-Cookie', 'kotbo_oauth_state=; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=0');
 
             const code = url.searchParams.get('code');
             if (!code) {
@@ -3058,7 +3136,7 @@ export const startDashboardApi = (client: Client) => {
                 discordToken: tokenData.access_token
               }, JWT_SECRET, { expiresIn: '7d' });
 
-              res.writeHead(302, { Location: `${DASHBOARD_URL}?token=${token}` });
+              res.writeHead(302, { Location: `${DASHBOARD_URL}#token=${token}` });
               res.end();
             } catch (err) {
               logger.error('Auth', 'Discord callback error:', err);
@@ -3089,9 +3167,11 @@ export const startDashboardApi = (client: Client) => {
           }
 
           const user = verifyAuth(req);
-          const userInfo = user
-            ? `**Utilisateur:** <@${user.userId}> (${user.username} - ID: ${user.userId})`
-            : `**Utilisateur:** Non connecté / Inconnu`;
+          if (!user) {
+            json(res, 401, { error: 'Non authentifié' });
+            return;
+          }
+          const userInfo = `**Utilisateur:** <@${user.userId}> (${user.username} - ID: ${user.userId})`;
 
           const ownerId = process.env.DISCORD_CLIENT_OWNER_ID;
           if (!ownerId) {
@@ -11746,19 +11826,57 @@ export const startDashboardApi = (client: Client) => {
 
       json(res, 404, { error: 'Route introuvable' });
 
-    } catch (error) {
+    } catch (error: any) {
+      if (error && typeof error === 'object' && 'statusCode' in error) {
+        json(res, error.statusCode, { error: error.message });
+        return;
+      }
       logger.error('DashboardAPI', error);
       json(res, 500, { error: 'Erreur interne API dashboard' });
     }
   });
 
   wsServer.on('connection', (socket) => {
-    socket.send(
-      JSON.stringify({
-        type: 'dashboard_ws_connected',
-        at: new Date().toISOString(),
-      }),
-    );
+    (socket as any).isAuthenticated = false;
+
+    socket.on('message', (messageData) => {
+      try {
+        const raw = messageData.toString('utf8');
+        const data = JSON.parse(raw);
+
+        if (data.type === 'auth') {
+          const token = data.token;
+          if (!token) {
+            socket.close(4001, 'Token manquant');
+            return;
+          }
+
+          try {
+            const decoded = jwt.verify(token, JWT_SECRET);
+            (socket as any).isAuthenticated = true;
+            (socket as any).userId = (decoded as any).userId;
+
+            socket.send(
+              JSON.stringify({
+                type: 'dashboard_ws_connected',
+                at: new Date().toISOString(),
+              }),
+            );
+          } catch {
+            socket.close(4003, 'Token invalide');
+          }
+        }
+      } catch (err) {
+        socket.close(4000, 'Payload invalide');
+      }
+    });
+
+    // Enforce authentication timeout (disconnect if not authenticated within 5s)
+    setTimeout(() => {
+      if (!(socket as any).isAuthenticated) {
+        socket.close(4008, 'Timeout authentification');
+      }
+    }, 5000);
   });
 
   // Diffuser les messages des salons de tickets en temps réel
@@ -11803,7 +11921,7 @@ export const startDashboardApi = (client: Client) => {
       });
 
       wsServer.clients.forEach((socket) => {
-        if (socket.readyState === WebSocket.OPEN) {
+        if (socket.readyState === WebSocket.OPEN && (socket as any).isAuthenticated) {
           socket.send(payload);
         }
       });
@@ -11824,20 +11942,9 @@ export const startDashboardApi = (client: Client) => {
       return;
     }
 
-    const token = url.searchParams.get('token');
-    if (!token) {
-      socket.destroy();
-      return;
-    }
-
-    try {
-      jwt.verify(token, JWT_SECRET);
-      wsServer.handleUpgrade(req, socket, head, (ws) => {
-        wsServer.emit('connection', ws, req);
-      });
-    } catch {
-      socket.destroy();
-    }
+    wsServer.handleUpgrade(req, socket, head, (ws) => {
+      wsServer.emit('connection', ws, req);
+    });
   });
 
   server.listen(port, () => {

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kotbo/dashboard",
   "private": true,
-  "version": "4.8",
+  "version": "4.13",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/dashboard/src/App.svelte
+++ b/apps/dashboard/src/App.svelte
@@ -120,7 +120,12 @@
   onMount(() => {
     
     const urlParams = new URLSearchParams(window.location.search);
-    const token = urlParams.get('token');
+    let token = urlParams.get('token');
+    
+    if (!token && window.location.hash) {
+      const hashParams = new URLSearchParams(window.location.hash.substring(1));
+      token = hashParams.get('token');
+    }
     
     if (token) {
       authStore.setToken(token);

--- a/apps/dashboard/src/lib/dashboardLifecycle.ts
+++ b/apps/dashboard/src/lib/dashboardLifecycle.ts
@@ -80,12 +80,17 @@ class DashboardLifecycleManager {
       }
 
       const wsUrl = new URL(DASHBOARD_WS_URL);
-      wsUrl.searchParams.set('token', authStore.token);
 
       this.socket = new WebSocket(wsUrl.toString());
 
       this.socket.onopen = () => {
-        console.log('[DashboardWS] Connecté');
+        console.log('[DashboardWS] Connecté. Envoi de l\'authentification...');
+        this.socket?.send(
+          JSON.stringify({
+            type: 'auth',
+            token: authStore.token,
+          })
+        );
         this.isConnecting = false;
       };
 


### PR DESCRIPTION
Improve security and auth flows for the dashboard API and client.

- Bump package versions: @kotbo/bot 7.10, @kotbo/dashboard 4.13.
- Generate ephemeral JWT_SECRET (with warning) when env var missing to avoid unsafe default.
- Add HttpError class and better error handling to return proper HTTP status codes/messages.
- Validate Content-Type and JSON parse errors in readJsonBody (returns 415/400 accordingly).
- Add CORS origin whitelist, extend allowed headers, and set multiple security response headers (CSP, HSTS, X-Frame-Options, etc.).
- Add input validation for user/guild/transcript IDs on public endpoints.
- Add OAuth state: generate state cookie on redirect, verify and clear state on callback to mitigate CSRF.
- Change OAuth redirect to include token in URL fragment (#token) instead of query parameter.
- WebSocket hardening: remove token-in-query upgrade flow; new handshake expects an auth message after connection, verifies JWT, marks socket as authenticated, enforces a 5s auth timeout, and only broadcasts to authenticated sockets.
- Client updates: App.svelte reads token from URL hash fallback and dashboardLifecycle sends an auth message over the socket instead of using ws query param.

These changes tighten security, mitigate CSRF/CSRF-like issues, reduce token exposure, and ensure only authenticated WS clients receive broadcasts.