### PR TITLE
refactor(bot): centralize command definitions

### DIFF
--- a/apps/bot/src/commands.ts
+++ b/apps/bot/src/commands.ts
@@ -33,6 +33,7 @@ import { statusCommand } from './commands/status.js';
 import { suggestCommand } from './commands/suggest.js';
 import { ticketCommand } from './commands/ticket.js';
 import { transcriptCommand } from './commands/transcript.js';
+import { suggestionConfigCommand } from './commands/suggestion-config.ts';
 
 export type SlashCommandDefinition = {
   data: { name: string; toJSON: () => unknown };
@@ -83,6 +84,7 @@ export const commands: SlashCommandDefinition[] = [
   rankCommand,
   giveawayCommand,
   suggestCommand,
+  suggestionConfigCommand,
 ];
 
 export const contextCommands: ContextCommandDefinition[] = [

--- a/apps/bot/src/commands.ts
+++ b/apps/bot/src/commands.ts
@@ -20,8 +20,8 @@ import { meetingCommand } from './commands/meeting.js';
 import { noteCommand, noteContextCommand } from './commands/note.js';
 import { pingCommand } from './commands/ping.js';
 import { postCommand } from './commands/post.js';
-import { profilCommand } from './commands/profil.ts';
-import { profileCommand } from './commands/profile.ts';
+import { profilCommand } from './commands/profil.js';
+import { profileCommand } from './commands/profile.js';
 import { rankCommand } from './commands/rank.js';
 import { rescanCommand } from './commands/rescan.js';
 import { sanctionCommand, sanctionContextCommand } from './commands/sanction.js';
@@ -33,7 +33,7 @@ import { statusCommand } from './commands/status.js';
 import { suggestCommand } from './commands/suggest.js';
 import { ticketCommand } from './commands/ticket.js';
 import { transcriptCommand } from './commands/transcript.js';
-import { suggestionConfigCommand } from './commands/suggestion-config.ts';
+import { suggestionConfigCommand } from './commands/suggestion-config.js';
 
 export type SlashCommandDefinition = {
   data: { name: string; toJSON: () => unknown };

--- a/apps/bot/src/commands.ts
+++ b/apps/bot/src/commands.ts
@@ -1,0 +1,97 @@
+import type { AutocompleteInteraction, ChatInputCommandInteraction, MessageContextMenuCommandInteraction, UserContextMenuCommandInteraction } from 'discord.js';
+import { absentCommand } from './commands/absent.js';
+import { activateCommand } from './commands/activate.js';
+import { adminCommand } from './commands/admin.js';
+import { casierCommand, casierContextCommand } from './commands/casier.js';
+import { configCommand } from './commands/config.js';
+import { dailyAlgoCommand } from './commands/dailyAlgo.js';
+import { dcCommand } from './commands/dc.js';
+import { demissionCommand } from './commands/demission.js';
+import { devutilsCommand } from './commands/devutils.js';
+import { epochCommand } from './commands/epoch.js';
+import { eventCommand } from './commands/event.js';
+import { excuseCommand } from './commands/excuse.js';
+import { giveawayCommand } from './commands/giveaway.js';
+import { helpCommand } from './commands/help.js';
+import { infoCommand } from './commands/info.js';
+import { invitesCommand } from './commands/invites.js';
+import { leaderboardCommand } from './commands/leaderboard.js';
+import { meetingCommand } from './commands/meeting.js';
+import { noteCommand, noteContextCommand } from './commands/note.js';
+import { pingCommand } from './commands/ping.js';
+import { postCommand } from './commands/post.js';
+import { profilCommand } from './commands/profil.ts';
+import { profileCommand } from './commands/profile.ts';
+import { rankCommand } from './commands/rank.js';
+import { rescanCommand } from './commands/rescan.js';
+import { sanctionCommand, sanctionContextCommand } from './commands/sanction.js';
+import { sayCommand } from './commands/say.js';
+import { serverstatsCommand } from './commands/serverstats.js';
+import { setupCommand } from './commands/setup.js';
+import { statsCommand } from './commands/stats.js';
+import { statusCommand } from './commands/status.js';
+import { suggestCommand } from './commands/suggest.js';
+import { ticketCommand } from './commands/ticket.js';
+import { transcriptCommand } from './commands/transcript.js';
+
+export type SlashCommandDefinition = {
+  data: { name: string; toJSON: () => unknown };
+  execute: (interaction: ChatInputCommandInteraction) => Promise<unknown>;
+  autocomplete?: (interaction: AutocompleteInteraction) => Promise<unknown>;
+};
+
+export type ContextCommandDefinition = {
+  data: { name: string; toJSON: () => unknown };
+  execute:
+  (interaction: UserContextMenuCommandInteraction) => Promise<unknown> | ((interaction: MessageContextMenuCommandInteraction) => Promise<unknown>);
+};
+
+export type ApplicationCommandDefinition = SlashCommandDefinition | ContextCommandDefinition;
+
+export const commands: SlashCommandDefinition[] = [
+  setupCommand,
+  configCommand,
+  pingCommand,
+  infoCommand,
+  excuseCommand,
+  epochCommand,
+  devutilsCommand,
+  statusCommand,
+  adminCommand,
+  postCommand,
+  helpCommand,
+  dailyAlgoCommand,
+  profileCommand,
+  profilCommand,
+  sanctionCommand,
+  dcCommand,
+  rescanCommand,
+  casierCommand,
+  absentCommand,
+  meetingCommand,
+  statsCommand,
+  invitesCommand,
+  leaderboardCommand,
+  serverstatsCommand,
+  noteCommand,
+  eventCommand,
+  activateCommand,
+  transcriptCommand,
+  ticketCommand,
+  sayCommand,
+  demissionCommand,
+  rankCommand,
+  giveawayCommand,
+  suggestCommand,
+];
+
+export const contextCommands: ContextCommandDefinition[] = [
+  noteContextCommand,
+  casierContextCommand,
+  sanctionContextCommand,
+];
+
+export const applicationCommands: ApplicationCommandDefinition[] = [
+  ...commands,
+  ...contextCommands,
+];

--- a/apps/bot/src/commands/absent.ts
+++ b/apps/bot/src/commands/absent.ts
@@ -15,8 +15,9 @@ import {
   getLatestOpenAbsenceForMember,
 } from '../services/staffLeadershipService.js';
 import { getStaffMember } from '../services/staffManagementService.js';
+import type { SlashCommandDefinition } from '../commands.js';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('absent')
   .setDescription('Gère vos absences staff (déclaration et clôture).')
   .addSubcommand((subcommand) =>
@@ -150,7 +151,7 @@ const askIndefiniteConfirmation = async (
   }
 };
 
-export async function execute(interaction: ChatInputCommandInteraction) {
+async function execute(interaction: ChatInputCommandInteraction) {
   if (!interaction.guildId) return;
 
   const staff = await getStaffMember(interaction.guildId, interaction.user.id);
@@ -278,3 +279,5 @@ export async function execute(interaction: ChatInputCommandInteraction) {
     });
   }
 }
+
+export const absentCommand: SlashCommandDefinition = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/activate.ts
+++ b/apps/bot/src/commands/activate.ts
@@ -8,8 +8,9 @@ import prisma from '../utils/db.js';
 import { successEmbed, errorEmbed } from '../utils/embeds.js';
 import { isGuildActivated, activateGuild } from '../utils/activation.js';
 import { initializeAutoBackup } from '../services/autoBackupService.js';
+import type { SlashCommandDefinition } from '../commands.js';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('activate')
   .setDescription('🔑 Activer le bot sur ce serveur à l\'aide d\'un code d\'activation')
   .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
@@ -20,7 +21,7 @@ export const data = new SlashCommandBuilder()
       .setRequired(true)
   );
 
-export async function execute(interaction: ChatInputCommandInteraction) {
+async function execute(interaction: ChatInputCommandInteraction) {
   const guildId = interaction.guildId;
   if (!guildId) {
     return interaction.reply({
@@ -100,3 +101,5 @@ export async function execute(interaction: ChatInputCommandInteraction) {
     });
   }
 }
+
+export const activateCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/admin.ts
+++ b/apps/bot/src/commands/admin.ts
@@ -1,3 +1,4 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import { SlashCommandBuilder, type ChatInputCommandInteraction, PermissionFlagsBits, MessageFlags } from 'discord.js';
 import { successEmbed, errorEmbed, infoEmbed, COLORS, truncate } from '../utils/embeds.js';
 import prisma from '../utils/db.js';
@@ -13,7 +14,7 @@ import {
 
 
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('admin')
   .setDescription('🔧 Commandes administrateur')
   .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
@@ -116,7 +117,7 @@ export const data = new SlashCommandBuilder()
       )
   );
 
-export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
   const subcommand = interaction.options.getSubcommand() as string;
   const guildId = interaction.guildId;
 
@@ -499,3 +500,5 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
     }
   }
 }
+
+export const adminCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/casier.ts
+++ b/apps/bot/src/commands/casier.ts
@@ -1,3 +1,4 @@
+import type { ContextCommandDefinition, SlashCommandDefinition } from '../commands.js';
 import {
   MessageFlags,
   PermissionFlagsBits,
@@ -11,7 +12,7 @@ import { errorEmbed } from '../utils/embeds.js';
 import { renderPanelTarget } from '../utils/interactionResponses.js';
 import { buildMemberCasePanel } from '../services/memberCaseService.js';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('casier')
   .setDescription('📁 Ouvre le casier utilisateur complet')
   .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers)
@@ -23,7 +24,7 @@ export const data = new SlashCommandBuilder()
       .addStringOption((option) => option.setName('id').setDescription('ID Discord à consulter si le membre n’est plus présent').setRequired(false)),
   );
 
-export const contextData = new ContextMenuCommandBuilder()
+const contextData = new ContextMenuCommandBuilder()
   .setName('Voir le Casier')
   .setType(ApplicationCommandType.User)
   .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers);
@@ -45,7 +46,7 @@ async function replyError(interaction: ChatInputCommandInteraction, title: strin
   await interaction.reply({ embeds: [errorEmbed(title, description)], flags: [MessageFlags.Ephemeral] });
 }
 
-export async function execute(interaction: ChatInputCommandInteraction | UserContextMenuCommandInteraction): Promise<void> {
+async function execute(interaction: ChatInputCommandInteraction | UserContextMenuCommandInteraction): Promise<void> {
   if (!interaction.inCachedGuild()) return;
 
   const targetUserId = interaction.isChatInputCommand()
@@ -76,3 +77,6 @@ export async function execute(interaction: ChatInputCommandInteraction | UserCon
     });
   }
 }
+
+export const casierCommand = { data, execute } satisfies SlashCommandDefinition;
+export const casierContextCommand = { data: contextData, execute } satisfies ContextCommandDefinition;

--- a/apps/bot/src/commands/config.ts
+++ b/apps/bot/src/commands/config.ts
@@ -1,3 +1,4 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import {
   SlashCommandBuilder,
   type ChatInputCommandInteraction,
@@ -7,12 +8,12 @@ import {
 import { sendMainConfigPanel } from '../panels/generalConfigPanel.js';
 import prisma from '../utils/db.js';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('config')
   .setDescription('⚙️ Configure toutes les fonctionnalités de Kotbo')
   .setDefaultMemberPermissions(PermissionFlagsBits.Administrator);
 
-export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
   const guildId = interaction.guildId!;
 
   await prisma.guild.upsert({
@@ -23,3 +24,5 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
 
   await sendMainConfigPanel(interaction, guildId);
 }
+
+export const configCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/dailyAlgo.ts
+++ b/apps/bot/src/commands/dailyAlgo.ts
@@ -1,3 +1,4 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import { EmbedBuilder, MessageFlags, SlashCommandBuilder, type ChatInputCommandInteraction } from 'discord.js';
 import {
   getDailyAlgoUserProfile,
@@ -8,7 +9,7 @@ import {
 import { COLORS, truncate } from '../utils/embeds.js';
 import { extractTrackingInfo, resolveModuleFromCommand, wrapModuleTracking } from '../utils/moduleTracking.js';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('daily-algo')
   .setDescription('📚 Infos et stats Daily Algo')
   .addStringOption((option) =>
@@ -230,7 +231,7 @@ async function replyProfile(interaction: ChatInputCommandInteraction, guildId: s
   });
 }
 
-export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
   const { guildId, userId } = extractTrackingInfo(interaction);
   const moduleName = resolveModuleFromCommand('daily-algo');
   const view = interaction.options.getString('vue') ?? 'previous';
@@ -279,3 +280,5 @@ async function executeInternal(interaction: ChatInputCommandInteraction): Promis
 
   await replyPreviousRun(interaction, guildId);
 }
+
+export const dailyAlgoCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/dc.ts
+++ b/apps/bot/src/commands/dc.ts
@@ -1,3 +1,4 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import {
   SlashCommandBuilder,
   EmbedBuilder,
@@ -13,7 +14,7 @@ import prisma from '../utils/db.js';
 import { COLORS, successEmbed, errorEmbed, infoEmbed } from '../utils/embeds.js';
 import { scanGuildMembersForYoungAccounts } from '../services/dcDetectionService.js';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('dc')
   .setDescription('Gestion des doubles comptes et liaisons.')
   .addSubcommand((sub) =>
@@ -80,7 +81,7 @@ async function canUseModerationTools(interaction: ChatInputCommandInteraction): 
   return isAdmin || !!isStaffDb || interaction.memberPermissions?.has(PermissionFlagsBits.ModerateMembers);
 }
 
-export async function execute(interaction: ChatInputCommandInteraction) {
+async function execute(interaction: ChatInputCommandInteraction) {
   const subcommand = interaction.options.getSubcommand();
 
   if (subcommand === 'scan' || subcommand === 'rescan') {
@@ -346,3 +347,5 @@ export async function execute(interaction: ChatInputCommandInteraction) {
     });
   }
 }
+
+export const dcCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/demission.ts
+++ b/apps/bot/src/commands/demission.ts
@@ -1,3 +1,4 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import {
   ActionRowBuilder,
   MessageFlags,
@@ -10,11 +11,11 @@ import {
 import prisma from '../utils/db.js';
 import { getStaffMember } from '../services/staffManagementService.js';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('demission')
   .setDescription('Soumet une demande de démission du staff avec un motif.');
 
-export async function execute(interaction: ChatInputCommandInteraction) {
+async function execute(interaction: ChatInputCommandInteraction) {
   if (!interaction.guildId) return;
 
   const staff = await getStaffMember(interaction.guildId, interaction.user.id);
@@ -53,3 +54,5 @@ export async function execute(interaction: ChatInputCommandInteraction) {
   modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(reasonInput));
   await interaction.showModal(modal);
 }
+
+export const demissionCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/devutils.ts
+++ b/apps/bot/src/commands/devutils.ts
@@ -1,8 +1,9 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import { SlashCommandBuilder, type ChatInputCommandInteraction } from 'discord.js';
 import { infoEmbed, errorEmbed } from '../utils/embeds.js';
 import { createHash } from 'crypto';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('devutils')
   .setDescription('🛠️ Utilitaires pour développeurs')
   .addSubcommand(sub =>
@@ -81,7 +82,7 @@ function sha256(str: string): string {
   return createHash('sha256').update(str).digest('hex');
 }
 
-export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
   const subcommand = interaction.options.getSubcommand();
 
   try {
@@ -167,3 +168,5 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
     });
   }
 }
+
+export const devutilsCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/epoch.ts
+++ b/apps/bot/src/commands/epoch.ts
@@ -1,7 +1,8 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import { SlashCommandBuilder, type ChatInputCommandInteraction } from 'discord.js';
 import { infoEmbed, errorEmbed } from '../utils/embeds.js';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('epoch')
   .setDescription('🕐 Convertis entre timestamp Unix et date lisible')
   .addStringOption(option =>
@@ -11,7 +12,7 @@ export const data = new SlashCommandBuilder()
       .setRequired(false)
   );
 
-export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
   const input = interaction.options.getString('value');
 
   try {
@@ -90,3 +91,5 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
     });
   }
 }
+
+export const epochCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/event.ts
+++ b/apps/bot/src/commands/event.ts
@@ -1,3 +1,4 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import { 
   MessageFlags, 
   SlashCommandBuilder, 
@@ -6,7 +7,7 @@ import {
 import { logger } from '../utils/logger.js';
 import { buildEventResultsView } from '../services/eventService.js';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('event')
   .setDescription('🎯 Commandes liées aux événements')
   .addSubcommand(sub => 
@@ -15,7 +16,7 @@ export const data = new SlashCommandBuilder()
       .setDescription('📈 Voir tes résultats à un quiz')
   );
 
-export async function execute(interaction: ChatInputCommandInteraction) {
+async function execute(interaction: ChatInputCommandInteraction) {
   const subcommand = interaction.options.getSubcommand();
 
   if (subcommand === 'resultat') {
@@ -40,3 +41,5 @@ async function handleResults(interaction: ChatInputCommandInteraction) {
     await interaction.editReply('❌ Une erreur est survenue.');
   }
 }
+
+export const eventCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/excuse.ts
+++ b/apps/bot/src/commands/excuse.ts
@@ -1,12 +1,13 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import { SlashCommandBuilder, type ChatInputCommandInteraction } from 'discord.js';
 import prisma from '../utils/db.js';
 import { errorEmbed, successEmbed } from '../utils/embeds.js';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('excuse')
   .setDescription('😅 Génère une excuse de développeur aléatoire');
 
-export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
   const excuses = await prisma.developerExcuse.findMany({
     where: { language: 'fr' },
     select: { text: true },
@@ -27,3 +28,5 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
     ],
   });
 }
+
+export const excuseCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/giveaway.ts
+++ b/apps/bot/src/commands/giveaway.ts
@@ -1,9 +1,10 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import { SlashCommandBuilder, PermissionFlagsBits, MessageFlags, type ChatInputCommandInteraction } from 'discord.js';
 import { createGiveaway, endGiveaway, rerollGiveaway } from '../services/giveawayService.js';
 import prisma from '../utils/db.js';
 import { extractTrackingInfo, resolveModuleFromCommand, wrapModuleTracking } from '../utils/moduleTracking.js';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('giveaway')
   .setDescription('🎉 Gérer les giveaways/concours')
   .setDefaultMemberPermissions(PermissionFlagsBits.ManageMessages)
@@ -30,7 +31,7 @@ export const data = new SlashCommandBuilder()
       .addStringOption((o) => o.setName('id').setDescription('ID du giveaway').setRequired(true))
   );
 
-export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
   const { guildId, userId } = extractTrackingInfo(interaction);
   const moduleName = resolveModuleFromCommand('giveaway');
   const subcommand = interaction.options.getSubcommand();
@@ -124,3 +125,5 @@ async function executeInternal(interaction: ChatInputCommandInteraction): Promis
     await interaction.editReply(`🎲 Un nouveau gagnant a été tiré au sort pour le giveaway \`${id}\`.`);
   }
 }
+
+export const giveawayCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/help.ts
+++ b/apps/bot/src/commands/help.ts
@@ -1,3 +1,4 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import {
   ApplicationCommandOptionType,
   EmbedBuilder,
@@ -8,21 +9,21 @@ import {
   type ChatInputCommandInteraction,
 } from 'discord.js';
 import { COLORS } from '../utils/embeds.js';
-import * as setupCmd from './setup.js';
-import * as configCmd from './config.js';
-import * as pingCmd from './ping.js';
-import * as infoCmd from './info.js';
-import * as excuseCmd from './excuse.js';
-import * as epochCmd from './epoch.js';
-import * as devutilsCmd from './devutils.js';
-import * as statusCmd from './status.js';
-import * as adminCmd from './admin.js';
-import * as postCmd from './post.js';
-import * as dailyAlgoCmd from './dailyAlgo.js';
-import * as profileCmd from './profile.js';
-import * as sanctionCmd from './sanction.js';
-import * as casierCmd from './casier.js';
-import * as ticketCmd from './ticket.js';
+import { adminCommand } from './admin.js';
+import { casierCommand } from './casier.js';
+import { configCommand } from './config.js';
+import { dailyAlgoCommand } from './dailyAlgo.js';
+import { devutilsCommand } from './devutils.js';
+import { epochCommand } from './epoch.js';
+import { excuseCommand } from './excuse.js';
+import { infoCommand } from './info.js';
+import { pingCommand } from './ping.js';
+import { postCommand } from './post.js';
+import { profileCommand } from './profile.js';
+import { sanctionCommand } from './sanction.js';
+import { setupCommand } from './setup.js';
+import { statusCommand } from './status.js';
+import { ticketCommand } from './ticket.js';
 
 type CommandJson = {
   name: string;
@@ -40,91 +41,91 @@ type HelpCommand = CommandJson & {
 
 const COMMANDS: HelpCommand[] = [
   {
-    command: setupCmd,
+    command: setupCommand,
     icon: '🚀',
     category: 'Mise en route',
     summary: 'Assistant de configuration guidée du serveur',
   },
   {
-    command: configCmd,
+    command: configCommand,
     icon: '⚙️',
     category: 'Mise en route',
     summary: 'Panneau central pour régler toutes les fonctionnalités',
   },
   {
-    command: infoCmd,
+    command: infoCommand,
     icon: 'ℹ️',
     category: 'Mise en route',
     summary: 'Affiche l’état du bot et les statistiques du serveur',
   },
   {
-    command: pingCmd,
+    command: pingCommand,
     icon: '🏓',
     category: 'Mise en route',
     summary: 'Mesure la latence du bot et de l’API Discord',
   },
   {
-    command: postCmd,
+    command: postCommand,
     icon: '🚀',
     category: 'Flux & actualités',
     summary: 'Publie le digest et/ou le Daily Algo du serveur',
   },
   {
-    command: dailyAlgoCmd,
+    command: dailyAlgoCommand,
     icon: '📚',
     category: 'Flux & actualités',
     summary: 'Affiche le défi, le barème, le classement et la progression Daily Algo',
   },
   {
-    command: profileCmd,
+    command: profileCommand,
     icon: '👤',
     category: 'Outils',
     summary: 'Affiche le profil utilisateur avec classement/streak/historique Daily Algo',
   },
   {
-    command: statusCmd,
+    command: statusCommand,
     icon: '🌐',
     category: 'Outils',
     summary: 'Vérifie rapidement le statut HTTP d’une URL',
   },
   {
-    command: epochCmd,
+    command: epochCommand,
     icon: '🕐',
     category: 'Outils',
     summary: 'Convertit les timestamps Unix en dates lisibles',
   },
   {
-    command: devutilsCmd,
+    command: devutilsCommand,
     icon: '🛠️',
     category: 'Outils',
     summary: 'Décode des JWT, manipule la Base64 et génère des hash',
   },
   {
-    command: excuseCmd,
+    command: excuseCommand,
     icon: '😅',
     category: 'Outils',
     summary: 'Génère une excuse de développeur aléatoire',
   },
   {
-    command: adminCmd,
+    command: adminCommand,
     icon: '🔧',
     category: 'Administration',
     summary: 'Réunit les commandes de maintenance et de configuration avancée',
   },
   {
-    command: sanctionCmd,
+    command: sanctionCommand,
     icon: '🛡️',
     category: 'Administration',
     summary: 'Gère les sanctions: warn, timeout, kick, ban et tempban',
   },
   {
-    command: ticketCmd,
+    command: ticketCommand,
     icon: '🎫',
     category: 'Administration',
     summary: 'Gère les tickets: claim, info membre, close, reopen, delete et rename',
   },
   {
-    command: casierCmd,
+    command: casierCommand,
     icon: '📁',
     category: 'Administration',
     summary: 'Ouvre le casier utilisateur complet avec profil, activité et sanctions',
@@ -147,7 +148,7 @@ const OPTION_TYPE_LABEL: Record<number, string> = {
   [ApplicationCommandOptionType.Attachment]: 'fichier',
 };
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('help')
   .setDescription('❓ Centre d’aide interactif des commandes Kotbo')
   .addStringOption((o) =>
@@ -263,7 +264,7 @@ function buildCommandHelpEmbed(command: CommandJson) {
     .setTimestamp();
 }
 
-export async function autocomplete(interaction: AutocompleteInteraction) {
+async function autocomplete(interaction: AutocompleteInteraction) {
   const focused = interaction.options.getFocused().toLowerCase();
 
   const choices = COMMANDS
@@ -275,7 +276,7 @@ export async function autocomplete(interaction: AutocompleteInteraction) {
   await interaction.respond(choices);
 }
 
-export async function execute(interaction: ChatInputCommandInteraction) {
+async function execute(interaction: ChatInputCommandInteraction) {
   const requestedCmd = interaction.options.getString('cmd', false)?.trim().toLowerCase();
 
   if (!requestedCmd) {
@@ -295,3 +296,5 @@ export async function execute(interaction: ChatInputCommandInteraction) {
 
   await interaction.reply({ embeds: [buildCommandHelpEmbed(command)], flags: [MessageFlags.Ephemeral] });
 }
+
+export const helpCommand = { data, execute, autocomplete } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/info.ts
+++ b/apps/bot/src/commands/info.ts
@@ -1,3 +1,4 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import { SlashCommandBuilder, type ChatInputCommandInteraction, EmbedBuilder, MessageFlags } from 'discord.js';
 import { errorEmbed, COLORS } from '../utils/embeds.js';
 import prisma from '../utils/db.js';
@@ -44,11 +45,11 @@ function truncate(value: string, max = 120): string {
   return `${value.slice(0, max - 3)}...`;
 }
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('info')
   .setDescription('ℹ️ Informations sur le bot (version, état, configuration)');
 
-export async function execute(interaction: ChatInputCommandInteraction) {
+async function execute(interaction: ChatInputCommandInteraction) {
   const guildId = interaction.guildId;
   if (!guildId) {
     await interaction.reply({ 
@@ -153,3 +154,5 @@ export async function execute(interaction: ChatInputCommandInteraction) {
 
   await interaction.reply({ embeds: [embed], flags: [MessageFlags.Ephemeral] });
 }
+
+export const infoCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/invites.ts
+++ b/apps/bot/src/commands/invites.ts
@@ -1,9 +1,10 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import { EmbedBuilder, MessageFlags, SlashCommandBuilder, type ChatInputCommandInteraction } from 'discord.js';
 import { COLORS } from '../utils/embeds.js';
 import { getInviteLeaderboard, getUserInviteStats } from '../services/inviteService.js';
 import prisma from '../utils/db.js';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('invites')
   .setDescription("📩 Gestion et statistiques d'invitations")
   .addSubcommand(sub =>
@@ -20,7 +21,7 @@ export const data = new SlashCommandBuilder()
       .setDescription("Affiche le classement des meilleurs inviteurs")
   );
 
-export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
   const guildId = interaction.guildId;
   const subcommand = interaction.options.getSubcommand();
 
@@ -104,3 +105,5 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
     await interaction.editReply({ embeds: [embed] });
   }
 }
+
+export const invitesCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/leaderboard.ts
+++ b/apps/bot/src/commands/leaderboard.ts
@@ -1,9 +1,10 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import { EmbedBuilder, MessageFlags, SlashCommandBuilder, AttachmentBuilder, type ChatInputCommandInteraction } from 'discord.js';
 import prisma from '../utils/db.js';
 import { generateLeaderboardImage } from '../services/imageService.js';
 import { COLORS } from '../utils/embeds.js';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('leaderboard')
   .setDescription('🏆 Affiche le classement du serveur')
   .addStringOption((option) =>
@@ -29,7 +30,7 @@ export const data = new SlashCommandBuilder()
       ),
   );
 
-export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
   const guildId = interaction.guildId;
 
   if (!guildId) {
@@ -93,3 +94,5 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
     files: [attachment],
   });
 }
+
+export const leaderboardCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/meeting.ts
+++ b/apps/bot/src/commands/meeting.ts
@@ -1,9 +1,10 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import { SlashCommandBuilder, MessageFlags, type ChatInputCommandInteraction, EmbedBuilder } from 'discord.js';
 import { checkInMeeting, getMeetings, createMeeting, syncMeetingPresencesWithAbsences } from '../services/staffLeadershipService.js';
 import { getStaffMember } from '../services/staffManagementService.js';
 import { logger } from '../utils/logger.js';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('meeting')
   .setDescription('Outils de gestion de réunion Staff.')
   .addSubcommand(sub => 
@@ -22,7 +23,7 @@ export const data = new SlashCommandBuilder()
       .addStringOption(opt => opt.setName('date').setDescription('Date et heure (format: YYYY-MM-DD HH:mm)').setRequired(true))
       .addStringOption(opt => opt.setName('description').setDescription('Sujet ou ordre du jour').setRequired(false)));
 
-export async function execute(interaction: ChatInputCommandInteraction) {
+async function execute(interaction: ChatInputCommandInteraction) {
   if (!interaction.guildId) return;
 
   const staff = await getStaffMember(interaction.guildId, interaction.user.id);
@@ -105,3 +106,5 @@ export async function execute(interaction: ChatInputCommandInteraction) {
     }
   }
 }
+
+export const meetingCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/note.ts
+++ b/apps/bot/src/commands/note.ts
@@ -1,3 +1,4 @@
+import type { ContextCommandDefinition, SlashCommandDefinition } from '../commands.js';
 import {
   ActionRowBuilder,
   ContextMenuCommandBuilder,
@@ -12,7 +13,7 @@ import {
 } from 'discord.js';
 import prisma from '../utils/db.js';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('note')
   .setDescription('📝 Gère la note modérateur d’un membre')
   .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers)
@@ -20,12 +21,12 @@ export const data = new SlashCommandBuilder()
     option.setName('membre').setDescription('Le membre pour lequel vous souhaitez modifier la note').setRequired(true),
   );
 
-export const contextData = new ContextMenuCommandBuilder()
+const contextData = new ContextMenuCommandBuilder()
   .setName('Note Modérateur')
   .setType(ApplicationCommandType.User)
   .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers);
 
-export async function execute(interaction: ChatInputCommandInteraction | UserContextMenuCommandInteraction): Promise<void> {
+async function execute(interaction: ChatInputCommandInteraction | UserContextMenuCommandInteraction): Promise<void> {
   const targetUser = interaction.isChatInputCommand()
     ? interaction.options.getUser('membre', true)
     : interaction.targetUser;
@@ -86,3 +87,6 @@ export async function showModeratorNoteModal(
 function truncate(str: string, n: number) {
   return str.length > n ? str.slice(0, n - 1) + '…' : str;
 }
+
+export const noteCommand = { data, execute } satisfies SlashCommandDefinition;
+export const noteContextCommand = { data: contextData, execute } satisfies ContextCommandDefinition;

--- a/apps/bot/src/commands/ping.ts
+++ b/apps/bot/src/commands/ping.ts
@@ -1,7 +1,8 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import { SlashCommandBuilder, type ChatInputCommandInteraction } from 'discord.js';
 import { successEmbed } from '../utils/embeds.js';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('ping')
   .setDescription('🏓 Vérifie la latence du bot');
 
@@ -18,3 +19,5 @@ export async function execute(interaction: ChatInputCommandInteraction) {
     ],
   });
 }
+
+export const pingCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/post.ts
+++ b/apps/bot/src/commands/post.ts
@@ -1,3 +1,4 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import { SlashCommandBuilder, type ChatInputCommandInteraction, MessageFlags } from 'discord.js';
 import { sendDailyAlgo } from '../services/dailyAlgoService.js';
 import { formatDailyAlgoDate } from '../services/dailyAlgoService.js';
@@ -12,7 +13,7 @@ function formatPostError(error: unknown): string {
   return String(error ?? 'Erreur inconnue');
 }
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('post')
   .setDescription('🚀 Poster le contenu interactif du serveur')
   .addSubcommand(subcommand =>
@@ -21,7 +22,7 @@ export const data = new SlashCommandBuilder()
       .setDescription('💻 Poster le daily algo du jour')
   );
 
-export async function execute(interaction: ChatInputCommandInteraction) {
+async function execute(interaction: ChatInputCommandInteraction) {
   const subcommand = interaction.options.getSubcommand();
   const guildId = interaction.guildId;
 
@@ -56,3 +57,5 @@ export async function execute(interaction: ChatInputCommandInteraction) {
     });
   }
 }
+
+export const postCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/profil.ts
+++ b/apps/bot/src/commands/profil.ts
@@ -1,10 +1,11 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import { EmbedBuilder, MessageFlags, SlashCommandBuilder, type ChatInputCommandInteraction } from 'discord.js';
 import { getStaffMember, getStaffMemberStats } from '../services/staffManagementService.js';
 import { getStaffProfileSnapshot } from '../services/profileService.js';
 import { COLORS, truncate } from '../utils/embeds.js';
 import { logger } from '../utils/logger.js';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('profil')
   .setDescription('👤 Affiche le profil staff détaillé')
   .addUserOption((option) =>
@@ -51,7 +52,7 @@ function formatTestingPeriodStatus(status: string): string {
   return '⏳ En cours';
 }
 
-export async function execute(interaction: ChatInputCommandInteraction) {
+async function execute(interaction: ChatInputCommandInteraction) {
   await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
   try {
@@ -221,3 +222,5 @@ export async function execute(interaction: ChatInputCommandInteraction) {
     await interaction.editReply({ content: '❌ Une erreur est survenue lors de la récupération du profil.' });
   }
 }
+
+export const profilCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/profile.ts
+++ b/apps/bot/src/commands/profile.ts
@@ -1,9 +1,10 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import { EmbedBuilder, SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, type ChatInputCommandInteraction } from 'discord.js';
 import { getPublicProfileSnapshot } from '../services/profileService.js';
 import { getStaffMember } from '../services/staffManagementService.js';
 import { COLORS, truncate } from '../utils/embeds.js';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('profile')
   .setDescription('👤 Affiche le profil communautaire et la progression Daily Algo')
   .addUserOption((option) =>
@@ -51,7 +52,7 @@ function formatEventType(eventType: string): string {
   return eventType;
 }
 
-export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
   const guildId = interaction.guildId;
 
   if (!guildId) {
@@ -249,3 +250,5 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
 
   await interaction.editReply({ embeds: [embed], components: [row] });
 }
+
+export const profileCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/rank.ts
+++ b/apps/bot/src/commands/rank.ts
@@ -1,8 +1,9 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import { SlashCommandBuilder, AttachmentBuilder, MessageFlags, type ChatInputCommandInteraction } from 'discord.js';
 import { getMemberRankData, generateRankCard } from '../services/levelingService.js';
 import { extractTrackingInfo, resolveModuleFromCommand, wrapModuleTracking } from '../utils/moduleTracking.js';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('rank')
   .setDescription('⭐ Affiche votre carte de niveau et d\'expérience')
   .addUserOption((option) =>
@@ -12,7 +13,7 @@ export const data = new SlashCommandBuilder()
       .setRequired(false)
   );
 
-export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
   const { guildId, userId } = extractTrackingInfo(interaction);
   const moduleName = resolveModuleFromCommand('rank');
 
@@ -61,3 +62,5 @@ async function executeInternal(interaction: ChatInputCommandInteraction): Promis
     await interaction.editReply('❌ Une erreur est survenue lors de la génération de la carte de niveau.');
   }
 }
+
+export const rankCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/rescan.ts
+++ b/apps/bot/src/commands/rescan.ts
@@ -1,3 +1,4 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import {
   SlashCommandBuilder,
   PermissionFlagsBits,
@@ -9,7 +10,7 @@ import { infoEmbed, successEmbed, errorEmbed } from '../utils/embeds.js';
 import { scanGuildMembersForYoungAccounts } from '../services/dcDetectionService.js';
 import { scanAndModeratePseudos } from '../services/nicknameModerationService.js';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('rescan')
   .setDescription('Scanner les membres du serveur.')
   // ──────────────────────────────────────────────────────────────────────────
@@ -86,7 +87,7 @@ async function canUseModerationTools(interaction: ChatInputCommandInteraction): 
 // Handler principal
 // ---------------------------------------------------------------------------
 
-export async function execute(interaction: ChatInputCommandInteraction) {
+async function execute(interaction: ChatInputCommandInteraction) {
   const guild = interaction.guild;
   if (!guild || !interaction.guildId) {
     return interaction.reply({
@@ -214,3 +215,5 @@ export async function execute(interaction: ChatInputCommandInteraction) {
     }
   }
 }
+
+export const rescanCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/sanction.ts
+++ b/apps/bot/src/commands/sanction.ts
@@ -1,3 +1,4 @@
+import type { ContextCommandDefinition, SlashCommandDefinition } from '../commands.js';
 import {
   ActionRowBuilder,
   ButtonBuilder,
@@ -38,7 +39,7 @@ const SANCTION_PAGE_SIZE = 5;
 const SANCTION_LIST_TIMEOUT_MS = 2 * 60 * 1000;
 const DASHBOARD_URL = process.env.DASHBOARD_URL || 'http://localhost:5173';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('sanction')
   .setDescription('🛡️ Gère les sanctions (warn, TO, kick, ban, tempban, list)')
   .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers)
@@ -86,7 +87,7 @@ export const data = new SlashCommandBuilder()
       .addUserOption((option) => option.setName('membre').setDescription('Membre à afficher').setRequired(true)),
   );
 
-export const contextData = new ContextMenuCommandBuilder()
+const contextData = new ContextMenuCommandBuilder()
   .setName('Sanctionner')
   .setType(ApplicationCommandType.User)
   .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers);
@@ -269,7 +270,7 @@ async function buildSanctionListView(guildId: string, targetUserId: string, targ
   return { embed, row, caseRow, pageIndex: safePageIndex, totalPages };
 }
 
-export async function execute(interaction: ChatInputCommandInteraction | UserContextMenuCommandInteraction): Promise<void> {
+async function execute(interaction: ChatInputCommandInteraction | UserContextMenuCommandInteraction): Promise<void> {
   const { guildId, userId } = extractTrackingInfo(interaction);
   const moduleName = resolveModuleFromCommand('sanction');
   const actionName = interaction.isChatInputCommand() ? interaction.options.getSubcommand(true) : 'context_menu';
@@ -567,3 +568,6 @@ async function executeInternal(interaction: ChatInputCommandInteraction | UserCo
     });
   }
 }
+
+export const sanctionCommand = { data, execute } satisfies SlashCommandDefinition;
+export const sanctionContextCommand = { data: contextData, execute } satisfies ContextCommandDefinition;

--- a/apps/bot/src/commands/say.ts
+++ b/apps/bot/src/commands/say.ts
@@ -1,3 +1,4 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import {
   SlashCommandBuilder,
   type ChatInputCommandInteraction,
@@ -29,7 +30,7 @@ const COLOR_MAP: Record<string, number> = {
   white: 0xffffff,
 };
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('say')
   .setDescription('📢 Envoyer un message en tant que bot dans un salon')
   .setDefaultMemberPermissions(PermissionFlagsBits.ManageMessages)
@@ -67,7 +68,7 @@ export const data = new SlashCommandBuilder()
       .setRequired(false),
   );
 
-export async function execute(interaction: ChatInputCommandInteraction) {
+async function execute(interaction: ChatInputCommandInteraction) {
   if (!interaction.guildId) {
     await interaction.reply({
       embeds: [errorEmbed('Erreur', 'Cette commande ne peut être utilisée que dans un serveur.')],
@@ -131,3 +132,5 @@ export async function execute(interaction: ChatInputCommandInteraction) {
     });
   }
 }
+
+export const sayCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/serverstats.ts
+++ b/apps/bot/src/commands/serverstats.ts
@@ -1,9 +1,10 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import { EmbedBuilder, MessageFlags, SlashCommandBuilder, AttachmentBuilder, type ChatInputCommandInteraction } from 'discord.js';
 import prisma from '../utils/db.js';
 import { generateServerStatsImage } from '../services/imageService.js';
 import { COLORS } from '../utils/embeds.js';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('serverstats')
   .setDescription('📈 Affiche les statistiques globales du serveur')
   .addIntegerOption((option) =>
@@ -18,7 +19,7 @@ export const data = new SlashCommandBuilder()
       ),
   );
 
-export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
   const guildId = interaction.guildId;
   const guildName = interaction.guild?.name ?? 'Serveur Inconnu';
 
@@ -72,3 +73,5 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
     files: [attachment],
   });
 }
+
+export const serverstatsCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/setup.ts
+++ b/apps/bot/src/commands/setup.ts
@@ -1,3 +1,4 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import {
   SlashCommandBuilder,
   type ChatInputCommandInteraction,
@@ -9,13 +10,15 @@ import prisma from '../utils/db.js';
 import { successEmbed, errorEmbed } from '../utils/embeds.js';
 import { sendSetupWelcome, sendSetupStep1 } from '../panels/setupPanel.js';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('setup')
   .setDescription('⚙️ Assistant de configuration pas à pas de Kotbo')
   .setDefaultMemberPermissions(PermissionFlagsBits.Administrator);
 
-export async function execute(interaction: ChatInputCommandInteraction) {
+async function execute(interaction: ChatInputCommandInteraction) {
   const guildId = interaction.guildId!;
   
   await sendSetupWelcome(interaction.client, guildId, interaction);
 }
+
+export const setupCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/stats.ts
+++ b/apps/bot/src/commands/stats.ts
@@ -1,9 +1,10 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import { EmbedBuilder, MessageFlags, SlashCommandBuilder, AttachmentBuilder, type ChatInputCommandInteraction } from 'discord.js';
 import prisma from '../utils/db.js';
 import { generateMemberStatsImage } from '../services/imageService.js';
 import { COLORS } from '../utils/embeds.js';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('stats')
   .setDescription("📊 Affiche les statistiques d'activité d'un membre")
   .addUserOption((option) =>
@@ -24,7 +25,7 @@ export const data = new SlashCommandBuilder()
       ),
   );
 
-export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
   const guildId = interaction.guildId;
 
   if (!guildId) {
@@ -81,3 +82,5 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
     files: [attachment],
   });
 }
+
+export const statsCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/status.ts
+++ b/apps/bot/src/commands/status.ts
@@ -1,3 +1,4 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import { SlashCommandBuilder, type ChatInputCommandInteraction } from 'discord.js';
 import { infoEmbed, errorEmbed } from '../utils/embeds.js';
 import prisma from '../utils/db.js';
@@ -30,7 +31,7 @@ function getStatusLabel(code: number): string {
   return labels[code] ?? 'Statut inconnu';
 }
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('status')
   .setDescription('🌐 Vérifie le statut HTTP d\'une URL')
   .addStringOption(option =>
@@ -40,7 +41,7 @@ export const data = new SlashCommandBuilder()
       .setRequired(true)
   );
 
-export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
   const urlInput = interaction.options.getString('url', true);
 
   const guildId = interaction.guildId;
@@ -140,3 +141,5 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
     });
   }
 }
+
+export const statusCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/suggest.ts
+++ b/apps/bot/src/commands/suggest.ts
@@ -1,7 +1,8 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import { SlashCommandBuilder, MessageFlags, type ChatInputCommandInteraction } from 'discord.js';
 import { createSuggestion } from '../services/suggestionService.js';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('suggest')
   .setDescription('💡 Soumettre une suggestion ou une idée pour le serveur')
   .addStringOption((o) =>
@@ -11,7 +12,7 @@ export const data = new SlashCommandBuilder()
       .setRequired(true)
   );
 
-export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
   const guildId = interaction.guildId;
   if (!guildId) {
     await interaction.reply({
@@ -38,3 +39,5 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
     await interaction.editReply(`❌ Impossible de publier la suggestion : ${err?.message || 'erreur inconnue'}`);
   }
 }
+
+export const suggestCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/suggestion-config.ts
+++ b/apps/bot/src/commands/suggestion-config.ts
@@ -8,8 +8,9 @@ import {
 import { getOrCreateFeatureConfigs, updateFeatureConfig } from '../services/dashboardManagementService.js';
 import prisma from '../utils/db.js';
 import { successEmbed, errorEmbed } from '../utils/embeds.js';
+import { SlashCommandDefinition } from '../commands.js';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('suggestion-config')
   .setDescription('⚙️ Configure le module de suggestions')
   .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
@@ -48,7 +49,7 @@ export const data = new SlashCommandBuilder()
       )
   );
 
-export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
   const guildId = interaction.guildId;
   if (!guildId) {
     await interaction.reply({
@@ -64,7 +65,7 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
     await interaction.deferReply({ flags: [MessageFlags.Ephemeral] });
 
     const channel = interaction.options.getChannel('channel', true);
-    
+
     try {
       await getOrCreateFeatureConfigs(guildId);
       await updateFeatureConfig(guildId, 'suggestions', {
@@ -202,3 +203,5 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
     }
   }
 }
+
+export const suggestionConfigCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/ticket.ts
+++ b/apps/bot/src/commands/ticket.ts
@@ -1,3 +1,4 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import {
   ActionRowBuilder,
   ButtonBuilder,
@@ -16,7 +17,7 @@ import { buildMemberCasePanel } from '../services/memberCaseService.js';
 import { generateTranscript } from '../services/transcriptService.js';
 import { COLORS, successEmbed } from '../utils/embeds.js';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('ticket')
   .setDescription('🎫 Gère le ticket en cours')
   .setDMPermission(false)
@@ -57,7 +58,7 @@ export const data = new SlashCommandBuilder()
       )
   );
 
-export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
   const guildId = interaction.guildId;
   const channel = interaction.channel;
 
@@ -392,3 +393,5 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
     });
   }
 }
+
+export const ticketCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/transcript.ts
+++ b/apps/bot/src/commands/transcript.ts
@@ -1,3 +1,4 @@
+import type { SlashCommandDefinition } from '../commands.js';
 import {
   SlashCommandBuilder,
   type ChatInputCommandInteraction,
@@ -12,7 +13,7 @@ import { successEmbed, errorEmbed } from '../utils/embeds.js';
 import { generateTranscriptFromMessages } from '../services/transcriptService.js';
 import { logger } from '../utils/logger.js';
 
-export const data = new SlashCommandBuilder()
+const data = new SlashCommandBuilder()
   .setName('transcript')
   .setDescription('📄 Génère une transcription des messages de ce salon')
   .setDefaultMemberPermissions(PermissionFlagsBits.ManageMessages)
@@ -122,7 +123,7 @@ export function parseDateTimeOrDuration(input: string): number | null {
   return null;
 }
 
-export async function execute(interaction: ChatInputCommandInteraction) {
+async function execute(interaction: ChatInputCommandInteraction) {
   const { guildId, channel } = interaction;
   if (!guildId || !channel || !(channel instanceof TextChannel)) {
     await interaction.reply({
@@ -365,3 +366,4 @@ export async function execute(interaction: ChatInputCommandInteraction) {
   }
 }
 
+export const transcriptCommand = { data, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/deploy-commands.ts
+++ b/apps/bot/src/deploy-commands.ts
@@ -4,74 +4,9 @@ dotenv.config({ path: path.resolve(process.cwd(), '../../.env') });
 
 import { REST, Routes } from 'discord.js';
 import { logger } from './utils/logger.js';
-import * as setupCmd from './commands/setup.js';
-import * as configCmd from './commands/config.js';
-import * as pingCmd from './commands/ping.js';
-import * as infoCmd from './commands/info.js';
-import * as excuseCmd from './commands/excuse.js';
-import * as epochCmd from './commands/epoch.js';
-import * as devutilsCmd from './commands/devutils.js';
-import * as statusCmd from './commands/status.js';
-import * as adminCmd from './commands/admin.js';
-import * as helpCmd from './commands/help.js';
-import * as postCmd from './commands/post.js';
-import * as dailyAlgoCmd from './commands/dailyAlgo.js';
-import * as profileCmd from './commands/profile.ts';
-import * as profilCmd from './commands/profil.ts';
-import * as sanctionCmd from './commands/sanction.js';
-import * as dcCmd from './commands/dc.js';
-import * as rescanCmd from './commands/rescan.js';
-import * as casierCmd from './commands/casier.js';
-import * as absentCmd from './commands/absent.js';
-import * as statsCmd from './commands/stats.js';
-import * as leaderboardCmd from './commands/leaderboard.js';
-import * as serverstatsCmd from './commands/serverstats.js';
-import * as invitesCmd from './commands/invites.js';
-import * as noteCmd from './commands/note.js';
-import * as transcriptCmd from './commands/transcript.js';
-import * as ticketCmd from './commands/ticket.js';
-import * as sayCmd from './commands/say.js';
-import * as demissionCmd from './commands/demission.js';
-import * as meetingCmd from './commands/meeting.js';
-import * as eventCmd from './commands/event.js';
-import * as activateCmd from './commands/activate.js';
+import { applicationCommands } from './commands.js';
 
-const commands = [
-  setupCmd,
-  configCmd,
-  pingCmd,
-  infoCmd,
-  excuseCmd,
-  epochCmd,
-  devutilsCmd,
-  statusCmd,
-  adminCmd,
-  postCmd,
-  helpCmd,
-  dailyAlgoCmd,
-  profileCmd,
-  profilCmd,
-  sanctionCmd,
-  dcCmd,
-  rescanCmd,
-  casierCmd,
-  absentCmd,
-  meetingCmd,
-  statsCmd,
-  leaderboardCmd,
-  serverstatsCmd,
-  invitesCmd,
-  noteCmd,
-  eventCmd,
-  activateCmd,
-  transcriptCmd,
-  ticketCmd,
-  sayCmd,
-  demissionCmd,
-  { data: noteCmd.contextData },
-  { data: casierCmd.contextData },
-  { data: sanctionCmd.contextData },
-].map((cmd) => cmd.data.toJSON());
+const commands = applicationCommands.map((cmd) => cmd.data.toJSON());
 
 const token = process.env.DISCORD_TOKEN;
 const clientId = process.env.DISCORD_CLIENT_ID;

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -8,10 +8,9 @@ import {
   Collection,
   Events,
   ActivityType,
-  type ChatInputCommandInteraction,
-  type AutocompleteInteraction,
   MessageFlags,
   DiscordAPIError,
+  type ChatInputCommandInteraction,
 } from 'discord.js';
 import { logger } from './utils/logger.js';
 import { replyOrFollowUp } from './utils/interactionResponses.js';
@@ -21,30 +20,6 @@ import {
   handleSelectMenu,
   handleModalSubmit,
 } from './handlers/interactionHandler.js';
-import * as setupCmd from './commands/setup.js';
-import * as configCmd from './commands/config.js';
-import * as pingCmd from './commands/ping.js';
-import * as infoCmd from './commands/info.js';
-import * as excuseCmd from './commands/excuse.js';
-import * as epochCmd from './commands/epoch.js';
-import * as devutilsCmd from './commands/devutils.js';
-import * as statusCmd from './commands/status.js';
-import * as adminCmd from './commands/admin.js';
-import * as helpCmd from './commands/help.js';
-import * as postCmd from './commands/post.js';
-import * as dailyAlgoCmd from './commands/dailyAlgo.js';
-import * as profileCmd from './commands/profile.ts';
-import * as profilCmd from './commands/profil.ts';
-import * as sanctionCmd from './commands/sanction.js';
-import * as dcCmd from './commands/dc.js';
-import * as rescanCmd from './commands/rescan.js';
-import * as casierCmd from './commands/casier.js';
-import * as absentCmd from './commands/absent.js';
-import * as meetingCmd from './commands/meeting.js';
-import * as noteCmd from './commands/note.js';
-import * as eventCmd from './commands/event.js';
-import * as transcriptCmd from './commands/transcript.js';
-import * as ticketCmd from './commands/ticket.js';
 import prisma from './utils/db.js';
 import { errorEmbed } from './utils/embeds.js';
 import { getCachedDashboardSettings, cache } from './utils/cache.js';
@@ -73,23 +48,18 @@ import { initBotSentry, captureException } from './observability/sentry.js';
 import { initRedis } from './infra/redis.js';
 import { startBackgroundQueueWorker } from './infra/queues/backgroundQueue.js';
 import botPackageJson from '../package.json';
-import * as leaderboardCmd from './commands/leaderboard.js';
-import * as serverstatsCmd from './commands/serverstats.js';
-import * as statsCmd from './commands/stats.js';
-import * as invitesCmd from './commands/invites.js';
-import * as activateCmd from './commands/activate.js';
-import * as sayCmd from './commands/say.js';
-import * as rankCmd from './commands/rank.js';
-import * as giveawayCmd from './commands/giveaway.js';
-import * as suggestCmd from './commands/suggest.js';
-import * as suggestionConfigCmd from './commands/suggestion-config.js';
-import * as backupCmd from './commands/backup.js';
 import { registerLevelingListener } from './events/levelingEvents.js';
 import { registerWelcomeGoodbyeListener } from './events/welcomeGoodbyeEvents.js';
 import { registerAutoModListener } from './events/autoModEvents.js';
 import { registerAutoResponseListener } from './events/autoResponseEvents.js';
 import { loadActivatedGuilds, isGuildActivated } from './utils/activation.js';
 import { initializeAutoBackupForAllGuilds, initializeAutoBackup, stopAutoBackup } from './services/autoBackupService.js';
+import {
+  commands as slashCommandDefinitions,
+  contextCommands as contextCommandDefinitions,
+  type ContextCommandDefinition,
+  type SlashCommandDefinition,
+} from './commands.js';
 
 initBotSentry();
 
@@ -177,22 +147,15 @@ if (!client.shard || client.shard.ids.includes(0)) {
   startDashboardApi(client);
 }
 
-
-type SlashCommand = {
-  data: { name: string; toJSON: () => unknown };
-  execute: (interaction: ChatInputCommandInteraction) => Promise<void>;
-  autocomplete?: (interaction: AutocompleteInteraction) => Promise<void>;
-};
-
-import * as demissionCmd from './commands/demission.js';
-
-const commands = new Collection<string, SlashCommand>();
-[setupCmd, configCmd, pingCmd, infoCmd, excuseCmd, epochCmd, devutilsCmd, statusCmd, adminCmd, helpCmd, postCmd, dailyAlgoCmd, profileCmd, profilCmd, sanctionCmd, dcCmd, rescanCmd, casierCmd, absentCmd, meetingCmd, statsCmd, invitesCmd, leaderboardCmd, serverstatsCmd, noteCmd, eventCmd, activateCmd, transcriptCmd, ticketCmd, sayCmd, demissionCmd, rankCmd, giveawayCmd, suggestCmd, suggestionConfigCmd, backupCmd].forEach((cmd) => {
-  commands.set(cmd.data.name, cmd as SlashCommand);
+const slashCommands = new Collection<string, SlashCommandDefinition>();
+slashCommandDefinitions.forEach((cmd) => {
+  slashCommands.set(cmd.data.name, cmd);
 });
-commands.set(noteCmd.contextData.name, noteCmd as unknown as SlashCommand);
-commands.set(casierCmd.contextData.name, casierCmd as unknown as SlashCommand);
-commands.set(sanctionCmd.contextData.name, sanctionCmd as unknown as SlashCommand);
+
+const userContextCommands = new Collection<string, ContextCommandDefinition>();
+contextCommandDefinitions.forEach((cmd) => {
+  userContextCommands.set(cmd.data.name, cmd);
+});
 
 async function enforceCommandAccess(interaction: ChatInputCommandInteraction): Promise<boolean> {
   if (!interaction.guildId) return true;
@@ -381,7 +344,7 @@ client.on(Events.InteractionCreate, async (interaction) => {
         return;
       }
 
-      const cmd = commands.get(interaction.commandName);
+      const cmd = slashCommands.get(interaction.commandName);
       if (!cmd) {
         await interaction.reply({
           content: '⚠️ Cette commande n\'est pas encore disponible sur cette instance du bot. Redémarre le bot puis redéploie les commandes.',
@@ -404,13 +367,13 @@ client.on(Events.InteractionCreate, async (interaction) => {
     }
 
     else if (interaction.isAutocomplete()) {
-      const cmd = commands.get(interaction.commandName);
+      const cmd = slashCommands.get(interaction.commandName);
       if (cmd?.autocomplete) await cmd.autocomplete(interaction);
     }
 
     else if (interaction.isUserContextMenuCommand()) {
-      const cmd = commands.get(interaction.commandName);
-      if (cmd) await cmd.execute(interaction as any);
+      const cmd = userContextCommands.get(interaction.commandName);
+      if (cmd) await cmd.execute(interaction);
     }
 
     else if (interaction.isButton()) {


### PR DESCRIPTION
- add commands.ts with shared command types and combined command lists
- update command modules to import types and expose local data variables
- simplify deploy-commands to register applicationCommands directly
- adjust imports in index.ts for consistency