### PR TITLE
Corrections

### DIFF
--- a/apps/bot/src/api/routes/admin.ts
+++ b/apps/bot/src/api/routes/admin.ts
@@ -363,12 +363,38 @@ export async function handleAdminRoutes(
         const admins = await prisma.globalAdmin.findMany({
           orderBy: { createdAt: 'desc' }
         });
-        const enrichedAdmins = await Promise.all(admins.map(async (admin) => {
+
+        const now = Date.now();
+        const activeAdmins = admins.filter(admin => !admin.expiresAt || admin.expiresAt.getTime() > now);
+
+        const expiredIds = admins
+          .filter(admin => admin.expiresAt && admin.expiresAt.getTime() <= now)
+          .map(admin => admin.userId);
+        if (expiredIds.length > 0) {
+          await prisma.globalAdmin.deleteMany({ where: { userId: { in: expiredIds } } }).catch(() => {});
+        }
+
+        const enrichedAdmins = await Promise.all(activeAdmins.map(async (admin) => {
+          const remainingMs = admin.expiresAt ? admin.expiresAt.getTime() - now : null;
           try {
             const discordUser = await client.users.fetch(admin.userId);
-            return { ...admin, username: discordUser.username, avatarUrl: discordUser.displayAvatarURL() };
+            return {
+              ...admin,
+              username: discordUser.username,
+              avatarUrl: discordUser.displayAvatarURL(),
+              expiresAt: admin.expiresAt?.toISOString() ?? null,
+              remainingMinutes: remainingMs !== null ? Math.max(0, Math.ceil(remainingMs / 60000)) : null,
+              isTemporary: !!admin.expiresAt,
+            };
           } catch {
-            return { ...admin, username: 'Inconnu', avatarUrl: null };
+            return {
+              ...admin,
+              username: 'Inconnu',
+              avatarUrl: null,
+              expiresAt: admin.expiresAt?.toISOString() ?? null,
+              remainingMinutes: remainingMs !== null ? Math.max(0, Math.ceil(remainingMs / 60000)) : null,
+              isTemporary: !!admin.expiresAt,
+            };
           }
         }));
         json(res, 200, { admins: enrichedAdmins });
@@ -381,20 +407,34 @@ export async function handleAdminRoutes(
     // POST /api/admin/admins
     if (method === 'POST' && parts.length === 3) {
       try {
-         const body = await readJsonBody<{userId: string}>(req);
+         const body = await readJsonBody<{userId: string; durationMinutes?: number; reason?: string}>(req);
          if (!body || !body.userId) {
-           json(res, 400, { error: 'ID Discord requis' }); 
+           json(res, 400, { error: 'ID Discord requis' });
            return true;
          }
+
+         if (!body.durationMinutes || typeof body.durationMinutes !== 'number' || body.durationMinutes <= 0) {
+           json(res, 400, { error: 'Une durée en minutes (durationMinutes) est requise pour les accès temporaires' });
+           return true;
+         }
+
+         const MAX_DURATION_MINUTES = 43200; // 30 jours max
+         if (body.durationMinutes > MAX_DURATION_MINUTES) {
+           json(res, 400, { error: `La durée maximale est de ${MAX_DURATION_MINUTES} minutes (30 jours)` });
+           return true;
+         }
+
+         const expiresAt = new Date(Date.now() + body.durationMinutes * 60 * 1000);
+
          try {
             const discordUser = await client.users.fetch(body.userId);
             if (!discordUser) throw new Error();
             await prisma.globalAdmin.upsert({
               where: { userId: body.userId },
-              update: {},
-              create: { userId: body.userId, addedBy: user.userId }
+              update: { expiresAt, reason: body.reason || null },
+              create: { userId: body.userId, addedBy: user.userId, expiresAt, reason: body.reason || null }
             });
-            json(res, 201, { success: true });
+            json(res, 201, { success: true, expiresAt: expiresAt.toISOString(), durationMinutes: body.durationMinutes });
          } catch {
             json(res, 400, { error: 'Utilisateur Discord introuvable' });
          }

--- a/apps/bot/src/api/routes/auth.ts
+++ b/apps/bot/src/api/routes/auth.ts
@@ -11,6 +11,9 @@ import {
   DISCORD_REDIRECT_URI,
   DASHBOARD_URL,
   JWT_SECRET,
+  storeDiscordToken,
+  createAuthCode,
+  exchangeAuthCode,
 } from '../shared.js';
 
 interface DiscordTokenResponse {
@@ -116,14 +119,16 @@ export async function handleAuthRoutes(
         });
         const userData = await userResponse.json() as DiscordUserResponse;
 
+        storeDiscordToken(userData.id, tokenData.access_token);
+
         const token = jwt.sign({
           userId: userData.id,
           username: userData.username,
           avatar: userData.avatar,
-          discordToken: tokenData.access_token
         }, JWT_SECRET, { expiresIn: '7d' });
 
-        res.writeHead(302, { Location: `${DASHBOARD_URL}#token=${token}` });
+        const authCode = createAuthCode(token);
+        res.writeHead(302, { Location: `${DASHBOARD_URL}?auth_code=${authCode}` });
         res.end();
       } catch (err) {
         logger.error('Auth', 'Discord callback error:', err);
@@ -133,6 +138,24 @@ export async function handleAuthRoutes(
         res.writeHead(302, { Location: `${DASHBOARD_URL}/login?error=auth_failed` });
         res.end();
       }
+      return true;
+    }
+
+    // POST /api/auth/exchange
+    if (parts[3] === 'exchange' && method === 'POST') {
+      const code = url.searchParams.get('code');
+      if (!code) {
+        json(res, 400, { error: 'Code manquant' });
+        return true;
+      }
+
+      const jwtToken = exchangeAuthCode(code);
+      if (!jwtToken) {
+        json(res, 401, { error: 'Code invalide ou expiré' });
+        return true;
+      }
+
+      json(res, 200, { token: jwtToken });
       return true;
     }
   }

--- a/apps/bot/src/api/routes/error.ts
+++ b/apps/bot/src/api/routes/error.ts
@@ -83,14 +83,17 @@ export async function handleReportErrorRoute(
 
       const ownerId = process.env.DISCORD_CLIENT_OWNER_ID;
       const adminsFromDb = await prisma.globalAdmin.findMany({
-        select: { userId: true }
+        select: { userId: true, expiresAt: true }
       });
+      const now = new Date();
       const adminIds = new Set<string>();
       if (ownerId) {
         adminIds.add(ownerId);
       }
       for (const a of adminsFromDb) {
-        adminIds.add(a.userId);
+        if (!a.expiresAt || a.expiresAt > now) {
+          adminIds.add(a.userId);
+        }
       }
 
       if (adminIds.size === 0) {

--- a/apps/bot/src/api/routes/feedback.ts
+++ b/apps/bot/src/api/routes/feedback.ts
@@ -74,14 +74,17 @@ export async function handleReportFeedbackRoute(
 
       const ownerId = process.env.DISCORD_CLIENT_OWNER_ID;
       const adminsFromDb = await prisma.globalAdmin.findMany({
-        select: { userId: true }
+        select: { userId: true, expiresAt: true }
       });
+      const now = new Date();
       const adminIds = new Set<string>();
       if (ownerId) {
         adminIds.add(ownerId);
       }
       for (const a of adminsFromDb) {
-        adminIds.add(a.userId);
+        if (!a.expiresAt || a.expiresAt > now) {
+          adminIds.add(a.userId);
+        }
       }
 
       if (adminIds.size === 0) {

--- a/apps/bot/src/api/routes/user.ts
+++ b/apps/bot/src/api/routes/user.ts
@@ -11,6 +11,7 @@ import {
   hasDashboardAdminPermission,
   DashboardAccessLevel,
   AuthClaims,
+  getDiscordToken,
 } from '../shared.js';
 
 interface DiscordGuild {
@@ -65,13 +66,19 @@ export async function handleUserRoutes(
       }
 
       const decoded = jwt.decode(token) as AuthClaims | null;
-      if (!decoded || !decoded.discordToken) {
-        json(res, 400, { error: 'Token Discord manquant dans le JWT' });
+      if (!decoded || !decoded.userId) {
+        json(res, 400, { error: 'Token JWT invalide' });
+        return true;
+      }
+
+      const discordToken = getDiscordToken(decoded.userId);
+      if (!discordToken) {
+        json(res, 401, { error: 'Session Discord expirée, veuillez vous reconnecter' });
         return true;
       }
 
       const guildsResponse = await fetch('https://discord.com/api/users/@me/guilds', {
-        headers: { Authorization: `Bearer ${decoded.discordToken}` },
+        headers: { Authorization: `Bearer ${discordToken}` },
       });
 
       if (!guildsResponse.ok) {

--- a/apps/bot/src/api/shared.ts
+++ b/apps/bot/src/api/shared.ts
@@ -1,11 +1,9 @@
 import { createServer, type IncomingMessage, ServerResponse } from 'node:http';
 import { Socket } from 'node:net';
-import { appendFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const debugLogFile = path.resolve(__dirname, '../../scratch/debug_api.log');
 
 import {
   ActionRowBuilder,
@@ -1098,8 +1096,39 @@ export type AuthClaims = {
   userId: string;
   username?: string;
   avatar?: string;
-  discordToken?: string;
 };
+
+const discordTokenStore = new Map<string, { token: string; expiresAt: number }>();
+
+export function storeDiscordToken(userId: string, token: string): void {
+  discordTokenStore.set(userId, { token, expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000 });
+}
+
+export function getDiscordToken(userId: string): string | null {
+  const entry = discordTokenStore.get(userId);
+  if (!entry) return null;
+  if (Date.now() > entry.expiresAt) {
+    discordTokenStore.delete(userId);
+    return null;
+  }
+  return entry.token;
+}
+
+const authCodeStore = new Map<string, { jwt: string; expiresAt: number }>();
+
+export function createAuthCode(jwtToken: string): string {
+  const code = crypto.randomBytes(32).toString('hex');
+  authCodeStore.set(code, { jwt: jwtToken, expiresAt: Date.now() + 60_000 });
+  return code;
+}
+
+export function exchangeAuthCode(code: string): string | null {
+  const entry = authCodeStore.get(code);
+  authCodeStore.delete(code);
+  if (!entry) return null;
+  if (Date.now() > entry.expiresAt) return null;
+  return entry.jwt;
+}
 
 export const verifyAuth = (req: IncomingMessage): AuthClaims | null => {
   const authHeader = req.headers.authorization;
@@ -1281,8 +1310,15 @@ export async function resolveAdminAccess(client: Client, userId: string): Promis
   const admin = await prisma.globalAdmin.findUnique({
     where: { userId }
   });
-  
-  return !!admin;
+
+  if (!admin) return false;
+
+  if (admin.expiresAt && admin.expiresAt.getTime() < Date.now()) {
+    await prisma.globalAdmin.delete({ where: { userId } }).catch(() => {});
+    return false;
+  }
+
+  return true;
 }
 
 export class HttpError extends Error {
@@ -1371,36 +1407,20 @@ export class BunServerResponse extends ServerResponse {
 
 export const readJsonBody = async <T>(req: IncomingMessage): Promise<T | null> => {
   const contentType = req.headers['content-type'];
-  const logFile = '/mnt/c/Users/Elouan/Documents/GitHub/Kotbo/apps/bot/scratch/debug_api.log';
-  const logMsg = (msg: string) => {
-    try {
-      appendFileSync(logFile, `[${new Date().toISOString()}] [readJsonBody] ${msg}\n`, 'utf8');
-    } catch {}
-  };
-
-  logMsg(`URL: ${req.url}, contentType: ${contentType}`);
 
   if (!contentType || !contentType.includes('application/json')) {
-    logMsg(`Invalid content type: ${contentType}`);
     throw new HttpError(415, 'Content-Type doit être application/json');
   }
 
   if (req.bodyText !== undefined) {
     const text = req.bodyText.trim();
-    logMsg(`Using pre-read bodyText: length=${text.length}, content="${text}"`);
     if (!text) {
-      logMsg(`Empty bodyText, returning null`);
-      logger.info('readJsonBody', `Empty body for URL: ${req.url}`);
       return null;
     }
     try {
-      const parsed = JSON.parse(text) as T;
-      logMsg(`JSON parse success`);
-      return parsed;
+      return JSON.parse(text) as T;
     } catch (err) {
-      const errMsg = err instanceof Error ? err.message : String(err);
-      logMsg(`JSON parse error: ${errMsg}`);
-      logger.error('readJsonBody', `JSON parse error for URL ${req.url}, text="${text}":`, err);
+      logger.error('readJsonBody', `JSON parse error for URL ${req.url}:`, err);
       throw new HttpError(400, 'Format JSON invalide');
     }
   }
@@ -1887,7 +1907,7 @@ export async function buildMemberCaseData(client: Client, guildId: string, userI
         orderBy: { dateIso: 'desc' },
         take: 500,
       }).catch(() => []),
-      fetchMemberConnections(auth.userId === actualUserId ? auth.discordToken : null).catch(() => ({ connections: [], note: "Erreur lors de la récupération des connexions." })),
+      fetchMemberConnections(auth.userId === actualUserId ? getDiscordToken(auth.userId) : null).catch(() => ({ connections: [], note: "Erreur lors de la récupération des connexions." })),
       getStaffMember(guildId, actualUserId).catch(() => null),
       getCandidatureHistory(guildId, actualUserId).catch(() => []),
       prisma.sanctionReport.findMany({

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -360,9 +360,10 @@ client.on(Events.InteractionCreate, async (interaction) => {
 
     // 2. Vérification du mode maintenance (sauf pour créateur et admins globaux)
     if ((global as any).KOTBO_MAINTENANCE_MODE && interaction.user.id !== process.env.DISCORD_CLIENT_OWNER_ID) {
-      // Allow global admins bypass
+      // Allow global admins bypass (only if access hasn't expired)
       const admin = await prisma.globalAdmin.findUnique({ where: { userId: interaction.user.id } });
-      if (!admin) {
+      const isAdminValid = admin && (!admin.expiresAt || admin.expiresAt.getTime() > Date.now());
+      if (!isAdminValid) {
         if (interaction.isRepliable()) {
           await interaction.reply({
             content: '⚠️ **Mode Maintenance**\nKotbo est actuellement en cours de maintenance globale. Réessayez plus tard.',

--- a/apps/dashboard/src/App.svelte
+++ b/apps/dashboard/src/App.svelte
@@ -4,6 +4,7 @@
   const Route = RouteLegacy as any;
   import MainLayout from "./lib/components/MainLayout.svelte";
   import { authStore } from "./lib/stores/auth.svelte";
+  import { API_BASE_URL } from "./lib/api";
   import { dashboardStore } from "./lib/stores/dashboard.svelte";
   import { themeStore } from "./lib/stores/theme.svelte";
   import { toast } from "./lib/stores/toast.svelte";
@@ -171,20 +172,24 @@
     selectedGuildAccessLevel() !== "moderator",
   );
 
-  onMount(() => {
+  onMount(async () => {
     const urlParams = new URLSearchParams(window.location.search);
-    let token = urlParams.get("token");
+    const authCode = urlParams.get("auth_code");
 
-    if (!token && window.location.hash) {
-      const hashParams = new URLSearchParams(window.location.hash.substring(1));
-      token = hashParams.get("token");
-    }
-
-    if (token) {
-      authStore.setToken(token);
-
+    if (authCode) {
       window.history.replaceState({}, document.title, window.location.pathname);
-      router.goto("/");
+      try {
+        const res = await fetch(`${API_BASE_URL}/api/auth/discord/exchange?code=${encodeURIComponent(authCode)}`, { method: 'POST' });
+        if (res.ok) {
+          const data = await res.json();
+          authStore.setToken(data.token);
+          router.goto("/");
+        } else {
+          router.goto("/login?error=auth_failed");
+        }
+      } catch {
+        router.goto("/login?error=auth_failed");
+      }
     }
 
     if (

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -1133,11 +1133,11 @@ export async function fetchGlobalAdmins() {
   return response.json();
 }
 
-export async function addGlobalAdmin(userId: string) {
+export async function addGlobalAdmin(userId: string, durationMinutes: number, reason?: string) {
   const response = await authorizedFetch(`${API_BASE_URL}/api/admin/admins`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ userId })
+    body: JSON.stringify({ userId, durationMinutes, reason })
   });
   if (!response.ok) {
     const error = await response.json().catch(() => ({}));

--- a/apps/dashboard/src/lib/components/CalendarEventModal.svelte
+++ b/apps/dashboard/src/lib/components/CalendarEventModal.svelte
@@ -45,9 +45,19 @@
     }
   }
 
+  function escapeHtml(text: string): string {
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+
   function interpretMarkdown(text: string) {
     if (!text) return '';
-    return text
+    let escaped = escapeHtml(text);
+    return escaped
       .replace(/### (.*)/g, '<h5 class="text-xs font-black uppercase tracking-wider text-primary mt-4 mb-2">$1</h5>')
       .replace(/## (.*)/g, '<h4 class="text-sm font-black text-on-surface mt-6 mb-3 border-b border-outline-variant/20 pb-1">$1</h4>')
       .replace(/# (.*)/g, '<h3 class="text-lg font-black text-on-surface mt-8 mb-4">$1</h3>')

--- a/apps/dashboard/src/lib/components/MemberCaseModal.svelte
+++ b/apps/dashboard/src/lib/components/MemberCaseModal.svelte
@@ -506,8 +506,17 @@
     return 'Hors ligne';
   }
 
+  function escapeHtml(text: string): string {
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+
   function sanitizeLogSnippet(value: string) {
-    return value.replace(/^Contenu:\s*/i, '').replace(/^\s+|\s+$/g, '');
+    return escapeHtml(value.replace(/^Contenu:\s*/i, '').replace(/^\s+|\s+$/g, ''));
   }
 
   function getConnectionIcon(type: string) {

--- a/apps/dashboard/src/pages/Logs.svelte
+++ b/apps/dashboard/src/pages/Logs.svelte
@@ -574,8 +574,17 @@
     return Math.round(value * (unitMs[unit] ?? 0)) || null;
   }
 
+  function escapeHtml(text: string): string {
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+
   function sanitizeLogSnippet(value: string) {
-    return value.replace(/^Contenu:\s*/i, '').replace(/^\s+|\s+$/g, '');
+    return escapeHtml(value.replace(/^Contenu:\s*/i, '').replace(/^\s+|\s+$/g, ''));
   }
 
   async function loadMemberCase(userId: string) {

--- a/apps/dashboard/src/pages/admin/Security.svelte
+++ b/apps/dashboard/src/pages/admin/Security.svelte
@@ -12,6 +12,10 @@
     avatarUrl: string | null;
     addedBy: string;
     createdAt: string;
+    expiresAt: string | null;
+    remainingMinutes: number | null;
+    isTemporary: boolean;
+    reason: string | null;
   }
 
   interface BlacklistEntry {
@@ -27,12 +31,38 @@
 
   let globalAdmins = $state<GlobalAdmin[]>([]);
   let globalBlacklist = $state<BlacklistEntry[]>([]);
+  const DURATION_PRESETS = [
+    { label: '30 min', minutes: 30 },
+    { label: '1h', minutes: 60 },
+    { label: '2h', minutes: 120 },
+    { label: '6h', minutes: 360 },
+    { label: '12h', minutes: 720 },
+    { label: '24h', minutes: 1440 },
+    { label: '3 jours', minutes: 4320 },
+    { label: '7 jours', minutes: 10080 },
+    { label: '30 jours', minutes: 43200 },
+  ];
+
   let newAdminId = $state('');
+  let newAdminDuration = $state(60);
+  let newAdminReason = $state('');
   let newBlacklistId = $state('');
   let newBlacklistReason = $state('');
   let loading = $state(true);
   let error = $state<string | null>(null);
   let adminTab = $state<'admins' | 'blacklist'>('admins');
+
+  function formatRemaining(minutes: number | null): string {
+    if (minutes === null) return '';
+    if (minutes <= 0) return 'Expiré';
+    if (minutes < 60) return `${minutes}min`;
+    const h = Math.floor(minutes / 60);
+    const m = minutes % 60;
+    if (h < 24) return m > 0 ? `${h}h ${m}min` : `${h}h`;
+    const d = Math.floor(h / 24);
+    const rh = h % 24;
+    return rh > 0 ? `${d}j ${rh}h` : `${d}j`;
+  }
 
   onMount(async () => {
     try {
@@ -53,11 +83,13 @@
     e.preventDefault();
     if (!newAdminId.trim()) return;
     try {
-      await addGlobalAdmin(newAdminId.trim());
+      await addGlobalAdmin(newAdminId.trim(), newAdminDuration, newAdminReason.trim() || undefined);
       newAdminId = '';
+      newAdminReason = '';
+      newAdminDuration = 60;
       const data = await fetchGlobalAdmins();
       globalAdmins = data.admins;
-      toast.success('Administrateur ajouté.');
+      toast.success('Accès temporaire accordé.');
     } catch (err: any) { toast.error(err.message); }
   }
 
@@ -163,21 +195,39 @@
       <div class="bg-surface-container-low/50 border border-outline-variant/10 rounded-2xl p-6 space-y-5">
         <!-- Add form -->
         <div>
-          <p class="text-[10px] font-black uppercase tracking-widest text-on-surface-variant/40 mb-2">Ajouter un administrateur</p>
-          <form onsubmit={handleAddAdmin} class="flex gap-2">
-            <input
-              type="text"
-              bind:value={newAdminId}
-              placeholder="ID Discord (ex: 457275321171968000)"
-              class="flex-1 bg-on-surface/4 border border-outline-variant/10 rounded-xl px-4 py-2.5 text-sm text-on-surface placeholder-on-surface-variant/30 focus:outline-none focus:border-primary/30 transition-all"
-              required
-            />
-            <button
-              type="submit"
-              class="px-5 py-2.5 rounded-xl bg-primary text-on-primary text-xs font-black uppercase tracking-widest hover:scale-[1.02] transition-all shadow-md shadow-primary/20"
-            >
-              Ajouter
-            </button>
+          <p class="text-[10px] font-black uppercase tracking-widest text-on-surface-variant/40 mb-2">Accorder un accès temporaire</p>
+          <form onsubmit={handleAddAdmin} class="space-y-2">
+            <div class="flex gap-2">
+              <input
+                type="text"
+                bind:value={newAdminId}
+                placeholder="ID Discord (ex: 457275321171968000)"
+                class="flex-1 bg-on-surface/4 border border-outline-variant/10 rounded-xl px-4 py-2.5 text-sm text-on-surface placeholder-on-surface-variant/30 focus:outline-none focus:border-primary/30 transition-all"
+                required
+              />
+              <select
+                bind:value={newAdminDuration}
+                class="bg-on-surface/4 border border-outline-variant/10 rounded-xl px-3 py-2.5 text-sm text-on-surface focus:outline-none focus:border-primary/30 transition-all"
+              >
+                {#each DURATION_PRESETS as preset}
+                  <option value={preset.minutes}>{preset.label}</option>
+                {/each}
+              </select>
+            </div>
+            <div class="flex gap-2">
+              <input
+                type="text"
+                bind:value={newAdminReason}
+                placeholder="Raison de l'accès (optionnel)"
+                class="flex-1 bg-on-surface/4 border border-outline-variant/10 rounded-xl px-4 py-2.5 text-sm text-on-surface placeholder-on-surface-variant/30 focus:outline-none focus:border-primary/30 transition-all"
+              />
+              <button
+                type="submit"
+                class="px-5 py-2.5 rounded-xl bg-primary text-on-primary text-xs font-black uppercase tracking-widest hover:scale-[1.02] transition-all shadow-md shadow-primary/20"
+              >
+                Accorder
+              </button>
+            </div>
           </form>
         </div>
 
@@ -199,19 +249,36 @@
                   <div>
                     <p class="font-bold text-sm text-on-surface">{admin.username}</p>
                     <p class="text-[10px] text-on-surface-variant/30 font-mono">{admin.userId}</p>
+                    {#if admin.reason}
+                      <p class="text-[10px] text-on-surface-variant/50 italic mt-0.5">{admin.reason}</p>
+                    {/if}
                   </div>
                 </div>
-                {#if admin.userId === OWNER_ID}
-                  <span class="text-[9px] uppercase font-black tracking-widest text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-full">Créateur</span>
-                {:else}
-                  <button
-                    onclick={() => handleRemoveAdmin(admin.userId, admin.username)}
-                    class="w-8 h-8 flex items-center justify-center rounded-lg text-on-surface-variant/30 hover:bg-red-500/10 hover:text-red-400 transition-all opacity-0 group-hover:opacity-100"
-                    title="Révoquer l'accès"
-                  >
-                    <Papicon icon="Trash" size={14} />
-                  </button>
-                {/if}
+                <div class="flex items-center gap-2">
+                  {#if admin.userId === OWNER_ID}
+                    <span class="text-[9px] uppercase font-black tracking-widest text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-full">Créateur</span>
+                  {:else if admin.isTemporary}
+                    <span class="text-[9px] uppercase font-black tracking-widest text-amber-400 bg-amber-500/10 border border-amber-500/20 px-2.5 py-1 rounded-full flex items-center gap-1">
+                      <Papicon icon="Clock" size={10} />
+                      {formatRemaining(admin.remainingMinutes)}
+                    </span>
+                    <button
+                      onclick={() => handleRemoveAdmin(admin.userId, admin.username)}
+                      class="w-8 h-8 flex items-center justify-center rounded-lg text-on-surface-variant/30 hover:bg-red-500/10 hover:text-red-400 transition-all opacity-0 group-hover:opacity-100"
+                      title="Révoquer l'accès"
+                    >
+                      <Papicon icon="Trash" size={14} />
+                    </button>
+                  {:else}
+                    <button
+                      onclick={() => handleRemoveAdmin(admin.userId, admin.username)}
+                      class="w-8 h-8 flex items-center justify-center rounded-lg text-on-surface-variant/30 hover:bg-red-500/10 hover:text-red-400 transition-all opacity-0 group-hover:opacity-100"
+                      title="Révoquer l'accès"
+                    >
+                      <Papicon icon="Trash" size={14} />
+                    </button>
+                  {/if}
+                </div>
               </div>
             {/each}
           {/if}

--- a/packages/database/prisma/bot-admin.prisma
+++ b/packages/database/prisma/bot-admin.prisma
@@ -3,9 +3,11 @@
 // ============================================================================
 
 model GlobalAdmin {
-  userId String @id
-  addedBy String
-  createdAt DateTime @default(now())
+  userId    String    @id
+  addedBy   String
+  createdAt DateTime  @default(now())
+  expiresAt DateTime?
+  reason    String?
 
   @@map("global_admins")
 }

--- a/packages/database/prisma/migrations/20260619120000_add_temporary_admin_access/migration.sql
+++ b/packages/database/prisma/migrations/20260619120000_add_temporary_admin_access/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "global_admins" ADD COLUMN "expiresAt" TIMESTAMP(3);
+ALTER TABLE "global_admins" ADD COLUMN "reason" TEXT;


### PR DESCRIPTION
Corrections appliquées
Vuln 1 — Debug logging supprimé
shared.ts : Suppression du appendFileSync, du logFile, de logMsg() et de tous les appels de debug dans readJsonBody(). Import appendFileSync et variable debugLogFile également supprimés. Vuln 2 — Token Discord retiré du JWT
shared.ts : Ajout d'un discordTokenStore (Map en mémoire) avec storeDiscordToken() et getDiscordToken(). Le champ discordToken est supprimé du type AuthClaims. auth.ts : Le token Discord est maintenant stocké côté serveur via storeDiscordToken() au lieu d'être inclus dans le JWT. user.ts : Utilise getDiscordToken() au lieu de decoded.discordToken. Vuln 3 — JWT plus exposé dans l'URL
auth.ts : Le callback redirige maintenant avec un code d'autorisation éphémère (?auth_code=xxx) valable 60 secondes, à usage unique. Nouvel endpoint POST /api/auth/discord/exchange pour échanger le code contre le JWT. App.svelte : Le dashboard détecte auth_code dans l'URL, appelle l'endpoint d'échange, et stocke le JWT reçu dans la réponse. Vuln 4 — XSS dans CalendarEventModal
CalendarEventModal.svelte : Ajout de escapeHtml() avant les transformations markdown. Vuln 5 — XSS dans sanitizeLogSnippet
MemberCaseModal.svelte et Logs.svelte : sanitizeLogSnippet() applique maintenant escapeHtml() avant de retourner le contenu.