### PR TITLE
feat(dashboard/automod): add dynamic nickname whitelist and member bypass exceptions

### DIFF
--- a/apps/bot/src/api/dashboardApi.ts
+++ b/apps/bot/src/api/dashboardApi.ts
@@ -8222,13 +8222,21 @@ export const startDashboardApi = (client: Client) => {
               try {
                 const guild = await prisma.guild.findUnique({
                   where: { id: guildId },
-                  select: { autoNicknameModerationEnabled: true },
+                  select: {
+                    autoNicknameModerationEnabled: true,
+                    nicknameModerationWhitelist: true,
+                    nicknameModerationBypass: true,
+                  },
                 });
                 if (!guild) {
                   json(res, 404, { error: 'Serveur introuvable' });
                   return;
                 }
-                json(res, 200, { enabled: guild.autoNicknameModerationEnabled });
+                json(res, 200, {
+                  enabled: guild.autoNicknameModerationEnabled,
+                  whitelist: guild.nicknameModerationWhitelist,
+                  bypass: guild.nicknameModerationBypass,
+                });
               } catch (err) {
                 logger.error('NicknameAPI', 'GET nickname-moderation error:', err);
                 json(res, 500, { error: 'Erreur lors de la récupération de la configuration' });
@@ -8237,16 +8245,36 @@ export const startDashboardApi = (client: Client) => {
             }
 
             if (req.method === 'PATCH') {
-              const body = await readJsonBody<{ enabled?: boolean }>(req);
-              if (!body || !Object.prototype.hasOwnProperty.call(body, 'enabled')) {
-                json(res, 400, { error: 'Payload invalide — champ `enabled` requis' });
+              const body = await readJsonBody<{ enabled?: boolean; whitelist?: string[]; bypass?: string[] }>(req);
+              
+              const updateData: any = {};
+              if (body && Object.prototype.hasOwnProperty.call(body, 'enabled')) {
+                updateData.autoNicknameModerationEnabled = !!body.enabled;
+              }
+              if (body && Object.prototype.hasOwnProperty.call(body, 'whitelist')) {
+                if (!Array.isArray(body.whitelist) || body.whitelist.some(item => typeof item !== 'string')) {
+                  json(res, 400, { error: 'Format whitelist invalide (doit être un tableau de chaînes)' });
+                  return;
+                }
+                updateData.nicknameModerationWhitelist = body.whitelist.map((w: string) => w.trim().toLowerCase()).filter(Boolean);
+              }
+              if (body && Object.prototype.hasOwnProperty.call(body, 'bypass')) {
+                if (!Array.isArray(body.bypass) || body.bypass.some(item => typeof item !== 'string')) {
+                  json(res, 400, { error: 'Format bypass invalide (doit être un tableau de chaînes)' });
+                  return;
+                }
+                updateData.nicknameModerationBypass = body.bypass.map((id: string) => id.trim()).filter(Boolean);
+              }
+
+              if (Object.keys(updateData).length === 0) {
+                json(res, 400, { error: 'Payload invalide — aucun champ à mettre à jour fourni' });
                 return;
               }
 
               try {
                 await prisma.guild.update({
                   where: { id: guildId },
-                  data: { autoNicknameModerationEnabled: !!body.enabled },
+                  data: updateData,
                 });
 
                 const { invalidateNicknameModerationCache } = await import('../events/nicknameModeration.js');
@@ -8258,7 +8286,7 @@ export const startDashboardApi = (client: Client) => {
                   context: getGuildName(client, guildId),
                   module: 'Modération des pseudos',
                   eventType: 'Manuel',
-                  details: `Activé: ${body.enabled}`,
+                  details: `Modifications appliquées: ${Object.keys(updateData).join(', ')}`,
                   channelId: null,
                 });
 

--- a/apps/bot/src/api/dashboardApi.ts
+++ b/apps/bot/src/api/dashboardApi.ts
@@ -8256,14 +8256,32 @@ export const startDashboardApi = (client: Client) => {
                   json(res, 400, { error: 'Format whitelist invalide (doit être un tableau de chaînes)' });
                   return;
                 }
-                updateData.nicknameModerationWhitelist = body.whitelist.map((w: string) => w.trim().toLowerCase()).filter(Boolean);
+                const cleanedWhitelist = [...new Set(body.whitelist.map((w: string) => w.trim().toLowerCase()).filter(Boolean))];
+                if (cleanedWhitelist.length > 100) {
+                  json(res, 400, { error: 'La whitelist ne peut pas contenir plus de 100 pseudos' });
+                  return;
+                }
+                if (cleanedWhitelist.some(w => w.length > 32)) {
+                  json(res, 400, { error: 'Les pseudos autorisés ne peuvent pas dépasser 32 caractères' });
+                  return;
+                }
+                updateData.nicknameModerationWhitelist = cleanedWhitelist;
               }
               if (body && Object.prototype.hasOwnProperty.call(body, 'bypass')) {
                 if (!Array.isArray(body.bypass) || body.bypass.some(item => typeof item !== 'string')) {
                   json(res, 400, { error: 'Format bypass invalide (doit être un tableau de chaînes)' });
                   return;
                 }
-                updateData.nicknameModerationBypass = body.bypass.map((id: string) => id.trim()).filter(Boolean);
+                const cleanedBypass = [...new Set(body.bypass.map((id: string) => id.trim()).filter(Boolean))];
+                if (cleanedBypass.length > 100) {
+                  json(res, 400, { error: 'La liste des membres exemptés ne peut pas contenir plus de 100 IDs' });
+                  return;
+                }
+                if (cleanedBypass.some(id => !/^\d{17,20}$/.test(id))) {
+                  json(res, 400, { error: 'Format bypass invalide : certains IDs sont incorrects (doivent être de 17 à 20 chiffres)' });
+                  return;
+                }
+                updateData.nicknameModerationBypass = cleanedBypass;
               }
 
               if (Object.keys(updateData).length === 0) {
@@ -8790,6 +8808,19 @@ export const startDashboardApi = (client: Client) => {
               : 'custom';
 
             try {
+              // Vérification anti-conflit : le mot ne doit pas être déjà dans la whitelist
+              const guildData = await prisma.guild.findUnique({
+                where: { id: guildId },
+                select: { nicknameModerationWhitelist: true },
+              });
+              const whitelist = guildData?.nicknameModerationWhitelist ?? [];
+              if (whitelist.includes(cleanWord)) {
+                json(res, 400, {
+                  error: `Impossible de bannir ce mot car il est déjà présent dans la liste des pseudos autorisés (whitelist) : ${cleanWord}`,
+                });
+                return;
+              }
+
               const created = await prisma.bannedWord.create({
                 data: { guildId, word: cleanWord, category },
               });
@@ -8835,6 +8866,21 @@ export const startDashboardApi = (client: Client) => {
               if (!existing) {
                 json(res, 404, { error: 'Mot introuvable' });
                 return;
+              }
+
+              if (body.enabled) {
+                // Vérification anti-conflit : le mot ne doit pas être déjà dans la whitelist
+                const guildData = await prisma.guild.findUnique({
+                  where: { id: guildId },
+                  select: { nicknameModerationWhitelist: true },
+                });
+                const whitelist = guildData?.nicknameModerationWhitelist ?? [];
+                if (whitelist.includes(existing.word.toLowerCase())) {
+                  json(res, 400, {
+                    error: `Impossible d'activer ce mot car il est déjà présent dans la liste des pseudos autorisés (whitelist) : ${existing.word}`,
+                  });
+                  return;
+                }
               }
 
               await prisma.bannedWord.update({ where: { id: wordId }, data: { enabled: body.enabled } });

--- a/apps/bot/src/api/dashboardApi.ts
+++ b/apps/bot/src/api/dashboardApi.ts
@@ -8257,6 +8257,10 @@ export const startDashboardApi = (client: Client) => {
                   return;
                 }
                 const cleanedWhitelist = [...new Set(body.whitelist.map((w: string) => w.trim().toLowerCase()).filter(Boolean))];
+                if (cleanedWhitelist.length > 250) {
+                  json(res, 400, { error: 'La whitelist ne peut pas contenir plus de 250 pseudos' });
+                  return;
+                }
                 if (cleanedWhitelist.some(w => w.length > 32)) {
                   json(res, 400, { error: 'Les pseudos autorisés ne peuvent pas dépasser 32 caractères' });
                   return;
@@ -8269,6 +8273,10 @@ export const startDashboardApi = (client: Client) => {
                   return;
                 }
                 const cleanedBypass = [...new Set(body.bypass.map((id: string) => id.trim()).filter(Boolean))];
+                if (cleanedBypass.length > 250) {
+                  json(res, 400, { error: 'La liste des membres exemptés ne peut pas contenir plus de 250 IDs' });
+                  return;
+                }
                 if (cleanedBypass.some(id => !/^\d{17,20}$/.test(id))) {
                   json(res, 400, { error: 'Format bypass invalide : certains IDs sont incorrects (doivent être de 17 à 20 chiffres)' });
                   return;

--- a/apps/bot/src/api/dashboardApi.ts
+++ b/apps/bot/src/api/dashboardApi.ts
@@ -8257,10 +8257,6 @@ export const startDashboardApi = (client: Client) => {
                   return;
                 }
                 const cleanedWhitelist = [...new Set(body.whitelist.map((w: string) => w.trim().toLowerCase()).filter(Boolean))];
-                if (cleanedWhitelist.length > 100) {
-                  json(res, 400, { error: 'La whitelist ne peut pas contenir plus de 100 pseudos' });
-                  return;
-                }
                 if (cleanedWhitelist.some(w => w.length > 32)) {
                   json(res, 400, { error: 'Les pseudos autorisés ne peuvent pas dépasser 32 caractères' });
                   return;
@@ -8273,10 +8269,6 @@ export const startDashboardApi = (client: Client) => {
                   return;
                 }
                 const cleanedBypass = [...new Set(body.bypass.map((id: string) => id.trim()).filter(Boolean))];
-                if (cleanedBypass.length > 100) {
-                  json(res, 400, { error: 'La liste des membres exemptés ne peut pas contenir plus de 100 IDs' });
-                  return;
-                }
                 if (cleanedBypass.some(id => !/^\d{17,20}$/.test(id))) {
                   json(res, 400, { error: 'Format bypass invalide : certains IDs sont incorrects (doivent être de 17 à 20 chiffres)' });
                   return;

--- a/apps/bot/src/api/dashboardApi.ts
+++ b/apps/bot/src/api/dashboardApi.ts
@@ -8272,6 +8272,31 @@ export const startDashboardApi = (client: Client) => {
               }
 
               try {
+                if (updateData.nicknameModerationWhitelist) {
+                  const activeBannedWords = await prisma.bannedWord.findMany({
+                    where: {
+                      OR: [
+                        { guildId: null, enabled: true },
+                        { guildId, enabled: true },
+                      ],
+                    },
+                    select: { word: true },
+                  });
+                  const bannedSet = new Set(
+                    activeBannedWords.map((b) => b.word.trim().toLowerCase())
+                  );
+
+                  const invalidItems = updateData.nicknameModerationWhitelist.filter(
+                    (item: string) => bannedSet.has(item)
+                  );
+                  if (invalidItems.length > 0) {
+                    json(res, 400, {
+                      error: `Impossible d'autoriser ces pseudos car ils font partie de la liste des mots bannis : ${invalidItems.join(', ')}`,
+                    });
+                    return;
+                  }
+                }
+
                 await prisma.guild.update({
                   where: { id: guildId },
                   data: updateData,

--- a/apps/bot/src/api/dashboardApi.ts
+++ b/apps/bot/src/api/dashboardApi.ts
@@ -3989,6 +3989,11 @@ export const startDashboardApi = (client: Client) => {
             for (const entry of entries) {
               const word = normalizeGlobalBannedWord(entry?.word);
               if (!word) continue;
+
+              if (word.includes('automod') || word.includes('pseudo non conforme')) {
+                continue;
+              }
+
               seen.set(word, {
                 word,
                 category: normalizeGlobalBannedWordCategory(entry?.category),
@@ -4077,6 +4082,11 @@ export const startDashboardApi = (client: Client) => {
 
                 if (!nextWord) {
                   json(res, 400, { error: 'Le mot ne peut pas être vide' });
+                  return;
+                }
+
+                if (nextWord.includes('automod') || nextWord.includes('pseudo non conforme')) {
+                  json(res, 400, { error: 'Ce mot ne peut pas être banni (réservé par le système de modération)' });
                   return;
                 }
 
@@ -8716,6 +8726,12 @@ export const startDashboardApi = (client: Client) => {
             }
 
             const cleanWord = body.word.trim().toLowerCase().slice(0, 100);
+
+            if (cleanWord.includes('automod') || cleanWord.includes('pseudo non conforme')) {
+              json(res, 400, { error: 'Ce mot ne peut pas être banni (réservé par le système de modération)' });
+              return;
+            }
+
             const category = ['custom', 'racism', 'threat', 'sexual', 'lgbtphobia', 'hate', 'insult'].includes(body.category ?? '')
               ? body.category!
               : 'custom';

--- a/apps/bot/src/events/nicknameModeration.ts
+++ b/apps/bot/src/events/nicknameModeration.ts
@@ -7,41 +7,60 @@ import { logger } from '../utils/logger.js';
 // Cache du statut d'activation par serveur (TTL 60s)
 // ---------------------------------------------------------------------------
 
-type EnabledCache = { enabled: boolean; expiresAt: number };
-const enabledCache = new Map<string, EnabledCache>();
+type NicknameModConfig = {
+  enabled: boolean;
+  whitelist: string[];
+  bypass: string[];
+};
+
+type ConfigCacheEntry = {
+  config: NicknameModConfig;
+  expiresAt: number;
+};
+
+const configCache = new Map<string, ConfigCacheEntry>();
 const CACHE_TTL_MS = 60_000;
 
 /**
- * Invalide uniquement le cache d'activation (enabled).
+ * Invalide uniquement le cache de configuration de modération de pseudos.
  * Pour les mots bannis, utiliser invalidateBannedWordsCache depuis bannedWordsService.
  */
 export function invalidateNicknameModerationCache(guildId?: string): void {
   if (guildId) {
-    enabledCache.delete(guildId);
+    configCache.delete(guildId);
     invalidateBannedWordsCache(guildId);
     return;
   }
-  enabledCache.clear();
+  configCache.clear();
   invalidateBannedWordsCache();
 }
 
 // Re-export pour les usages existants dans dashboardApi.ts
 export { invalidateBannedWordsCache };
 
-async function isNicknameModerationEnabled(guildId: string): Promise<boolean> {
-  const cached = enabledCache.get(guildId);
+async function getNicknameModerationConfig(guildId: string): Promise<NicknameModConfig> {
+  const cached = configCache.get(guildId);
   const now = Date.now();
-  if (cached && cached.expiresAt > now) return cached.enabled;
+  if (cached && cached.expiresAt > now) return cached.config;
 
   const { default: prisma } = await import('../utils/db.js');
   const guild = await prisma.guild.findUnique({
     where: { id: guildId },
-    select: { autoNicknameModerationEnabled: true },
+    select: {
+      autoNicknameModerationEnabled: true,
+      nicknameModerationWhitelist: true,
+      nicknameModerationBypass: true,
+    },
   });
 
-  const enabled = guild?.autoNicknameModerationEnabled ?? false;
-  enabledCache.set(guildId, { enabled, expiresAt: now + CACHE_TTL_MS });
-  return enabled;
+  const config = {
+    enabled: guild?.autoNicknameModerationEnabled ?? false,
+    whitelist: guild?.nicknameModerationWhitelist ?? [],
+    bypass: guild?.nicknameModerationBypass ?? [],
+  };
+
+  configCache.set(guildId, { config, expiresAt: now + CACHE_TTL_MS });
+  return config;
 }
 
 // ---------------------------------------------------------------------------
@@ -52,8 +71,8 @@ async function checkAndRename(member: GuildMember): Promise<void> {
   if (member.user.bot) return;
 
   const guildId = member.guild.id;
-  const enabled = await isNicknameModerationEnabled(guildId);
-  if (!enabled) return;
+  const config = await getNicknameModerationConfig(guildId);
+  if (!config.enabled) return;
 
   // Vérification des permissions du bot
   const botMember = await member.guild.members.fetchMe().catch(() => null);
@@ -69,7 +88,15 @@ async function checkAndRename(member: GuildMember): Promise<void> {
   // Chargement des mots bannis depuis le service générique (global + serveur)
   const bannedWords = await loadBannedWords(guildId);
 
-  if (!isNicknameProblematic(effectiveName, bannedWords)) return;
+  if (
+    !isNicknameProblematic(effectiveName, bannedWords, {
+      whitelist: config.whitelist,
+      userId: member.id,
+      bypassUserIds: config.bypass,
+    })
+  ) {
+    return;
+  }
 
   try {
     await member.setNickname(SAFE_NICKNAME, buildRenameReason(effectiveName));

--- a/apps/bot/src/services/nicknameModerationService.ts
+++ b/apps/bot/src/services/nicknameModerationService.ts
@@ -22,6 +22,14 @@ export const SAFE_NICKNAME = 'pseudo non conforme | automod';
 export function isNicknameProblematic(name: string, words: string[]): boolean {
   if (!name || name.trim().length === 0) return true;
   if (INVISIBLE_ONLY_REGEX.test(name)) return true;
+
+  const normalized = name.toLowerCase().trim();
+
+  // Protection anti-boucle : Ignorer notre propre pseudo de remplacement ou tout ce qui s'y apparente (contient "automod" ou "pseudo non conforme")
+  if (normalized.includes('automod') || normalized.includes('pseudo non conforme')) {
+    return false;
+  }
+
   return containsBannedWord(name, words);
 }
 

--- a/apps/bot/src/services/nicknameModerationService.ts
+++ b/apps/bot/src/services/nicknameModerationService.ts
@@ -19,7 +19,15 @@ export const SAFE_NICKNAME = 'pseudo non conforme | automod';
  * @param words Liste de mots bannis chargée via `loadBannedWords(guildId)`.
  * @returns `true` si le pseudo doit être remplacé.
  */
-export function isNicknameProblematic(name: string, words: string[]): boolean {
+export function isNicknameProblematic(
+  name: string,
+  words: string[],
+  options?: {
+    whitelist?: string[];
+    userId?: string;
+    bypassUserIds?: string[];
+  }
+): boolean {
   if (!name || name.trim().length === 0) return true;
   if (INVISIBLE_ONLY_REGEX.test(name)) return true;
 
@@ -28,6 +36,19 @@ export function isNicknameProblematic(name: string, words: string[]): boolean {
   // Protection anti-boucle : Ignorer notre propre pseudo de remplacement ou tout ce qui s'y apparente (contient "automod" ou "pseudo non conforme")
   if (normalized.includes('automod') || normalized.includes('pseudo non conforme')) {
     return false;
+  }
+
+  // Membre exempté (Bypass par ID utilisateur)
+  if (options?.userId && options.bypassUserIds?.includes(options.userId)) {
+    return false;
+  }
+
+  // Pseudo sur la whitelist du serveur (comparaison exacte insensible à la casse)
+  if (options?.whitelist) {
+    const isWhitelisted = options.whitelist.some(
+      (w) => w.trim().toLowerCase() === normalized
+    );
+    if (isWhitelisted) return false;
   }
 
   return containsBannedWord(name, words);
@@ -80,10 +101,14 @@ export async function scanAndModeratePseudos(guild: Guild): Promise<PseudoScanRe
   // Charger les mots bannis une seule fois pour tout le scan
   const bannedWords = await loadBannedWords(guild.id);
 
-  // Charger le channel de logs
+  // Charger le channel de logs et la configuration de la whitelist/bypass
   const guildData = await prisma.guild.findUnique({
     where: { id: guild.id },
-    select: { logChannelId: true },
+    select: {
+      logChannelId: true,
+      nicknameModerationWhitelist: true,
+      nicknameModerationBypass: true,
+    },
   }).catch(() => null);
 
   const logChannel = guildData?.logChannelId
@@ -93,6 +118,9 @@ export async function scanAndModeratePseudos(guild: Guild): Promise<PseudoScanRe
   // Récupérer tous les membres
   const members = await guild.members.fetch().catch(() => null);
   if (!members) return result;
+
+  const whitelist = guildData?.nicknameModerationWhitelist ?? [];
+  const bypass = guildData?.nicknameModerationBypass ?? [];
 
   for (const [, member] of members) {
     if (member.user.bot) { result.skippedCount++; continue; }
@@ -106,7 +134,7 @@ export async function scanAndModeratePseudos(guild: Guild): Promise<PseudoScanRe
     // Déjà au pseudo de sécurité → skip
     if (effectiveName === SAFE_NICKNAME) continue;
 
-    if (!isNicknameProblematic(effectiveName, bannedWords)) continue;
+    if (!isNicknameProblematic(effectiveName, bannedWords, { whitelist, userId: member.id, bypassUserIds: bypass })) continue;
 
     try {
       await member.setNickname(SAFE_NICKNAME, buildRenameReason(effectiveName));

--- a/apps/bot/src/services/nicknameModerationService.ts
+++ b/apps/bot/src/services/nicknameModerationService.ts
@@ -46,7 +46,7 @@ export function isNicknameProblematic(
   // Pseudo sur la whitelist du serveur (comparaison exacte insensible à la casse)
   if (options?.whitelist) {
     const isWhitelisted = options.whitelist.some(
-      (w) => w.trim().toLowerCase() === normalized
+      (w) => typeof w === 'string' && w.trim().toLowerCase() === normalized
     );
     if (isWhitelisted) return false;
   }

--- a/apps/bot/src/tests/unit/bannedWordsService.test.ts
+++ b/apps/bot/src/tests/unit/bannedWordsService.test.ts
@@ -1,175 +1,122 @@
 /**
- * Tests unitaires pour containsBannedWord (Option C).
+ * Tests unitaires pour containsBannedWord et isNicknameProblematic.
  *
- * Vérifie que la détection combinée (token exact + frontières Unicode)
- * élimine les faux positifs signalés tout en continuant à flagguer
- * les vrais mots bannis.
+ * Vérifie que la détection combinée (token exact + frontières Unicode + substring long)
+ * fonctionne de manière générique, et que les sécurités anti-boucle (automod)
+ * fonctionnent correctement.
  */
 
 import { describe, it, expect } from 'bun:test';
 import { containsBannedWord } from '../../services/bannedWordsService.js';
+import { isNicknameProblematic } from '../../services/nicknameModerationService.js';
 
-// ---------------------------------------------------------------------------
-// Faux positifs à NE PAS flagguer
-// ---------------------------------------------------------------------------
+describe('containsBannedWord — Détection automatique', () => {
+  // ---------------------------------------------------------------------------
+  // Faux positifs à NE PAS flagguer (doit retourner false)
+  // ---------------------------------------------------------------------------
+  describe('Faux positifs (ne doit PAS flagguer)', () => {
+    const fauxPositifs = [
+      { text: 'cacao', banned: ['caca'], reason: 'caca est un sous-mot' },
+      { text: 'Xavier', banned: ['xav'], reason: 'xav est un sous-mot' },
+      { text: 'assassin', banned: ['ass'], reason: 'ass est un sous-mot' },
+      { text: 'classique', banned: ['lass'], reason: 'lass est un sous-mot' },
+      { text: 'cocasse', banned: ['caca'], reason: 'caca est un sous-mot' },
+      { text: 'patapon', banned: ['pat'], reason: 'pat est un sous-mot' },
+      { text: 'r2d2', banned: ['r', 'd'], reason: 'les chiffres ne sont pas des séparateurs' },
+      { text: 'super2man', banned: ['man'], reason: 'les chiffres ne sont pas des séparateurs' },
+      { text: 'bidon', banned: ['bi'], reason: 'mot banni court (< 4c) en bord de pseudo' },
+      { text: '', banned: ['caca'], reason: 'pseudo vide' },
+      { text: '   ', banned: ['caca'], reason: 'pseudo composé uniquement d\'espaces' },
+      { text: 'caca', banned: ['', '   '], reason: 'mots bannis vides' },
+    ];
 
-describe('containsBannedWord — faux positifs (ne doit PAS flagguer)', () => {
-  it('ne flaggue pas "cacao" à cause de "caca"', () => {
-    expect(containsBannedWord('cacao', ['caca'])).toBe(false);
+    for (const { text, banned, reason } of fauxPositifs) {
+      it(`ignore "${text}" avec la liste [${banned.join(', ')}] (${reason})`, () => {
+        expect(containsBannedWord(text, banned)).toBe(false);
+      });
+    }
   });
 
-  it('ne flaggue pas "Xavier" à cause de "xav" ou sous-mots similaires', () => {
-    expect(containsBannedWord('Xavier', ['xav'])).toBe(false);
+  // ---------------------------------------------------------------------------
+  // Vrais positifs (DOIT flagguer / retourner true)
+  // ---------------------------------------------------------------------------
+  describe('Vrais positifs (DOIT flagguer)', () => {
+    const vraisPositifs = [
+      { text: 'caca', banned: ['caca'], reason: 'mot exact' },
+      { text: 'caca lol', banned: ['caca'], reason: 'début de mot composé' },
+      { text: 'super caca', banned: ['caca'], reason: 'fin de mot composé' },
+      { text: 'le-caca-lol', banned: ['caca'], reason: 'séparateur tiret' },
+      { text: 'pseudo_caca', banned: ['caca'], reason: 'séparateur underscore' },
+      { text: 'caca123', banned: ['caca'], reason: 'frontière de chiffre (non-lettre)' },
+      { text: 'CACA', banned: ['caca'], reason: 'insensible à la casse' },
+      { text: 'caca!lol', banned: ['caca'], reason: 'frontière de ponctuation' },
+      { text: 'ass-boy', banned: ['ass'], reason: 'séparateur tiret' },
+      { text: 'je suis caca', banned: ['sale', 'caca', 'merde'], reason: 'un mot de la liste correspond' },
+    ];
+
+    for (const { text, banned, reason } of vraisPositifs) {
+      it(`flaggue "${text}" avec la liste [${banned.join(', ')}] (${reason})`, () => {
+        expect(containsBannedWord(text, banned)).toBe(true);
+      });
+    }
   });
 
-  it('ne flaggue pas "assassin" à cause de "ass" (anglais)', () => {
-    expect(containsBannedWord('assassin', ['ass'])).toBe(false);
+  // ---------------------------------------------------------------------------
+  // Substring match pour mots longs (≥ 6c)
+  // ---------------------------------------------------------------------------
+  describe('Substring match mots longs (seuil ≥ 6c)', () => {
+    const substringCases = [
+      { text: 'connerieman', banned: ['connerie'], expected: true, reason: 'connerie (8c ≥ 6) est un mot long' },
+      { text: 'leputaindetruc', banned: ['putain'], expected: true, reason: 'putain (6c ≥ 6) est un mot long' },
+      { text: 'sonofbitch0139', banned: ['bitch'], expected: false, reason: 'bitch (5c < 6) est sous le seuil' },
+      { text: 'fichier', banned: ['chier'], expected: false, reason: 'chier (5c < 6) est sous le seuil' },
+      { text: 'supermerdedu', banned: ['merde'], expected: false, reason: 'merde (5c < 6) est sous le seuil' },
+      { text: 'cacao', banned: ['caca'], expected: false, reason: 'caca (4c < 6) est sous le seuil' },
+      { text: 'cacahuète', banned: ['caca'], expected: false, reason: 'caca (4c < 6) est sous le seuil' },
+    ];
+
+    for (const { text, banned, expected, reason } of substringCases) {
+      it(`${expected ? 'flaggue' : 'ignore'} "${text}" avec la liste [${banned.join(', ')}] (${reason})`, () => {
+        expect(containsBannedWord(text, banned)).toBe(expected);
+      });
+    }
   });
 
-  it('ne flaggue pas "classique" à cause de "lass"', () => {
-    expect(containsBannedWord('classique', ['lass'])).toBe(false);
-  });
+  // ---------------------------------------------------------------------------
+  // Cas limites / Spécificités
+  // ---------------------------------------------------------------------------
+  describe('Cas limites', () => {
+    const edgeCases = [
+      { text: 'éléphant', banned: ['éléphant'], expected: true, reason: 'caractères accentués' },
+      { text: 'réélection', banned: ['ré'], expected: false, reason: 'mot court avec accents' },
+      { text: 'caca', banned: [], expected: false, reason: 'liste de mots vide' },
+      { text: 'caca', banned: ['  caca  '], expected: true, reason: 'mot banni avec espaces superflus' },
+    ];
 
-  it('ne flaggue pas "cocasse" à cause de "caca"', () => {
-    expect(containsBannedWord('cocasse', ['caca'])).toBe(false);
-  });
-
-  it('ne flaggue pas "patapon" à cause de "pat"', () => {
-    expect(containsBannedWord('patapon', ['pat'])).toBe(false);
-  });
-
-  it('préserve les pseudos avec chiffres en un seul token (r2d2, super2man)', () => {
-    // Les chiffres ne sont plus des séparateurs → "r2d2" reste un token entier
-    expect(containsBannedWord('r2d2', ['r', 'd'])).toBe(false);
-    expect(containsBannedWord('super2man', ['man'])).toBe(false);
-  });
-
-  it('ne flag pas les mots bannis courts (< 4 chars) en bord de pseudo via regex', () => {
-    // "bi" est court → pas de check regex → seul l'exact token match compte
-    // "bidon" → token ["bidon"] ≠ "bi" → pas de match
-    expect(containsBannedWord('bidon', ['bi'])).toBe(false);
-  });
-
-  it('ne flaggue pas un pseudo vide', () => {
-    expect(containsBannedWord('', ['caca'])).toBe(false);
-  });
-
-  it('ne flaggue pas un pseudo avec uniquement des espaces', () => {
-    expect(containsBannedWord('   ', ['caca'])).toBe(false);
-  });
-
-  it('ignore les mots bannis vides ou composés d\'espaces', () => {
-    expect(containsBannedWord('caca', ['', '   '])).toBe(false);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Vrais positifs — DOIT flagguer
-// ---------------------------------------------------------------------------
-
-describe('containsBannedWord — vrais positifs (DOIT flagguer)', () => {
-  it('flaggue "caca" seul', () => {
-    expect(containsBannedWord('caca', ['caca'])).toBe(true);
-  });
-
-  it('flaggue "caca" en début de pseudo multi-mots', () => {
-    expect(containsBannedWord('caca lol', ['caca'])).toBe(true);
-  });
-
-  it('flaggue "caca" en fin de pseudo multi-mots', () => {
-    expect(containsBannedWord('super caca', ['caca'])).toBe(true);
-  });
-
-  it('flaggue "caca" séparé par un tiret', () => {
-    expect(containsBannedWord('le-caca-lol', ['caca'])).toBe(true);
-  });
-
-  it('flaggue "caca" séparé par un underscore', () => {
-    expect(containsBannedWord('pseudo_caca', ['caca'])).toBe(true);
-  });
-
-  it('flaggue "caca123" via la regex frontière (chiffre = non-lettre)', () => {
-    // Les chiffres ne sont plus des séparateurs → token = ["caca123"]
-    // Mais "caca" est suivi de "1" (non-lettre) → frontière valide → flaggé via regex
-    expect(containsBannedWord('caca123', ['caca'])).toBe(true);
-  });
-
-  it('flaggue un pseudo insensible à la casse', () => {
-    expect(containsBannedWord('CACA', ['caca'])).toBe(true);
-  });
-
-  it('flaggue "caca" collé à un non-lettre (ex: "caca!lol")', () => {
-    // "!" n'est pas une lettre → la frontière est respectée
-    expect(containsBannedWord('caca!lol', ['caca'])).toBe(true);
-  });
-
-  it('flaggue "ass" dans "ass-boy" (séparé par tiret)', () => {
-    expect(containsBannedWord('ass-boy', ['ass'])).toBe(true);
-  });
-
-  it('flaggue un mot banni parmi plusieurs', () => {
-    expect(containsBannedWord('je suis caca', ['sale', 'caca', 'merde'])).toBe(true);
-  });
-
-  it('ne flaggue rien si aucun mot banni ne correspond', () => {
-    expect(containsBannedWord('pseudo propre', ['caca', 'merde'])).toBe(false);
+    for (const { text, banned, expected, reason } of edgeCases) {
+      it(`${expected ? 'flaggue' : 'ignore'} "${text}" avec la liste [${banned.join(', ')}] (${reason})`, () => {
+        expect(containsBannedWord(text, banned)).toBe(expected);
+      });
+    }
   });
 });
 
-// ---------------------------------------------------------------------------
-// Check 3 — substring match pour mots longs (≥ 5 chars)
-// ---------------------------------------------------------------------------
-
-describe('containsBannedWord — substring match mots longs (≥ 6c)', () => {
-  it('flaggue "connerieman" car "connerie" (8c ≥ 6) est un mot banni long', () => {
-    expect(containsBannedWord('connerieman', ['connerie'])).toBe(true);
+describe('isNicknameProblematic — Sécurités anti-boucle', () => {
+  it('ignore le pseudo de remplacement exact (SAFE_NICKNAME)', () => {
+    expect(isNicknameProblematic('pseudo non conforme | automod', ['con', 'caca'])).toBe(false);
   });
 
-  it('flaggue "leputaindetruc" car "putain" (6c ≥ 6) est dedans', () => {
-    expect(containsBannedWord('leputaindetruc', ['putain'])).toBe(true);
+  it('ignore les variations contenant "automod" ou "pseudo non conforme"', () => {
+    expect(isNicknameProblematic('SuperAutoMod', ['auto', 'mod'])).toBe(false);
+    expect(isNicknameProblematic('pseudo non conforme', ['non', 'con'])).toBe(false);
   });
 
-  it('ne flaggue PAS "sonofbitch0139" car "bitch" (5c < 6) est sous le seuil', () => {
-    // "bitch" = 5c → pas de substring check. Mais token exact ou regex frontière
-    // peuvent toujours le détecter s'il est séparé par un séparateur.
-    expect(containsBannedWord('sonofbitch0139', ['bitch'])).toBe(false);
+  it('flaggue les pseudos réellement problématiques', () => {
+    expect(isNicknameProblematic('caca', ['caca'])).toBe(true);
+    expect(isNicknameProblematic('le-caca-lol', ['caca'])).toBe(true);
   });
 
-  it('ne flaggue PAS "fichier" à cause de "chier" (5c < 6)', () => {
-    expect(containsBannedWord('fichier', ['chier'])).toBe(false);
-  });
-
-  it('ne flaggue PAS "supermerdedu" car "merde" (5c < 6) est sous le seuil', () => {
-    expect(containsBannedWord('supermerdedu', ['merde'])).toBe(false);
-  });
-
-  it('ne flaggue PAS via substring un mot de 4c comme "caca" dans "cacao"', () => {
-    expect(containsBannedWord('cacao', ['caca'])).toBe(false);
-  });
-
-  it('ne flaggue PAS via substring un mot de 4c comme "caca" dans "cacahuète"', () => {
-    expect(containsBannedWord('cacahuète', ['caca'])).toBe(false);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Cas limites
-// ---------------------------------------------------------------------------
-
-describe('containsBannedWord — cas limites', () => {
-  it('gère les mots bannis avec des caractères accentués', () => {
-    expect(containsBannedWord('éléphant', ['éléphant'])).toBe(true);
-  });
-
-  it('ne flaggue pas "réélection" à cause de "ré"', () => {
-    expect(containsBannedWord('réélection', ['ré'])).toBe(false);
-  });
-
-  it('gère une liste de mots bannis vide', () => {
-    expect(containsBannedWord('caca', [])).toBe(false);
-  });
-
-  it('flaggue un mot banni avec des espaces autour dans la liste', () => {
-    expect(containsBannedWord('caca', ['  caca  '])).toBe(true);
+  it('ne flaggue pas les pseudos propres', () => {
+    expect(isNicknameProblematic('pseudo_propre', ['caca'])).toBe(false);
   });
 });

--- a/apps/bot/src/tests/unit/bannedWordsService.test.ts
+++ b/apps/bot/src/tests/unit/bannedWordsService.test.ts
@@ -101,7 +101,7 @@ describe('containsBannedWord — Détection automatique', () => {
   });
 });
 
-describe('isNicknameProblematic — Sécurités anti-boucle', () => {
+describe('isNicknameProblematic — Sécurités & Whitelist', () => {
   it('ignore le pseudo de remplacement exact (SAFE_NICKNAME)', () => {
     expect(isNicknameProblematic('pseudo non conforme | automod', ['con', 'caca'])).toBe(false);
   });
@@ -109,6 +109,15 @@ describe('isNicknameProblematic — Sécurités anti-boucle', () => {
   it('ignore les variations contenant "automod" ou "pseudo non conforme"', () => {
     expect(isNicknameProblematic('SuperAutoMod', ['auto', 'mod'])).toBe(false);
     expect(isNicknameProblematic('pseudo non conforme', ['non', 'con'])).toBe(false);
+  });
+
+  it('ignore les pseudos de la whitelist du serveur', () => {
+    expect(isNicknameProblematic('cacao_meow', ['caca'], { whitelist: ['cacao_meow'] })).toBe(false);
+    expect(isNicknameProblematic('fichier.py', ['chier'], { whitelist: ['fichier.py'] })).toBe(false);
+  });
+
+  it('ignore les membres exemptés (bypass)', () => {
+    expect(isNicknameProblematic('caca', ['caca'], { userId: '123456', bypassUserIds: ['123456'] })).toBe(false);
   });
 
   it('flaggue les pseudos réellement problématiques', () => {

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -1269,7 +1269,7 @@ export async function fetchNicknameModerationConfig(guildId = authStore.selected
 }
 
 export async function updateNicknameModerationConfig(
-  payload: { enabled: boolean },
+  payload: { enabled?: boolean; whitelist?: string[]; bypass?: string[] },
   guildId = authStore.selectedGuildId
 ) {
   return dashboardMutation('/nickname-moderation', {

--- a/apps/dashboard/src/pages/NicknameModeration.svelte
+++ b/apps/dashboard/src/pages/NicknameModeration.svelte
@@ -239,10 +239,25 @@
       async () => {
         const ok = await updateNicknameModerationConfig({ whitelist: updatedWhitelist });
         if (!ok) throw new Error('Erreur API');
+        
+        const previousWhitelist = whitelist;
         whitelist = updatedWhitelist;
+
+        toast.success(`"${item}" supprimé des pseudos autorisés.`, 6000, {
+          label: 'Annuler',
+          onClick: async () => {
+            await exceptionAction.run(async () => {
+              const okUndo = await updateNicknameModerationConfig({ whitelist: previousWhitelist });
+              if (!okUndo) throw new Error("Erreur lors de l'annulation");
+              whitelist = previousWhitelist;
+              return true;
+            }, { successMessage: `"${item}" rétabli.` });
+          }
+        });
+
         return true;
       },
-      { successMessage: `"${item}" supprimé des pseudos autorisés.` }
+      {}
     );
   }
 
@@ -278,10 +293,25 @@
       async () => {
         const ok = await updateNicknameModerationConfig({ bypass: updatedBypass });
         if (!ok) throw new Error('Erreur API');
+        
+        const previousBypass = bypass;
         bypass = updatedBypass;
+
+        toast.success(`Exemption pour le membre ${item} retirée.`, 6000, {
+          label: 'Annuler',
+          onClick: async () => {
+            await exceptionAction.run(async () => {
+              const okUndo = await updateNicknameModerationConfig({ bypass: previousBypass });
+              if (!okUndo) throw new Error("Erreur lors de l'annulation");
+              bypass = previousBypass;
+              return true;
+            }, { successMessage: `Exemption pour le membre ${item} rétablie.` });
+          }
+        });
+
         return true;
       },
-      { successMessage: `Exemption pour le membre ${item} retirée.` }
+      {}
     );
   }
 

--- a/apps/dashboard/src/pages/NicknameModeration.svelte
+++ b/apps/dashboard/src/pages/NicknameModeration.svelte
@@ -53,6 +53,8 @@
   let enabled = $state(false);
   let globalWords = $state<BannedWordEntry[]>([]);
   let customWords = $state<BannedWordEntry[]>([]);
+  let whitelist = $state<string[]>([]);
+  let bypass = $state<string[]>([]);
   let loading = $state(true);
   let loadError = $state('');
 
@@ -60,8 +62,12 @@
   let newCategory = $state('custom');
   let activeTab = $state<'custom' | 'global'>('custom');
 
+  let newWhitelistItem = $state('');
+  let newBypassItem = $state('');
+
   const saveToggleAction = createAsyncActionState();
   const wordAction = createAsyncActionState();
+  const exceptionAction = createAsyncActionState();
 
   // ---------------------------------------------------------------------------
   // Lifecycle
@@ -76,7 +82,11 @@
         fetchNicknameModerationConfig(),
         fetchBannedWords(),
       ]);
-      if (config) enabled = config.enabled ?? false;
+      if (config) {
+        enabled = config.enabled ?? false;
+        whitelist = config.whitelist ?? [];
+        bypass = config.bypass ?? [];
+      }
       if (words) {
         globalWords = words.global ?? [];
         customWords = words.custom ?? [];
@@ -200,6 +210,87 @@
 
   function getCat(key: string): CategoryMeta {
     return CATEGORIES[key] ?? CATEGORIES.custom;
+  }
+
+  async function addWhitelistItem() {
+    const trimmed = newWhitelistItem.trim().toLowerCase();
+    if (!trimmed) return;
+    if (whitelist.includes(trimmed)) {
+      exceptionAction.setError('Ce pseudo est déjà autorisé.');
+      return;
+    }
+
+    const updatedWhitelist = [...whitelist, trimmed];
+    await exceptionAction.run(
+      async () => {
+        const ok = await updateNicknameModerationConfig({ whitelist: updatedWhitelist });
+        if (!ok) throw new Error('Erreur API');
+        whitelist = updatedWhitelist;
+        newWhitelistItem = '';
+        return true;
+      },
+      { successMessage: `"${trimmed}" ajouté aux pseudos autorisés.` }
+    );
+  }
+
+  async function removeWhitelistItem(item: string) {
+    const updatedWhitelist = whitelist.filter((w) => w !== item);
+    await exceptionAction.run(
+      async () => {
+        const ok = await updateNicknameModerationConfig({ whitelist: updatedWhitelist });
+        if (!ok) throw new Error('Erreur API');
+        whitelist = updatedWhitelist;
+        return true;
+      },
+      { successMessage: `"${item}" supprimé des pseudos autorisés.` }
+    );
+  }
+
+  async function addBypassItem() {
+    const trimmed = newBypassItem.trim();
+    if (!trimmed) return;
+    if (bypass.includes(trimmed)) {
+      exceptionAction.setError('Cet ID membre est déjà exempté.');
+      return;
+    }
+
+    if (!/^\d{17,20}$/.test(trimmed)) {
+      exceptionAction.setError('ID membre invalide (doit contenir entre 17 et 20 chiffres).');
+      return;
+    }
+
+    const updatedBypass = [...bypass, trimmed];
+    await exceptionAction.run(
+      async () => {
+        const ok = await updateNicknameModerationConfig({ bypass: updatedBypass });
+        if (!ok) throw new Error('Erreur API');
+        bypass = updatedBypass;
+        newBypassItem = '';
+        return true;
+      },
+      { successMessage: `Membre ${trimmed} exempté.` }
+    );
+  }
+
+  async function removeBypassItem(item: string) {
+    const updatedBypass = bypass.filter((b) => b !== item);
+    await exceptionAction.run(
+      async () => {
+        const ok = await updateNicknameModerationConfig({ bypass: updatedBypass });
+        if (!ok) throw new Error('Erreur API');
+        bypass = updatedBypass;
+        return true;
+      },
+      { successMessage: `Exemption pour le membre ${item} retirée.` }
+    );
+  }
+
+  function handleWhitelistKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') { e.preventDefault(); addWhitelistItem(); }
+  }
+
+  function handleBypassKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') { e.preventDefault(); addBypassItem(); }
   }
 </script>
 
@@ -408,6 +499,120 @@
           </div>
         {/if}
       {/if}
+    </section>
+
+    <!-- ============================================================ -->
+    <!-- Section 3 — Exceptions (Pseudos & Membres autorisés)          -->
+    <!-- ============================================================ -->
+    <section class="bg-surface-container-low/40 backdrop-blur-xl rounded-4xl border border-outline-variant/30 p-8 flex flex-col gap-6">
+      <div class="flex flex-col gap-1">
+        <h2 class="text-base font-black tracking-tight text-on-surface">Exceptions de modération (Whitelist)</h2>
+        <p class="text-sm text-on-surface-variant/70">
+          Gérez les pseudos et les membres qui doivent contourner la modération automatique pour éviter les faux positifs.
+        </p>
+      </div>
+
+      <InlineFeedback state={exceptionAction} />
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+        <!-- Pseudos autorisés -->
+        <div class="flex flex-col gap-4">
+          <div class="flex flex-col gap-1">
+            <h3 class="text-sm font-bold text-on-surface">Pseudos autorisés (exacts)</h3>
+            <p class="text-xs text-on-surface-variant/50">
+              Ces pseudos complets (insensibles à la casse) ne seront jamais modérés, même s'ils contiennent un mot banni.
+            </p>
+          </div>
+
+          <div class="flex gap-2">
+            <input
+              type="text"
+              bind:value={newWhitelistItem}
+              onkeydown={handleWhitelistKeydown}
+              placeholder="Ex: xavier085409, fichier.py..."
+              class="flex-1 bg-surface-container/60 border border-outline-variant/30 rounded-2xl px-4 py-3 text-sm text-on-surface placeholder:text-on-surface-variant/30 focus:outline-none focus:border-primary/60 transition-all"
+            />
+            <button
+              onclick={addWhitelistItem}
+              disabled={!newWhitelistItem.trim() || exceptionAction.state.loading}
+              class="px-5 py-3 bg-primary text-white rounded-2xl text-sm font-bold transition-all hover:bg-primary/90 active:scale-95 disabled:opacity-40"
+            >
+              Ajouter
+            </button>
+          </div>
+
+          {#if whitelist.length > 0}
+            <div class="flex flex-wrap gap-2 p-4 rounded-2xl bg-surface-container/20 border border-outline-variant/10">
+              {#each whitelist as item}
+                <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-xs font-bold bg-primary/10 text-primary border border-primary/20">
+                  {item}
+                  <button
+                    onclick={() => removeWhitelistItem(item)}
+                    disabled={exceptionAction.state.loading}
+                    aria-label="Supprimer {item}"
+                    class="text-primary hover:text-error transition-colors focus:outline-none"
+                  >
+                    <Papicon icon="x" size={12} />
+                  </button>
+                </span>
+              {/each}
+            </div>
+          {:else}
+            <div class="p-6 rounded-2xl bg-surface-container/10 border border-dashed border-outline-variant/20 text-center text-xs text-on-surface-variant/40">
+              Aucun pseudo autorisé configuré.
+            </div>
+          {/if}
+        </div>
+
+        <!-- Membres exemptés -->
+        <div class="flex flex-col gap-4">
+          <div class="flex flex-col gap-1">
+            <h3 class="text-sm font-bold text-on-surface">Membres exemptés (Bypass)</h3>
+            <p class="text-xs text-on-surface-variant/50">
+              Les membres avec ces IDs Discord ne seront jamais renommés, peu importe le pseudo qu'ils choisissent.
+            </p>
+          </div>
+
+          <div class="flex gap-2">
+            <input
+              type="text"
+              bind:value={newBypassItem}
+              onkeydown={handleBypassKeydown}
+              placeholder="Ex: 636012675402..."
+              class="flex-1 bg-surface-container/60 border border-outline-variant/30 rounded-2xl px-4 py-3 text-sm text-on-surface placeholder:text-on-surface-variant/30 focus:outline-none focus:border-primary/60 transition-all"
+            />
+            <button
+              onclick={addBypassItem}
+              disabled={!newBypassItem.trim() || exceptionAction.state.loading}
+              class="px-5 py-3 bg-primary text-white rounded-2xl text-sm font-bold transition-all hover:bg-primary/90 active:scale-95 disabled:opacity-40"
+            >
+              Ajouter
+            </button>
+          </div>
+
+          {#if bypass.length > 0}
+            <div class="flex flex-wrap gap-2 p-4 rounded-2xl bg-surface-container/20 border border-outline-variant/10">
+              {#each bypass as item}
+                <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-xs font-bold bg-secondary/10 text-on-secondary-container border border-secondary/20 font-mono">
+                  {item}
+                  <button
+                    onclick={() => removeBypassItem(item)}
+                    disabled={exceptionAction.state.loading}
+                    aria-label="Retirer l'exemption pour {item}"
+                    class="text-on-secondary-container hover:text-error transition-colors focus:outline-none"
+                  >
+                    <Papicon icon="x" size={12} />
+                  </button>
+                </span>
+              {/each}
+            </div>
+          {:else}
+            <div class="p-6 rounded-2xl bg-surface-container/10 border border-dashed border-outline-variant/20 text-center text-xs text-on-surface-variant/40">
+              Aucun membre exempté (les admins/bots sont déjà ignorés par défaut).
+            </div>
+          {/if}
+        </div>
+      </div>
     </section>
   {/if}
 </ModulePage>

--- a/packages/database/prisma/migrations/20260529000000_add_nickname_whitelist_bypass/migration.sql
+++ b/packages/database/prisma/migrations/20260529000000_add_nickname_whitelist_bypass/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "guilds" ADD COLUMN IF NOT EXISTS "nicknameModerationWhitelist" TEXT[] DEFAULT ARRAY[]::TEXT[];
+ALTER TABLE "guilds" ADD COLUMN IF NOT EXISTS "nicknameModerationBypass" TEXT[] DEFAULT ARRAY[]::TEXT[];

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -50,6 +50,8 @@ model Guild {
   codePoliceRules          CodePoliceRule[]
 
   autoNicknameModerationEnabled Boolean   @default(false)
+  nicknameModerationWhitelist  String[]  @default([])
+  nicknameModerationBypass     String[]  @default([])
   bannedWords              BannedWord[]
   
   dailyAlgoEnabled         Boolean @default(false)


### PR DESCRIPTION
# 🇫🇷 Version Française

## Sécurité & Anti-boucle
* **Protection anti-boucle** : Interdiction d'ajouter `"automod"` ou `"pseudo non conforme"` (ou tout ce qui peut y ressembler) dans la liste des mots bannis afin d'éviter tout renommage en boucle infinie.
* **Sécurisation du Dashboard (Anti-DoS)** : 
  * Limite maximale de **250 éléments** pour la whitelist et le bypass.
  * Validation stricte des formats : max 32 caractères pour les pseudos, et format numérique strict (17 à 20 chiffres) pour les IDs Discord.

## Exceptions & Whitelist (Par serveur)
* **Whitelist de pseudos** : Comparaison exacte insensible à la casse. Si le pseudo d'un membre correspond exactement à une entrée de la whitelist, il contourne la modération.
* **Validation bidirectionnelle** : Un mot banni ne peut pas être whitelisté, et inversement (un mot de la whitelist ne peut pas être banni). En cas de conflit de données exceptionnel, la whitelist a toujours la priorité.
* **Exemption par ID utilisateur (Bypass)** : Possibilité d'exempter un membre par son ID Discord unique. Il obtient une immunité totale, peu importe les pseudos qu'il choisit. *(Les bots et le propriétaire du serveur sont déjà ignorés par défaut)*.

## UX & Notifications Dashboard
* **Action d'annulation (Undo)** : Ajout d'un bouton temporaire de 6 secondes « Annuler » sur les notifications de succès du dashboard lors de la suppression d'un pseudo ou d'un ID de la whitelist, permettant de le restaurer instantanément en un clic (comportement identique aux mots personnalisés).
* **Messages d'erreur clairs** : Les erreurs de validation de l'API (conflits avec mots bannis, limite de taille, ID invalides) sont remontées proprement sous forme de toasts d'erreur sur le dashboard.
* **Temps réel (WebSockets)** : Les modifications de la whitelist et du bypass sont diffusées instantanément via WebSockets à tous les administrateurs connectés sur le serveur.

## Technique
* Création d'une migration Prisma pour ajouter les colonnes array `nicknameModerationWhitelist` et `nicknameModerationBypass` (`TEXT[]`) avec des valeurs par défaut vides.
* Ajout d'un cache TTL de 60s côté bot Discord pour éviter de surcharger la base de données.
* Enregistrement automatique de chaque modification de paramètre dans les logs d'activité du site (`DashboardAuditLog`), et envoi d'embeds de modération détaillés dans le salon de logs Discord lors des renommages.

***

# 🇬🇧 English Version

## Security & Anti-loop
* **Anti-loop protection**: Prevent adding `"automod"` or `"pseudo non conforme"` (or anything resembling them) to the banned words list to prevent infinite rename loops.
* **Dashboard Security (Anti-DoS)**: 
  * Maximum limit of **250 entries** for both the whitelist and the bypass lists.
  * Strict format validation: max 32 characters for whitelisted nicknames, and strict numeric format (17 to 20 digits) for Discord IDs.

## Exceptions & Whitelist (Per-server)
* **Nickname Whitelist**: Case-insensitive exact match. If a member's nickname matches a whitelist entry exactly, they bypass moderation.
* **Bidirectional validation**: A banned word cannot be whitelisted, and vice versa (a whitelisted word cannot be banned). In the event of an exceptional database conflict, the whitelist takes priority.
* **User ID Bypass**: Ability to exempt a member using their unique Discord ID. They receive complete immunity, regardless of the nickname they choose. *(Bots and the server owner are already bypassed by default)*.

## UX & Dashboard Notifications
* **Undo Action**: Added a temporary 6-second "Undo" button on dashboard success notifications when removing a nickname or user ID from the exception lists, allowing instant restoration in a single click (matching the custom words behavior).
* **Clear Error Messages**: API validation errors (conflicts with banned words, size limits, invalid IDs) are cleanly reported as error toasts on the dashboard.
* **Real-time (WebSockets)**: Whitelist and bypass updates are instantly broadcasted via WebSockets to all connected server administrators.

## Technical
* Created a Prisma migration to add the array columns `nicknameModerationWhitelist` and `nicknameModerationBypass` (`TEXT[]`) with empty arrays as defaults.
* Added a 60-second TTL cache on the Discord bot to prevent database overhead.
* Automatic logging of all dashboard setting changes in the activity logs (`DashboardAuditLog`), and detailed embeds of rename events sent to the server's Discord log channel.