### PR TITLE
Optimisation du buffering I/O et du cache pour Prisma et le service de leveling

### DIFF
--- a/apps/bot/src/events/levelingEvents.ts
+++ b/apps/bot/src/events/levelingEvents.ts
@@ -18,6 +18,8 @@ export function registerLevelingListener(client: Client) {
   
   voiceXpInterval = setInterval(async () => {
     try {
+      const xpPromises: Promise<void>[] = [];
+
       for (const [guildId, guild] of client.guilds.cache) {
         const config = await getOrCreateLevelConfig(guildId).catch(() => null);
         if (!config || !config.enabled || config.vocalXpPerMin <= 0) continue;
@@ -39,7 +41,7 @@ export function registerLevelingListener(client: Client) {
             if (isMuted || isDeafened) continue;
 
             // Vérifier si le membre possède un rôle exclu
-            if (config.ignoredRoles && config.ignoredRoles.some(roleId => member.roles.cache.has(roleId))) continue;
+            if (config.ignoredRoles && (config.ignoredRoles as string[]).some(roleId => member.roles.cache.has(roleId))) continue;
 
             // Calculer le multiplicateur d'XP par rôle
             let multiplier = 1.0;
@@ -57,13 +59,24 @@ export function registerLevelingListener(client: Client) {
             const voiceXp = Math.floor(config.vocalXpPerMin * multiplier);
             if (voiceXp <= 0) continue;
 
-            // Ajouter l'XP vocale
-            await addXp(guildId, member.id, voiceXp, client).catch(err => 
-              logger.error('LevelingService', `Erreur lors de l'attribution XP vocal à ${member.id}:`, err)
+            // Ajouter aux promesses à résoudre
+            xpPromises.push(
+              addXp(guildId, member.id, voiceXp, client).catch(err => 
+                logger.error('LevelingService', `Erreur lors de l'attribution XP vocal à ${member.id}:`, err)
+              )
             );
           }
         }
       }
+
+      // Exécuter l'ajout d'XP par lots pour ne pas saturer la base de données
+      if (xpPromises.length > 0) {
+        const CHUNK_SIZE = 50;
+        for (let i = 0; i < xpPromises.length; i += CHUNK_SIZE) {
+          await Promise.all(xpPromises.slice(i, i + CHUNK_SIZE));
+        }
+      }
+
     } catch (err) {
       logger.error('LevelingEvents', 'Erreur lors de la boucle d\'XP vocale :', err);
     }

--- a/apps/bot/src/events/levelingEvents.ts
+++ b/apps/bot/src/events/levelingEvents.ts
@@ -59,22 +59,24 @@ export function registerLevelingListener(client: Client) {
             const voiceXp = Math.floor(config.vocalXpPerMin * multiplier);
             if (voiceXp <= 0) continue;
 
-            // Ajouter aux promesses à résoudre
+            // Ajouter l'XP vocale (batching: max 50 opérations en parallèle)
             xpPromises.push(
-              addXp(guildId, member.id, voiceXp, client).catch(err => 
+              addXp(guildId, member.id, voiceXp, client).catch(err =>
                 logger.error('LevelingService', `Erreur lors de l'attribution XP vocal à ${member.id}:`, err)
               )
             );
+
+            if (xpPromises.length >= 50) {
+              await Promise.all(xpPromises);
+              xpPromises.length = 0;
+            }
           }
         }
       }
 
-      // Exécuter l'ajout d'XP par lots pour ne pas saturer la base de données
+      // Flush remaining XP updates
       if (xpPromises.length > 0) {
-        const CHUNK_SIZE = 50;
-        for (let i = 0; i < xpPromises.length; i += CHUNK_SIZE) {
-          await Promise.all(xpPromises.slice(i, i + CHUNK_SIZE));
-        }
+        await Promise.all(xpPromises);
       }
 
     } catch (err) {

--- a/apps/bot/src/events/ticketLeaveFollowUp.ts
+++ b/apps/bot/src/events/ticketLeaveFollowUp.ts
@@ -14,14 +14,6 @@ import { logger } from '../utils/logger.js';
 export function registerTicketLeaveFollowUpListener(client: Client): void {
   client.on(Events.GuildMemberRemove, async (member) => {
     try {
-      const guildConfig = await prisma.guild.findUnique({
-        where: { id: member.guild.id },
-        select: {
-          ticketStaffRoleId: true,
-          moderatorRoleId: true,
-        },
-      });
-
       const tickets = await prisma.ticket.findMany({
         where: {
           guildId: member.guild.id,
@@ -32,6 +24,14 @@ export function registerTicketLeaveFollowUpListener(client: Client): void {
       });
 
       if (tickets.length === 0) return;
+
+      const guildConfig = await prisma.guild.findUnique({
+        where: { id: member.guild.id },
+        select: {
+          ticketStaffRoleId: true,
+          moderatorRoleId: true,
+        },
+      });
 
       for (const ticket of tickets) {
         if (!ticket.channelId) continue;

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -350,29 +350,12 @@ client.on(Events.InteractionCreate, async (interaction) => {
         await cache.invalidateGuild(interaction.guildId);
       }
 
-      // Track command usage for analytics
+      // Track command usage for analytics (buffered)
       try {
-        await prisma.dashboardCommandUsage.upsert({
-          where: {
-            guildId_commandName_userId: {
-              guildId: interaction.guildId || 'DM',
-              commandName: interaction.commandName,
-              userId: interaction.user.id
-            }
-          },
-          update: {
-            count: { increment: 1 },
-            lastUsedAt: new Date()
-          },
-          create: {
-            guildId: interaction.guildId || 'DM',
-            commandName: interaction.commandName,
-            userId: interaction.user.id,
-            count: 1
-          }
-        });
+        const usageKey = `${interaction.guildId || 'DM'}:${interaction.commandName}:${interaction.user.id}`;
+        commandUsageBuffer.set(usageKey, (commandUsageBuffer.get(usageKey) || 0) + 1);
       } catch (e) {
-        logger.error('Analytics', 'Erreur lors du tracking de commande', e);
+        logger.error('Analytics', 'Erreur lors de la mise en buffer de commande', e);
       }
     }
 
@@ -431,25 +414,71 @@ client.on(Events.InteractionCreate, async (interaction) => {
   }
 });
 
+// ============================================================================
+// IN-MEMORY BUFFERS FOR PERFORMANCE
+// ============================================================================
+const commandUsageBuffer = new Map<string, number>();
+let errorLogBuffer: Array<{ message: string, stack: string | null, source: string }> = [];
+
+async function flushIndexBuffers() {
+  // Flush Command Usage
+  const usageEntries = [...commandUsageBuffer.entries()];
+  commandUsageBuffer.clear();
+  
+  if (usageEntries.length > 0) {
+    try {
+      const ops = usageEntries.map(([key, count]) => {
+        const [guildId, commandName, userId] = key.split(':');
+        return prisma.dashboardCommandUsage.upsert({
+          where: { guildId_commandName_userId: { guildId, commandName, userId } },
+          update: { count: { increment: count }, lastUsedAt: new Date() },
+          create: { guildId, commandName, userId, count }
+        });
+      });
+      await Promise.all(ops);
+    } catch (e) {
+      logger.error('Analytics', 'Erreur lors du flush des command usages', e);
+    }
+  }
+
+  // Flush Error Logs
+  const errorsToInsert = [...errorLogBuffer];
+  errorLogBuffer = [];
+  if (errorsToInsert.length > 0) {
+    try {
+      await prisma.botErrorLog.createMany({
+        data: errorsToInsert
+      });
+    } catch (e) {
+      logger.error('System', 'Erreur lors du flush des bot error logs', e);
+    }
+  }
+}
+
+// Flush every 5 seconds
+const flushInterval = setInterval(() => {
+  void flushIndexBuffers();
+}, 5000);
+
+process.on('beforeExit', () => {
+  clearInterval(flushInterval);
+  void flushIndexBuffers();
+});
+// ============================================================================
+
 const token = process.env.DISCORD_TOKEN;
 if (!token) {
   logger.error('Bot', 'DISCORD_TOKEN non défini dans .env !');
   process.exit(1);
 }
 
-// Global Error Logging for Dashboard
-async function logErrorToDb(error: Error, source: string) {
-  try {
-    await prisma.botErrorLog.create({
-      data: {
-        message: error.message || 'Erreur inconnue',
-        stack: error.stack?.substring(0, 4000) || null,
-        source
-      }
-    });
-  } catch (e) {
-    logger.error('System', 'Impossible de sauvegarder l\'erreur en BDD', e);
-  }
+// Global Error Logging for Dashboard (buffered)
+function logErrorToDb(error: Error, source: string) {
+  errorLogBuffer.push({
+    message: error.message || 'Erreur inconnue',
+    stack: error.stack?.substring(0, 4000) || null,
+    source
+  });
 }
 
 process.on('uncaughtException', (error) => {

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -437,6 +437,10 @@ async function flushIndexBuffers() {
       });
       await Promise.all(ops);
     } catch (e) {
+      // Re-queue entries so they can be retried on next flush
+      for (const [key, count] of usageEntries) {
+        commandUsageBuffer.set(key, (commandUsageBuffer.get(key) || 0) + count);
+      }
       logger.error('Analytics', 'Erreur lors du flush des command usages', e);
     }
   }

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -454,6 +454,8 @@ async function flushIndexBuffers() {
         data: errorsToInsert
       });
     } catch (e) {
+      // Re-queue entries so they can be retried on next flush
+      errorLogBuffer.unshift(...errorsToInsert);
       logger.error('System', 'Erreur lors du flush des bot error logs', e);
     }
   }

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -466,6 +466,23 @@ const flushInterval = setInterval(() => {
   void flushIndexBuffers();
 }, 5000);
 
+async function flushAndStop(exitCode = 0) {
+  clearInterval(flushInterval);
+  try {
+    await flushIndexBuffers();
+  } finally {
+    process.exit(exitCode);
+  }
+}
+
+process.on('SIGINT', () => {
+  void flushAndStop(0);
+});
+
+process.on('SIGTERM', () => {
+  void flushAndStop(0);
+});
+
 process.on('beforeExit', () => {
   clearInterval(flushInterval);
   void flushIndexBuffers();

--- a/apps/bot/src/services/levelingService.ts
+++ b/apps/bot/src/services/levelingService.ts
@@ -16,11 +16,13 @@ export function getXpForLevel(level: number): number {
   return 100 * Math.pow(level, 2) + 200 * level;
 }
 
-/**
- * Récupère ou initialise la configuration de leveling d'une guilde
- */
 export async function getOrCreateLevelConfig(guildId: string) {
-  let config = await prisma.levelConfig.findUnique({
+  const cacheKey = `guild:${guildId}:level_config`;
+  let config = await cache.get<any>(cacheKey);
+
+  if (config) return config;
+
+  config = await prisma.levelConfig.findUnique({
     where: { guildId },
   });
 
@@ -41,6 +43,8 @@ export async function getOrCreateLevelConfig(guildId: string) {
       },
     });
   }
+
+  await cache.set(cacheKey, config, 60);
   return config;
 }
 
@@ -64,7 +68,7 @@ export async function handleTextXp(guildId: string, userId: string, client: Clie
     if (!member) return;
 
     // Vérifier si le membre possède un rôle exclu
-    if (config.ignoredRoles && config.ignoredRoles.some(roleId => member.roles.cache.has(roleId))) {
+    if (config.ignoredRoles && (config.ignoredRoles as string[]).some(roleId => member.roles.cache.has(roleId))) {
       return;
     }
 


### PR DESCRIPTION
## Résumé

Cette pull request introduit plusieurs optimisations de performance et améliorations de code sur le bot.  
L’objectif principal est de réduire la charge sur la base de données grâce à du batching, du cache en mémoire et quelques ajustements de logique.

Les changements les plus importants concernent :

- la mise en place de buffers en mémoire pour les statistiques d’utilisation des commandes et les logs d’erreur ;
- le traitement groupé des mises à jour d’XP afin d’éviter de saturer la base de données ;
- la mise en cache temporaire des configurations de leveling par serveur ;
- quelques corrections mineures de typage et d’ordre d’exécution.

## Améliorations de performance et de scalabilité

### Batching des analytics et des logs d’erreur

Des buffers en mémoire ont été ajoutés dans `index.ts` :

- `commandUsageBuffer`
- `errorLogBuffer`

Au lieu d’écrire immédiatement en base de données à chaque utilisation de commande ou à chaque erreur, les données sont maintenant stockées temporairement en mémoire, puis envoyées en base toutes les 5 secondes.

Cela réduit fortement le nombre d’écritures individuelles, surtout lorsque le bot reçoit beaucoup d’interactions en peu de temps.

La fonction de logging d’erreur a également été modifiée pour pousser les erreurs dans le buffer plutôt que d’effectuer une écriture directe en base.

### Traitement groupé des mises à jour d’XP

L’attribution d’XP dans `levelingEvents.ts` a été modifiée afin de traiter les mises à jour par lots.

Les updates sont maintenant découpées en groupes, avec une taille par défaut de 50, puis exécutées avec `Promise.all`.

Cette approche permet d’éviter une surcharge de la base de données lors de gros volumes d’activité, par exemple lorsqu’un grand nombre de membres envoie des messages ou lorsqu’un traitement massif est déclenché.

## Améliorations du cache

### Cache des configurations de leveling

Un système de cache a été ajouté dans `levelingService.ts` via `getOrCreateLevelConfig`.

Les configurations de leveling propres à chaque serveur sont maintenant conservées en mémoire pendant 60 secondes.

Cela permet d’éviter de refaire une requête en base à chaque événement lié au leveling, tout en gardant une durée de cache courte pour limiter le risque d’utiliser une configuration trop ancienne.

## Corrections de bugs et améliorations mineures

### Correction de typage sur les rôles ignorés

Un problème de typage a été corrigé lors de la vérification des rôles ignorés dans :

- `levelingEvents.ts`
- `levelingService.ts`

La valeur `ignoredRoles` est maintenant explicitement castée en `string[]`, ce qui évite les erreurs TypeScript et rend le comportement plus clair.

### Optimisation du chargement de la configuration des tickets

Dans `ticketLeaveFollowUp.ts`, le chargement de `guildConfig` a été réorganisé.

La configuration du serveur n’est maintenant récupérée que si des tickets existent réellement.

Cela évite des requêtes inutiles à la base de données lorsqu’il n’y a aucun ticket à traiter.

## Impact global

Cette PR améliore la stabilité et la capacité du bot à gérer plus de charge, notamment sur les serveurs actifs.

Les écritures en base sont moins fréquentes, les accès aux configurations sont mieux optimisés, et certaines requêtes inutiles sont évitées.

En bref : moins de pression sur la base de données, un bot plus propre, et une meilleure tenue en cas de forte activité.