### PR TITLE
fix: éviter le spam de rappels et les crashs du dashboard

### DIFF
--- a/apps/bot/src/api/shared.ts
+++ b/apps/bot/src/api/shared.ts
@@ -2235,7 +2235,7 @@ export async function buildMemberCaseData(client: Client, guildId: string, userI
         sanctionDurationLabel: entry.sanctionDurationLabel ?? null,
         brokenRules: entry.brokenRules,
         detailedReason: entry.detailedReason,
-        evidenceLinks: entry.evidenceLinks,
+        evidenceLinks: parseEvidenceLinks(entry.evidenceLinks),
         additionalNotes: entry.additionalNotes ?? null,
         createdByUserId: entry.createdByUserId,
         createdByTag: entry.createdByTag ?? null,
@@ -2478,7 +2478,7 @@ export const getGuildState = async (client: Client, guildId: string, access: Das
     sanctionDurationLabel: entry.sanctionDurationLabel ?? null,
     brokenRules: entry.brokenRules,
     detailedReason: entry.detailedReason,
-    evidenceLinks: entry.evidenceLinks,
+    evidenceLinks: parseEvidenceLinks(entry.evidenceLinks),
     additionalNotes: entry.additionalNotes ?? null,
     createdByUserId: entry.createdByUserId,
     createdByTag: entry.createdByTag ?? null,
@@ -3137,4 +3137,3 @@ export function extractMediaUrls(content: string): { type: 'image' | 'video' | '
   }
   return urls;
 }
-

--- a/apps/bot/src/events/crons.ts
+++ b/apps/bot/src/events/crons.ts
@@ -231,12 +231,12 @@ export async function registerCrons(client: Client): Promise<void> {
     await runCronJob('staff-blacklist-expiration', expireStaffBlacklist, 1000);
   });
 
-  // 🛡️ Sanctions: Rapports manquants (tous les 3 jours à 12:00)
-  cron.schedule('* 12 */3 * *', async () => {
+  // 🛡️ Sanctions: Rapports manquants (tous les jours à 12:00, heure de Paris)
+  cron.schedule('0 12 * * *', async () => {
     await runCronJob('missing-reports-check', async () => {
       await checkMissingReports();
     }, 2000);
-  });
+  }, { timezone: 'Europe/Paris' });
 
   // 📅 Réunions: Notifications (toutes les minutes)
   cron.schedule('* * * * *', async () => {

--- a/apps/bot/src/services/moderation/sanctionReportReminderPolicy.ts
+++ b/apps/bot/src/services/moderation/sanctionReportReminderPolicy.ts
@@ -1,0 +1,27 @@
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export type MissingReportReminderState = {
+  createdAt: Date;
+  lastReportReminderAt: Date | null;
+  managerReportEscalatedAt: Date | null;
+  hasReport?: boolean;
+};
+
+export function getMissingReportReminderActions(
+  state: MissingReportReminderState,
+  now = new Date(),
+): { remindModerator: boolean; escalateManagers: boolean } {
+  if (state.hasReport) {
+    return { remindModerator: false, escalateManagers: false };
+  }
+
+  const ageMs = now.getTime() - state.createdAt.getTime();
+  const reminderAgeMs = state.lastReportReminderAt
+    ? now.getTime() - state.lastReportReminderAt.getTime()
+    : Number.POSITIVE_INFINITY;
+
+  return {
+    remindModerator: ageMs >= 3 * DAY_MS && reminderAgeMs >= DAY_MS,
+    escalateManagers: ageMs >= 7 * DAY_MS && !state.managerReportEscalatedAt,
+  };
+}

--- a/apps/bot/src/services/moderation/sanctionService.ts
+++ b/apps/bot/src/services/moderation/sanctionService.ts
@@ -6,6 +6,7 @@ import { COLORS } from '../../utils/embeds.js';
 import { notifyDashboardSanctionReportRequired } from '../../api/dashboardApi.js';
 import { createNotification } from '../staff/staffLeadershipService.js';
 import * as altAccountService from './altAccountService.js';
+import { getMissingReportReminderActions } from './sanctionReportReminderPolicy.js';
 
 const MAX_DISCORD_TIMEOUT_MS = 27 * 24 * 60 * 60 * 1000;
 const RENEWAL_BUFFER_MS = 60 * 1000;
@@ -1153,57 +1154,105 @@ export async function runGuildBan(guild: Guild, userId: string, reason: string):
 }
 
 export async function checkMissingReports() {
-  const threeDaysAgo = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000);
-  
-  // Trouver les sanctions sans rapport (SanctionReport) créées il y a plus de 3 jours
-  // On filtre les sanctions qui nécessitent un rapport (BAN, KICK, TIMEOUT)
+  const now = new Date();
+  const threeDaysAgo = new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000);
+  const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+
   const sanctions = await prisma.sanction.findMany({
     where: {
       createdAt: { lte: threeDaysAgo },
       type: { in: [SanctionType.BAN, SanctionType.TEMP_BAN, SanctionType.KICK, SanctionType.TIMEOUT] },
-      reports: { none: {} }
+      reports: { none: {} },
+      OR: [
+        { lastReportReminderAt: null },
+        { lastReportReminderAt: { lte: oneDayAgo } },
+        { createdAt: { lte: sevenDaysAgo }, managerReportEscalatedAt: null },
+      ],
     },
-    include: {
-      reports: true
-    }
+    select: {
+      id: true,
+      guildId: true,
+      targetUserId: true,
+      targetTag: true,
+      moderatorUserId: true,
+      moderatorTag: true,
+      createdAt: true,
+      lastReportReminderAt: true,
+      managerReportEscalatedAt: true,
+    },
   });
 
   for (const sanction of sanctions) {
-    // Notifier le modérateur à nouveau
-    await createNotification(
-      sanction.guildId,
-      sanction.moderatorUserId,
-      'RAPPEL : Rapport manquant (3 jours+)',
-      `Le rapport pour la sanction sur ${sanction.targetTag} est toujours manquant après 3 jours.`,
-      'ERROR',
-      '/sanctions'
-    ).catch(() => null);
+    const actions = getMissingReportReminderActions(sanction, now);
+    if (actions.remindModerator) {
+      const claim = await prisma.sanction.updateMany({
+        where: {
+          id: sanction.id,
+          reports: { none: {} },
+          OR: [
+            { lastReportReminderAt: null },
+            { lastReportReminderAt: { lte: oneDayAgo } },
+          ],
+        },
+        data: { lastReportReminderAt: now },
+      });
 
-    // Notifier le supérieur du modérateur
-    const moderator = await prisma.staffMember.findUnique({
-      where: { guildId_userId: { guildId: sanction.guildId, userId: sanction.moderatorUserId } }
-    });
+      if (claim.count === 1) {
+        try {
+          await createNotification(
+            sanction.guildId,
+            sanction.moderatorUserId,
+            'RAPPEL : Rapport manquant (3 jours+)',
+            `Le rapport pour la sanction sur ${sanction.targetTag ?? sanction.targetUserId} est toujours manquant.`,
+            'ERROR',
+            '/sanctions'
+          );
+        } catch (error) {
+          await prisma.sanction.updateMany({
+            where: { id: sanction.id, lastReportReminderAt: now },
+            data: { lastReportReminderAt: sanction.lastReportReminderAt },
+          });
+          logger.error('Sanctions', `Échec du rappel de rapport pour la sanction ${sanction.id}:`, error);
+        }
+      }
+    }
 
-    if (moderator && moderator.grade !== 'Staff') {
-      // On cherche les managers/admins pour les alerter
+    if (actions.escalateManagers) {
+      const claim = await prisma.sanction.updateMany({
+        where: {
+          id: sanction.id,
+          reports: { none: {} },
+          managerReportEscalatedAt: null,
+        },
+        data: { managerReportEscalatedAt: now },
+      });
+      if (claim.count !== 1) continue;
+
       const managers = await prisma.staffMember.findMany({
         where: {
           guildId: sanction.guildId,
-          grade: { in: ['Manager', 'Admin', 'Administrateur', 'Direction', 'Fondateur'] }
-        }
+          userId: { not: sanction.moderatorUserId },
+          grade: { in: ['Manager', 'Admin', 'Administrateur', 'Direction', 'Fondateur'] },
+        },
       });
 
-      for (const manager of managers) {
-        if (manager.userId === sanction.moderatorUserId) continue;
-
-        await createNotification(
+      const results = await Promise.allSettled(managers.map((manager) =>
+        createNotification(
           sanction.guildId,
           manager.userId,
           'Alerte : Rapport non rempli par un staff',
-          `Le modérateur ${sanction.moderatorTag} n'a pas rempli le rapport pour sa sanction sur ${sanction.targetTag} depuis 3 jours.`,
+          `Le modérateur ${sanction.moderatorTag ?? sanction.moderatorUserId} n'a pas rempli le rapport pour sa sanction sur ${sanction.targetTag ?? sanction.targetUserId} depuis 7 jours.`,
           'ERROR',
           `/members/${sanction.targetUserId}`
-        ).catch(() => null);
+        )
+      ));
+
+      if (managers.length === 0 || results.every((result) => result.status === 'rejected')) {
+        await prisma.sanction.updateMany({
+          where: { id: sanction.id, managerReportEscalatedAt: now },
+          data: { managerReportEscalatedAt: null },
+        });
       }
     }
   }

--- a/apps/bot/src/tests/unit/sanctionReportReminderPolicy.test.ts
+++ b/apps/bot/src/tests/unit/sanctionReportReminderPolicy.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'bun:test';
+import { getMissingReportReminderActions } from '../../services/moderation/sanctionReportReminderPolicy';
+
+const now = new Date('2026-06-13T12:00:00.000Z');
+const day = 24 * 60 * 60 * 1000;
+
+function state(ageDays: number, overrides: Record<string, unknown> = {}) {
+  return {
+    createdAt: new Date(now.getTime() - ageDays * day),
+    lastReportReminderAt: null,
+    managerReportEscalatedAt: null,
+    ...overrides,
+  };
+}
+
+describe('sanction report reminder policy', () => {
+  test('does nothing before J+3', () => {
+    expect(getMissingReportReminderActions(state(2), now)).toEqual({
+      remindModerator: false,
+      escalateManagers: false,
+    });
+  });
+
+  test('reminds the moderator at J+3', () => {
+    expect(getMissingReportReminderActions(state(3), now).remindModerator).toBe(true);
+  });
+
+  test('does not remind again during the next 24 hours', () => {
+    const result = getMissingReportReminderActions(state(4, {
+      lastReportReminderAt: new Date(now.getTime() - 23 * 60 * 60 * 1000),
+    }), now);
+    expect(result.remindModerator).toBe(false);
+  });
+
+  test('reminds again after 24 hours', () => {
+    const result = getMissingReportReminderActions(state(4, {
+      lastReportReminderAt: new Date(now.getTime() - day),
+    }), now);
+    expect(result.remindModerator).toBe(true);
+  });
+
+  test('escalates once to managers at J+7', () => {
+    expect(getMissingReportReminderActions(state(7), now).escalateManagers).toBe(true);
+    expect(getMissingReportReminderActions(state(8, {
+      managerReportEscalatedAt: new Date(now.getTime() - day),
+    }), now).escalateManagers).toBe(false);
+  });
+
+  test('does nothing when a report exists', () => {
+    expect(getMissingReportReminderActions(state(10, { hasReport: true }), now)).toEqual({
+      remindModerator: false,
+      escalateManagers: false,
+    });
+  });
+});

--- a/apps/dashboard/src/lib/components/MemberCaseModal.svelte
+++ b/apps/dashboard/src/lib/components/MemberCaseModal.svelte
@@ -13,6 +13,7 @@
   import SelectedRuleChips from './sanctions/SelectedRuleChips.svelte';
   import EvidenceInputList from './sanctions/EvidenceInputList.svelte';
   import ReportRuleSelector from './sanctions/ReportRuleSelector.svelte';
+  import { normalizeEvidenceLinks, sanitizeEvidenceLinks } from '../sanctions/evidenceLinks';
   import InteractionTree from './charts/InteractionTree.svelte';
   import Modal from './Modal.svelte';
 
@@ -311,7 +312,7 @@
       sanctionDurationLabel: report.sanctionDurationLabel || '',
       selectedRuleIds: getRuleIdsFromBrokenRules(report.brokenRules),
       detailedReason: report.detailedReason,
-      evidenceLinks: report.evidenceLinks && report.evidenceLinks.length > 0 ? [...report.evidenceLinks] : [''],
+      evidenceLinks: normalizeEvidenceLinks(report.evidenceLinks, true),
       additionalNotes: report.additionalNotes || ''
     };
     isEditingReport = true;
@@ -327,7 +328,7 @@
         sanctionDurationLabel: editReportData.sanctionDurationLabel.trim(),
         brokenRules: buildBrokenRulesPayload(editReportData.selectedRuleIds, reportRuleOptions),
         detailedReason: editReportData.detailedReason,
-        evidenceLinks: editReportData.evidenceLinks.map(l => l.trim()).filter(l => /^https?:\/\//i.test(l)),
+        evidenceLinks: sanitizeEvidenceLinks(editReportData.evidenceLinks),
         additionalNotes: editReportData.additionalNotes.trim() || null
       });
 
@@ -345,7 +346,7 @@
               sanctionDurationLabel: editReportData.sanctionDurationLabel.trim(),
               brokenRules: buildBrokenRulesPayload(editReportData.selectedRuleIds, reportRuleOptions),
               detailedReason: editReportData.detailedReason,
-              evidenceLinks: editReportData.evidenceLinks.map(l => l.trim()).filter(l => /^https?:\/\//i.test(l)),
+              evidenceLinks: sanitizeEvidenceLinks(editReportData.evidenceLinks),
               additionalNotes: editReportData.additionalNotes.trim() || null
             };
           }
@@ -1946,4 +1947,3 @@
     {/if}
 
 </Modal>
-

--- a/apps/dashboard/src/lib/components/Papicon.svelte
+++ b/apps/dashboard/src/lib/components/Papicon.svelte
@@ -271,8 +271,8 @@
     "Tasks", "TextBubble", "Trash", "Underline", "Unlock", "UserCross", "User", "Walk"
   ]);
 
-  function toPapiconsName(value: string) {
-    const normalized = (value || "").trim();
+  function toPapiconsName(value: unknown) {
+    const normalized = typeof value === "string" ? value.trim() : "";
     if (!normalized) return fallbackIconName;
 
     const lower = normalized.toLowerCase();
@@ -316,14 +316,22 @@
     return flattened;
   }
 
-  const iconName = $derived(toPapiconsName(icon));
+  const safeIcon = $derived(typeof icon === "string" ? icon : "");
+  const iconName = $derived(toPapiconsName(safeIcon));
   const isPapiconAvailable = $derived(availablePapicons.has(iconName));
   
   // Lucide fallback logic
   const lucideIconName = $derived(iconName); // Already PascalCase
-  const LucideComponent = $derived((LucideIcons as any)[lucideIconName] || (LucideIcons as any)[icon] || LucideIcons.HelpCircle);
+  const LucideComponent = $derived((LucideIcons as any)[lucideIconName] || (LucideIcons as any)[safeIcon] || LucideIcons.HelpCircle);
 
-  const reactIcon = $derived(isPapiconAvailable ? unwrapReactComponent(Papicons({ name: iconName, size, className })) : null);
+  const reactIcon = $derived.by(() => {
+    if (!isPapiconAvailable || !iconName) return null;
+    try {
+      return unwrapReactComponent(Papicons({ name: iconName, size, className }));
+    } catch {
+      return null;
+    }
+  });
   const svgProps = $derived(reactIcon?.props || {});
   const svgChildren = $derived(flattenChildren(svgProps.children));
 
@@ -358,5 +366,3 @@
 {:else}
   <LucideComponent size={size} class={className} stroke-width={2.5} />
 {/if}
-
-

--- a/apps/dashboard/src/lib/components/sanctions/EvidenceInputList.svelte
+++ b/apps/dashboard/src/lib/components/sanctions/EvidenceInputList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Papicon from '../Papicon.svelte';
+  import { normalizeEvidenceLinks } from '../../sanctions/evidenceLinks';
 
   let { 
     links = $bindable([]),
@@ -15,24 +16,26 @@
     inputIdPrefix?: string;
   }>();
 
-  if (links.length === 0) {
-    links = [''];
+  const initialLinks = normalizeEvidenceLinks(links, true);
+  if (initialLinks.length !== links.length || initialLinks.some((link, index) => link !== links[index])) {
+    links = initialLinks;
   }
 
   function addLink() {
-    links = [...links, ''];
+    links = [...normalizeEvidenceLinks(links, true), ''];
   }
 
   function removeLink(index: number) {
-    if (links.length <= 1) {
+    const normalized = normalizeEvidenceLinks(links, true);
+    if (normalized.length <= 1) {
       links = [''];
       return;
     }
-    links = links.filter((_, i) => i !== index);
+    links = normalized.filter((_, i) => i !== index);
   }
 
   function handleInput(index: number, value: string) {
-    links[index] = value;
+    links = normalizeEvidenceLinks(links, true).map((link, i) => i === index ? value : link);
   }
 </script>
 

--- a/apps/dashboard/src/lib/sanctions/evidenceLinks.ts
+++ b/apps/dashboard/src/lib/sanctions/evidenceLinks.ts
@@ -1,0 +1,13 @@
+export function normalizeEvidenceLinks(value: unknown, ensureOne = false): string[] {
+  const links = Array.isArray(value)
+    ? value.map((entry) => (typeof entry === 'string' ? entry : ''))
+    : [];
+
+  return links.length > 0 || !ensureOne ? links : [''];
+}
+
+export function sanitizeEvidenceLinks(value: unknown): string[] {
+  return normalizeEvidenceLinks(value)
+    .map((entry) => entry.trim())
+    .filter((entry) => /^https?:\/\//i.test(entry));
+}

--- a/apps/dashboard/src/pages/Absences.svelte
+++ b/apps/dashboard/src/pages/Absences.svelte
@@ -107,7 +107,7 @@
       
       allStaff = membersData.members || [];
       allRoles = rolesData.roles || [];
-      absenceConfig = configData?.config || null;
+      applyAbsenceConfig(configData?.config || null);
 
       // Default selection: just me
       if (myStaffRecord) {
@@ -129,21 +129,27 @@
   let savedNotifyViaDiscordChannel = $state(true);
   let savedManagerRoleLevels = $state<number[]>([]);
 
-  $effect(() => {
-    if (absenceConfig) {
-      webhookUrl = absenceConfig.metadata?.webhookUrl || '';
-      channelId = absenceConfig.channelId || '';
-      notificationRoleId = absenceConfig.notificationRoleId || '';
-      notifyViaDiscordChannel = absenceConfig.notifyViaDiscordChannel !== false;
-      managerRoleLevels = absenceConfig.roleAccess?.map((ra: any) => ra.staffRoleLevel) || [];
+  function applyAbsenceConfig(config: any) {
+    absenceConfig = config;
 
-      savedWebhookUrl = webhookUrl;
-      savedChannelId = channelId;
-      savedNotificationRoleId = notificationRoleId;
-      savedNotifyViaDiscordChannel = notifyViaDiscordChannel;
-      savedManagerRoleLevels = [...managerRoleLevels];
-    }
-  });
+    const nextWebhookUrl = config?.metadata?.webhookUrl || '';
+    const nextChannelId = config?.channelId || '';
+    const nextNotificationRoleId = config?.notificationRoleId || '';
+    const nextNotifyViaDiscordChannel = config?.notifyViaDiscordChannel !== false;
+    const nextManagerRoleLevels = config?.roleAccess?.map((ra: any) => ra.staffRoleLevel) || [];
+
+    webhookUrl = nextWebhookUrl;
+    channelId = nextChannelId;
+    notificationRoleId = nextNotificationRoleId;
+    notifyViaDiscordChannel = nextNotifyViaDiscordChannel;
+    managerRoleLevels = [...nextManagerRoleLevels];
+
+    savedWebhookUrl = nextWebhookUrl;
+    savedChannelId = nextChannelId;
+    savedNotificationRoleId = nextNotificationRoleId;
+    savedNotifyViaDiscordChannel = nextNotifyViaDiscordChannel;
+    savedManagerRoleLevels = [...nextManagerRoleLevels];
+  }
 
   const currentConfig = $derived({
     webhookUrl,
@@ -194,7 +200,7 @@
         const ok = await updateAbsenceConfig(payload);
         if (ok) {
           const configData = await fetchAbsenceConfig().catch(() => null);
-          absenceConfig = configData?.config || null;
+          applyAbsenceConfig(configData?.config || null);
           success = true;
         }
         return ok;

--- a/apps/dashboard/src/pages/Sanctions.svelte
+++ b/apps/dashboard/src/pages/Sanctions.svelte
@@ -36,6 +36,7 @@
     getRulesFromBrokenRules,
   } from '../lib/sanctions/reportRules';
   import EvidenceInputList from '../lib/components/sanctions/EvidenceInputList.svelte';
+  import { normalizeEvidenceLinks, sanitizeEvidenceLinks } from '../lib/sanctions/evidenceLinks';
   import { durationLabel, statusLabel, toDateTimeLocal, typeLabel } from '../lib/sanctions/formatters';
   import { filterAndSortSanctions, type SanctionFilters, type SortField, type SortOption, type Sanction } from '../lib/sanctions/filterSort';
 
@@ -463,7 +464,7 @@
     sanctionDurationLabel = selectedReport.sanctionDurationLabel || '';
     selectedRuleIds = getRuleIdsFromBrokenRules(selectedReport.brokenRules);
     detailedReason = selectedReport.detailedReason;
-    evidenceLinks = selectedReport.evidenceLinks.length > 0 ? [...selectedReport.evidenceLinks] : [''];
+    evidenceLinks = normalizeEvidenceLinks(selectedReport.evidenceLinks, true);
     additionalNotes = selectedReport.additionalNotes || '';
     isEditing = true;
   }
@@ -480,12 +481,6 @@
     isEditing = false;
     reportMessage = '';
     reportMessageIsError = false;
-  }
-
-  function sanitizeLinks(linksArr: string[]): string[] {
-    return linksArr
-      .map((value) => value.trim())
-      .filter((value) => /^https?:\/\//i.test(value));
   }
 
   async function submitReport() {
@@ -528,7 +523,7 @@
       return;
     }
 
-    const sanitizedLinks = sanitizeLinks(evidenceLinks);
+    const sanitizedLinks = sanitizeEvidenceLinks(evidenceLinks);
     if (sanitizedLinks.length === 0) {
       reportMessage = 'Ajoute au moins un lien de preuve valide (http/https).';
       reportMessageIsError = true;
@@ -573,7 +568,7 @@
   async function handleUpdateReport() {
     if (!selectedReport) return;
     
-    const sanitizedLinks = sanitizeLinks(evidenceLinks);
+    const sanitizedLinks = sanitizeEvidenceLinks(evidenceLinks);
     if (sanitizedLinks.length === 0) {
       reportMessage = 'Ajoute au moins un lien de preuve valide (http/https).';
       reportMessageIsError = true;

--- a/packages/database/prisma/migrations/20260613180000_add_sanction_report_reminder_tracking/migration.sql
+++ b/packages/database/prisma/migrations/20260613180000_add_sanction_report_reminder_tracking/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "sanctions"
+ADD COLUMN "lastReportReminderAt" TIMESTAMP(3),
+ADD COLUMN "managerReportEscalatedAt" TIMESTAMP(3);

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -513,6 +513,8 @@ model Sanction {
 
   resolvedAt DateTime?
   resolutionNote String?
+  lastReportReminderAt DateTime?
+  managerReportEscalatedAt DateTime?
 
   guild Guild @relation(fields: [guildId], references: [id], onDelete: Cascade)
   reports SanctionReport[]


### PR DESCRIPTION
Cette pull request apporte plusieurs améliorations et corrections autour des rappels de rapports de sanction, de la gestion des liens de preuves, du rendu des icônes et de la configuration des absences.

L’objectif principal est de rendre le workflow des rapports de sanction plus fiable, d’éviter les notifications redondantes, de sécuriser les données envoyées côté dashboard/API, et de réduire les risques de crash côté interface.

### Améliorations du système de rappels des rapports de sanction

La logique de rappel pour les rapports de sanction manquants a été extraite dans un nouveau module dédié : `sanctionReportReminderPolicy.ts`.

Ce refactor permet de centraliser les règles métier et de rendre le comportement plus clair :

* un modérateur reçoit un rappel après 3 jours sans rapport ;
* les rappels peuvent ensuite être renvoyés toutes les 24 heures ;
* après 7 jours sans rapport, le cas peut être escaladé aux managers.

Des tests unitaires ont été ajoutés afin de couvrir cette logique et de s’assurer que les rappels et escalades se déclenchent au bon moment.

La fonction `checkMissingReports` a également été mise à jour pour utiliser cette nouvelle policy. Elle évite maintenant les notifications redondantes, gère plus proprement l’escalade vers les managers, et inclut une logique de rollback si l’envoi d’une notification échoue.

Le cron chargé de vérifier les rapports manquants s’exécute désormais tous les jours à midi, heure de Paris, au lieu d’une fois tous les trois jours. Cela permet d’envoyer les rappels plus rapidement et de mieux suivre les rapports en attente.

### Normalisation et nettoyage des liens de preuves

Des fonctions utilitaires ont été ajoutées pour gérer les liens de preuves de manière plus fiable :

* `normalizeEvidenceLinks`
* `sanitizeEvidenceLinks`

Elles permettent de standardiser les tableaux de liens et de s’assurer que seules des URLs valides sont envoyées ou enregistrées.

Ces fonctions sont maintenant utilisées à plusieurs endroits du dashboard et de l’API, afin d’avoir un comportement cohérent partout où les liens de preuves sont manipulés.

Concrètement, cela évite les valeurs invalides, les formats inattendus, ou les données mal nettoyées qui pouvaient provoquer des bugs ou des incohérences.

### Robustesse du dashboard

Le composant `Papicon` a été renforcé pour mieux gérer les cas où la valeur d’icône reçue n’est pas une chaîne de caractères.

Avant, une valeur inattendue pouvait provoquer une erreur de rendu ou casser le fallback d’icône. Le composant vérifie maintenant plus proprement le type de donnée reçu avant de tenter d’afficher l’icône.

Ça rend l’interface plus stable, surtout quand certaines données viennent de sources externes ou peuvent être incomplètes.

### Gestion de la configuration des absences

La logique de configuration des absences a été refactorisée autour d’une fonction explicite : `applyAbsenceConfig`.

Cette fonction permet de mettre à jour ensemble toutes les variables d’état liées à la configuration d’absence.

L’intérêt est d’éviter les états partiellement mis à jour, où certaines valeurs seraient modifiées mais pas les autres. La gestion devient donc plus sûre, plus lisible et plus prévisible.

### Résumé

Cette PR améliore globalement la fiabilité du système de rapports de sanction, réduit les risques de spam de notifications, sécurise la gestion des liens de preuves, rend le dashboard plus robuste, et simplifie la gestion de la configuration des absences.

Elle rend aussi le code plus maintenable en séparant mieux les règles métier, notamment pour les rappels et les escalades.
