### PR TITLE
feat: intégration serveur MCP pour interaction IA avec le bot Discord

### DIFF
--- a/apps/bot/package.json
+++ b/apps/bot/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@kotbo/database": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@napi-rs/canvas": "^0.1.100",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",

--- a/apps/bot/src/api/dashboardApi.ts
+++ b/apps/bot/src/api/dashboardApi.ts
@@ -35,6 +35,7 @@ import { handleReportFeedbackRoute } from './routes/feedback.js';
 import { handleUserRoutes } from './routes/user.js';
 import { handleAdminRoutes } from './routes/admin.js';
 import { handleDashboardRoutes } from './routes/dashboard.js';
+import { handleMCPRoutes, mcpRateLimiter } from './mcp/mcpServer.js';
 
 export type { DashboardSanctionType };
 
@@ -127,6 +128,7 @@ export const startDashboardApi = (client: Client) => {
     cleanLimiter(configRateLimiter, 60 * 1000);
     cleanLimiter(errorReportRateLimiter, 15 * 60 * 1000);
     cleanLimiter(feedbackReportRateLimiter, 15 * 60 * 1000);
+    cleanLimiter(mcpRateLimiter, 60 * 1000);
   }, 10 * 60 * 1000).unref();
 
   const server = Bun.serve<WebSocketData>({
@@ -254,6 +256,9 @@ export const startDashboardApi = (client: Client) => {
               return;
             }
             if (await handleAdminRoutes(req, res, parts, url, client)) {
+              return;
+            }
+            if (await handleMCPRoutes(req, res, parts, url, client)) {
               return;
             }
             if (await handleDashboardRoutes(req, res, parts, url, client)) {

--- a/apps/bot/src/api/mcp/mcpKeyService.ts
+++ b/apps/bot/src/api/mcp/mcpKeyService.ts
@@ -1,0 +1,73 @@
+import prisma from '../../utils/db.js';
+import crypto from 'node:crypto';
+import type { McpKeyPermission } from '@prisma/client';
+
+export const hashMcpKey = (key: string): string => {
+  return crypto.createHash('sha256').update(key).digest('hex');
+};
+
+export const generateMcpKey = (): { fullKey: string; displayKey: string } => {
+  const fullKey = `mcp_${crypto.randomBytes(32).toString('hex')}`;
+  const displayKey = `${fullKey.slice(0, 8)}...${fullKey.slice(-4)}`;
+  return { fullKey, displayKey };
+};
+
+export const createMcpKey = async (
+  guildId: string,
+  name: string,
+  permissions: McpKeyPermission[]
+) => {
+  const { fullKey, displayKey } = generateMcpKey();
+  const keyHash = hashMcpKey(fullKey);
+
+  const record = await prisma.mcpApiKey.create({
+    data: {
+      guildId,
+      name,
+      keyHash,
+      displayKey,
+      permissions,
+    },
+  });
+
+  return { ...record, fullKey };
+};
+
+export const getMcpKeys = async (guildId: string) => {
+  return prisma.mcpApiKey.findMany({
+    where: { guildId, isActive: true },
+    select: {
+      id: true,
+      name: true,
+      displayKey: true,
+      permissions: true,
+      isActive: true,
+      lastUsedAt: true,
+      createdAt: true,
+    },
+    orderBy: { createdAt: 'desc' },
+  });
+};
+
+export const deactivateMcpKey = async (guildId: string, keyId: string) => {
+  return prisma.mcpApiKey.updateMany({
+    where: { id: keyId, guildId },
+    data: { isActive: false },
+  });
+};
+
+export const verifyMcpKey = async (rawKey: string, guildId: string) => {
+  const keyHash = hashMcpKey(rawKey);
+  const key = await prisma.mcpApiKey.findUnique({ where: { keyHash } });
+
+  if (!key || key.guildId !== guildId || !key.isActive) {
+    return null;
+  }
+
+  await prisma.mcpApiKey.update({
+    where: { id: key.id },
+    data: { lastUsedAt: new Date() },
+  });
+
+  return key;
+};

--- a/apps/bot/src/api/mcp/mcpServer.ts
+++ b/apps/bot/src/api/mcp/mcpServer.ts
@@ -1,0 +1,84 @@
+import { IncomingMessage, ServerResponse } from 'node:http';
+import { Client } from 'discord.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { json } from '../shared.js';
+import { verifyMcpKey } from './mcpKeyService.js';
+import { registerMcpTools } from './mcpTools.js';
+
+export const mcpRateLimiter = new Map<string, number[]>();
+
+function checkRateLimit(keyId: string, maxRequests: number, windowMs: number): boolean {
+  const now = Date.now();
+  const timestamps = (mcpRateLimiter.get(keyId) ?? []).filter((t) => now - t < windowMs);
+  if (timestamps.length >= maxRequests) return false;
+  timestamps.push(now);
+  mcpRateLimiter.set(keyId, timestamps);
+  return true;
+}
+
+export async function handleMCPRoutes(
+  req: IncomingMessage & { bodyText?: string },
+  res: ServerResponse,
+  parts: string[],
+  _url: URL,
+  client: Client
+): Promise<boolean> {
+  if (parts[0] !== 'api' || parts[1] !== 'mcp') return false;
+
+  const guildId = parts[2];
+  if (!guildId) {
+    json(res, 400, { error: 'guildId manquant dans le chemin /api/mcp/:guildId' });
+    return true;
+  }
+
+  if (req.method !== 'POST') {
+    json(res, 405, { error: 'Méthode non autorisée. Utilisez POST.' });
+    return true;
+  }
+
+  // Auth
+  const authHeader = req.headers['authorization'];
+  const rawKey = typeof authHeader === 'string' && authHeader.startsWith('Bearer ')
+    ? authHeader.slice(7).trim()
+    : null;
+
+  if (!rawKey) {
+    json(res, 401, { error: 'Clé MCP manquante. Utilisez Authorization: Bearer mcp_...' });
+    return true;
+  }
+
+  const mcpKey = await verifyMcpKey(rawKey, guildId);
+  if (!mcpKey) {
+    json(res, 401, { error: 'Clé MCP invalide ou inactive.' });
+    return true;
+  }
+
+  // Rate limit: 100 req/min per key
+  if (!checkRateLimit(mcpKey.id, 100, 60_000)) {
+    json(res, 429, { error: 'Trop de requêtes. Limite: 100 req/minute par clé.' });
+    return true;
+  }
+
+  // MCP server (stateless per-request)
+  const server = new McpServer({ name: 'kotbo', version: '1.0.0' });
+  registerMcpTools(server, guildId, mcpKey.permissions, client);
+
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: undefined, // stateless
+    enableJsonResponse: true,
+  });
+
+  await server.connect(transport);
+
+  let parsedBody: unknown;
+  try {
+    parsedBody = req.bodyText ? JSON.parse(req.bodyText) : undefined;
+  } catch {
+    json(res, 400, { error: 'Corps JSON invalide' });
+    return true;
+  }
+
+  await transport.handleRequest(req, res, parsedBody);
+  return true;
+}

--- a/apps/bot/src/api/mcp/mcpTools.ts
+++ b/apps/bot/src/api/mcp/mcpTools.ts
@@ -1,0 +1,514 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { Client, TextChannel } from 'discord.js';
+import type { McpKeyPermission, SanctionType, SanctionStatus } from '@prisma/client';
+import prisma from '../../utils/db.js';
+import {
+  registerWarnSanction,
+  registerKickSanction,
+  registerBanSanction,
+  registerTimeoutSanction,
+} from '../../services/moderation/sanctionService.js';
+
+const ok = (data: unknown) => ({
+  content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+});
+
+const err = (msg: string) => ({
+  content: [{ type: 'text' as const, text: JSON.stringify({ error: msg }) }],
+  isError: true,
+});
+
+export function registerMcpTools(
+  server: McpServer,
+  guildId: string,
+  permissions: McpKeyPermission[],
+  client: Client
+) {
+  const has = (p: McpKeyPermission) => permissions.includes(p);
+
+  // ── READ_STATS ────────────────────────────────────────────────────────────
+
+  if (has('READ_STATS')) {
+    server.tool(
+      'get_guild_stats',
+      'Récupère les statistiques du serveur Discord (membres, messages, sanctions) sur une période donnée.',
+      { period_days: z.number().int().min(1).max(90).default(30).describe('Nombre de jours à analyser (1-90)') },
+      async ({ period_days }) => {
+        const since = new Date();
+        since.setDate(since.getDate() - period_days);
+        const sinceKey = since.toISOString().slice(0, 10);
+
+        const stats = await prisma.guildDailyStat.findMany({
+          where: { guildId, dateKey: { gte: sinceKey } },
+          orderBy: { dateKey: 'asc' },
+        });
+
+        const discordGuild = client.guilds.cache.get(guildId);
+
+        const totals = stats.reduce(
+          (acc: { messages: number; voiceMinutes: number; joins: number; leaves: number; sanctions: number }, s) => ({
+            messages: acc.messages + s.messagesCount,
+            voiceMinutes: acc.voiceMinutes + s.voiceMinutes,
+            joins: acc.joins + s.membersJoined,
+            leaves: acc.leaves + s.membersLeft,
+            sanctions: acc.sanctions + s.sanctionsCount,
+          }),
+          { messages: 0, voiceMinutes: 0, joins: 0, leaves: 0, sanctions: 0 }
+        );
+
+        return ok({
+          guildId,
+          currentMemberCount: discordGuild?.memberCount ?? null,
+          period: { from: sinceKey, days: period_days },
+          totals,
+          trend: stats.map((s) => ({
+            date: s.dateKey,
+            messages: s.messagesCount,
+            voiceMinutes: s.voiceMinutes,
+            joins: s.membersJoined,
+            leaves: s.membersLeft,
+            sanctions: s.sanctionsCount,
+          })),
+        });
+      }
+    );
+  }
+
+  // ── READ_MEMBERS ──────────────────────────────────────────────────────────
+
+  if (has('READ_MEMBERS')) {
+    server.tool(
+      'get_recent_messages',
+      'Récupère les messages récents d\'un salon Discord (lecture en direct via l\'API Discord).',
+      {
+        channel_id: z.string().describe('ID du salon Discord'),
+        limit: z.number().int().min(1).max(100).default(20).describe('Nombre de messages (1-100)'),
+      },
+      async ({ channel_id, limit }) => {
+        const discordGuild = client.guilds.cache.get(guildId);
+        if (!discordGuild) return err('Serveur Discord introuvable');
+
+        const channel = discordGuild.channels.cache.get(channel_id);
+        if (!channel) return err('Salon introuvable');
+        if (!channel.isTextBased()) return err('Ce salon n\'est pas un salon textuel');
+
+        const messages = await (channel as TextChannel).messages.fetch({ limit }).catch(() => null);
+        if (!messages) return err('Impossible de lire les messages (permissions insuffisantes)');
+
+        return ok(
+          messages.map((m) => ({
+            id: m.id,
+            authorId: m.author.id,
+            authorName: m.author.username,
+            content: m.content,
+            createdAt: m.createdAt.toISOString(),
+          }))
+        );
+      }
+    );
+
+    server.tool(
+      'get_member_profile',
+      'Récupère le profil d\'un membre du serveur (activité, historique, informations Discord).',
+      { member_id: z.string().describe('ID Discord du membre') },
+      async ({ member_id }) => {
+        const [profile, discordMember] = await Promise.all([
+          prisma.memberProfile.findUnique({
+            where: { guildId_userId: { guildId, userId: member_id } },
+          }),
+          client.guilds.cache.get(guildId)?.members.fetch(member_id).catch(() => null),
+        ]);
+
+        if (!profile && !discordMember) return err('Membre introuvable');
+
+        return ok({
+          userId: member_id,
+          profile: profile
+            ? {
+                messageCount: profile.messageCount,
+                voiceTimeSeconds: profile.voiceTimeSeconds,
+                joinedAt: profile.guildJoinedAt?.toISOString(),
+                lastSeenAt: profile.lastSeenAt.toISOString(),
+                lastMessageAt: profile.lastMessageAt?.toISOString(),
+                isSuspectedDC: profile.isSuspectedDC,
+                moderatorNote: profile.moderatorNote,
+              }
+            : null,
+          discord: discordMember
+            ? {
+                username: discordMember.user.username,
+                displayName: discordMember.displayName,
+                avatarUrl: discordMember.displayAvatarURL(),
+                roles: discordMember.roles.cache.map((r) => ({ id: r.id, name: r.name })),
+                joinedAt: discordMember.joinedAt?.toISOString(),
+              }
+            : null,
+        });
+      }
+    );
+
+    server.tool(
+      'search_members',
+      'Recherche des membres par nom d\'utilisateur ou nom d\'affichage.',
+      {
+        query: z.string().describe('Terme de recherche (username, displayName ou userId)'),
+        limit: z.number().int().min(1).max(50).default(20),
+      },
+      async ({ query, limit }) => {
+        const members = await prisma.memberProfile.findMany({
+          where: {
+            guildId,
+            OR: [
+              { userId: query },
+              { username: { contains: query, mode: 'insensitive' } },
+              { displayName: { contains: query, mode: 'insensitive' } },
+            ],
+          },
+          take: limit,
+          orderBy: { lastSeenAt: 'desc' },
+          select: {
+            userId: true,
+            username: true,
+            displayName: true,
+            messageCount: true,
+            lastSeenAt: true,
+            guildJoinedAt: true,
+          },
+        });
+
+        const enriched = members.map((m) => ({
+          userId: m.userId,
+          username: m.username,
+          displayName: m.displayName,
+          messageCount: m.messageCount,
+          lastSeenAt: m.lastSeenAt.toISOString(),
+          joinedAt: m.guildJoinedAt?.toISOString() ?? null,
+        }));
+
+        return ok(enriched);
+      }
+    );
+  }
+
+  // ── READ_SANCTIONS ────────────────────────────────────────────────────────
+
+  if (has('READ_SANCTIONS')) {
+    server.tool(
+      'get_sanctions',
+      'Liste les sanctions du serveur avec filtres optionnels.',
+      {
+        member_id: z.string().optional().describe('Filtrer par ID du membre sanctionné'),
+        type: z.enum(['WARN', 'KICK', 'TIMEOUT', 'TEMP_BAN', 'BAN', 'SOFTBAN']).optional(),
+        status: z.enum(['ACTIVE', 'RESOLVED', 'FAILED']).optional(),
+        limit: z.number().int().min(1).max(100).default(50),
+        offset: z.number().int().min(0).default(0),
+      },
+      async ({ member_id, type, status, limit, offset }) => {
+        const [sanctions, total] = await Promise.all([
+          prisma.sanction.findMany({
+            where: {
+              guildId,
+              ...(member_id ? { targetUserId: member_id } : {}),
+              ...(type ? { type: type as SanctionType } : {}),
+              ...(status ? { status: status as SanctionStatus } : {}),
+            },
+            orderBy: { createdAt: 'desc' },
+            take: limit,
+            skip: offset,
+          }),
+          prisma.sanction.count({
+            where: {
+              guildId,
+              ...(member_id ? { targetUserId: member_id } : {}),
+              ...(type ? { type: type as SanctionType } : {}),
+              ...(status ? { status: status as SanctionStatus } : {}),
+            },
+          }),
+        ]);
+
+        return ok({
+          total,
+          sanctions: sanctions.map((s) => ({
+            id: s.id,
+            type: s.type,
+            status: s.status,
+            targetUserId: s.targetUserId,
+            targetTag: s.targetTag,
+            moderatorUserId: s.moderatorUserId,
+            moderatorTag: s.moderatorTag,
+            reason: s.reason,
+            durationSeconds: s.durationSeconds,
+            expiresAt: s.expiresAt?.toISOString(),
+            createdAt: s.createdAt.toISOString(),
+            resolvedAt: s.resolvedAt?.toISOString(),
+          })),
+        });
+      }
+    );
+
+    server.tool(
+      'get_sanction_history',
+      'Récupère l\'historique complet des sanctions pour un membre spécifique.',
+      { member_id: z.string().describe('ID Discord du membre') },
+      async ({ member_id }) => {
+        const [sanctions, reports] = await Promise.all([
+          prisma.sanction.findMany({
+            where: { guildId, targetUserId: member_id },
+            orderBy: { createdAt: 'desc' },
+          }),
+          prisma.sanctionReport.findMany({
+            where: { guildId, memberReference: member_id },
+            orderBy: { createdAt: 'desc' },
+          }),
+        ]);
+
+        const byType: Record<string, number> = {};
+        for (const s of sanctions) {
+          byType[s.type] = (byType[s.type] ?? 0) + 1;
+        }
+
+        return ok({
+          memberId: member_id,
+          summary: {
+            total: sanctions.length,
+            active: sanctions.filter((s) => s.status === 'ACTIVE').length,
+            byType,
+          },
+          sanctions: sanctions.map((s) => ({
+            id: s.id,
+            type: s.type,
+            status: s.status,
+            reason: s.reason,
+            moderatorTag: s.moderatorTag,
+            durationSeconds: s.durationSeconds,
+            createdAt: s.createdAt.toISOString(),
+          })),
+          reports: reports.map((r) => ({
+            id: r.id,
+            sanctionId: r.sanctionId,
+            brokenRules: r.brokenRules,
+            detailedReason: r.detailedReason,
+            evidenceLinks: r.evidenceLinks,
+            createdAt: r.createdAt.toISOString(),
+          })),
+        });
+      }
+    );
+  }
+
+  // ── READ_STAFF ────────────────────────────────────────────────────────────
+
+  if (has('READ_STAFF')) {
+    server.tool(
+      'get_staff_list',
+      'Récupère la liste des membres du staff du serveur.',
+      {
+        include_inactive: z.boolean().default(false).describe('Inclure les membres inactifs'),
+      },
+      async ({ include_inactive }) => {
+        const staffMembers = await prisma.staffMember.findMany({
+          where: {
+            guildId,
+            ...(include_inactive ? {} : {}),
+          },
+          include: {
+            absences: {
+              where: { status: { in: ['PENDING', 'APPROVED'] } },
+              select: { id: true, startDate: true, endDate: true, type: true },
+            },
+          },
+          orderBy: { joinedStaffAt: 'desc' },
+        });
+
+        return ok(
+          staffMembers.map((s) => ({
+            id: s.id,
+            userId: s.userId,
+            username: s.username,
+            displayName: s.displayName,
+            grade: s.grade,
+            joinedStaffAt: s.joinedStaffAt.toISOString(),
+            isCurrentlyAbsent: s.absences.length > 0,
+            absences: s.absences.map((a) => ({
+              type: a.type,
+              from: a.startDate.toISOString(),
+              until: a.endDate?.toISOString() ?? null,
+            })),
+          }))
+        );
+      }
+    );
+
+    server.tool(
+      'get_staff_member',
+      'Récupère le profil détaillé d\'un membre du staff.',
+      { member_id: z.string().describe('ID Discord du membre du staff') },
+      async ({ member_id }) => {
+        const staff = await prisma.staffMember.findUnique({
+          where: { guildId_userId: { guildId, userId: member_id } },
+          include: {
+            warnings: { orderBy: { createdAt: 'desc' }, take: 10 },
+            activities: { orderBy: { activityDate: 'desc' }, take: 30 },
+          },
+        });
+
+        if (!staff) return err('Membre du staff introuvable');
+
+        return ok({
+          id: staff.id,
+          userId: staff.userId,
+          username: staff.username,
+          displayName: staff.displayName,
+          avatarUrl: staff.avatarUrl,
+          grade: staff.grade,
+          joinedStaffAt: staff.joinedStaffAt.toISOString(),
+          warnings: staff.warnings.map((w) => ({
+            reason: w.reason,
+            type: w.type,
+            issuedAt: w.createdAt.toISOString(),
+            expiresAt: w.expiresAt?.toISOString(),
+          })),
+          recentActivity: staff.activities.map((a) => ({
+            date: a.activityDate.toISOString(),
+            messageCount: a.messageCount,
+            voiceMinutes: a.voiceMinutes,
+          })),
+        });
+      }
+    );
+  }
+
+  // ── READ_TICKETS ──────────────────────────────────────────────────────────
+
+  if (has('READ_TICKETS')) {
+    server.tool(
+      'get_tickets',
+      'Liste les tickets de support du serveur.',
+      {
+        status: z.enum(['OPEN', 'CLAIMED', 'CLOSED']).optional(),
+        limit: z.number().int().min(1).max(50).default(20),
+        offset: z.number().int().min(0).default(0),
+      },
+      async ({ status, limit, offset }) => {
+        const [tickets, total] = await Promise.all([
+          prisma.ticket.findMany({
+            where: {
+              guildId,
+              ...(status ? { status: status as 'OPEN' | 'CLAIMED' | 'CLOSED' } : {}),
+            },
+            orderBy: { createdAt: 'desc' },
+            take: limit,
+            skip: offset,
+          }),
+          prisma.ticket.count({
+            where: {
+              guildId,
+              ...(status ? { status: status as 'OPEN' | 'CLAIMED' | 'CLOSED' } : {}),
+            },
+          }),
+        ]);
+
+        return ok({
+          total,
+          tickets: tickets.map((t) => ({
+            id: t.id,
+            userId: t.userId,
+            status: t.status,
+            reason: t.reason,
+            description: t.description,
+            claimedById: t.claimedById,
+            createdAt: t.createdAt.toISOString(),
+            closedAt: t.closedAt?.toISOString() ?? null,
+          })),
+        });
+      }
+    );
+  }
+
+  // ── WRITE_SANCTIONS ───────────────────────────────────────────────────────
+
+  if (has('WRITE_SANCTIONS')) {
+    server.tool(
+      'apply_sanction',
+      'Applique une sanction à un membre du serveur Discord. Requiert la permission WRITE_SANCTIONS.',
+      {
+        member_id: z.string().describe('ID Discord du membre à sanctionner'),
+        type: z.enum(['WARN', 'KICK', 'TIMEOUT', 'TEMP_BAN', 'BAN', 'SOFTBAN']),
+        reason: z.string().min(1).max(512).describe('Raison de la sanction'),
+        duration_seconds: z
+          .number()
+          .int()
+          .positive()
+          .max(2332800)
+          .optional()
+          .describe('Durée en secondes (obligatoire pour TIMEOUT et TEMP_BAN, max 27 jours)'),
+        key_name: z.string().optional().describe('Nom de la clé MCP (pour l\'audit)'),
+      },
+      async ({ member_id, type, reason, duration_seconds, key_name }) => {
+        if ((type === 'TIMEOUT' || type === 'TEMP_BAN') && !duration_seconds) {
+          return err(`duration_seconds est obligatoire pour le type ${type}`);
+        }
+
+        const discordGuild = client.guilds.cache.get(guildId);
+        if (!discordGuild) return err('Serveur Discord introuvable');
+
+        const target = await discordGuild.members.fetch(member_id).catch(() => null);
+        if (!target) return err('Membre introuvable sur le serveur Discord');
+
+        const actorTag = `MCP[${key_name ?? 'agent'}]`;
+        const actor = { id: 'mcp_agent', tag: actorTag };
+        const targetData = { id: member_id, tag: target.user.tag ?? target.user.username };
+
+        try {
+          let sanction;
+
+          if (type === 'WARN') {
+            sanction = await registerWarnSanction({ guildId, target: targetData, moderator: actor, reason, client });
+          } else if (type === 'KICK') {
+            sanction = await registerKickSanction({ guildId, target: targetData, moderator: actor, reason, client });
+          } else if (type === 'TIMEOUT') {
+            sanction = await registerTimeoutSanction({
+              guildId,
+              target: targetData,
+              moderator: actor,
+              reason,
+              durationMs: duration_seconds! * 1000,
+              member: target,
+              client,
+            });
+          } else if (type === 'BAN' || type === 'TEMP_BAN') {
+            sanction = await registerBanSanction({
+              guildId,
+              target: targetData,
+              moderator: actor,
+              reason,
+              client,
+              ...(duration_seconds ? { temporaryDurationMs: duration_seconds * 1000 } : {}),
+            });
+          } else {
+            return err(`Type de sanction non supporté via MCP : ${type}`);
+          }
+
+          await prisma.dashboardAuditLog.create({
+            data: {
+              guildId,
+              user: actorTag,
+              action: `Sanction MCP - ${type}`,
+              context: `Cible: ${targetData.tag} (${member_id})`,
+              module: 'MCP',
+              eventType: 'Action',
+              details: `Type: ${type} | Cible: ${targetData.tag} | Raison: ${reason}`,
+              dateIso: new Date(),
+            },
+          });
+
+          return ok({ ok: true, sanctionId: sanction?.id ?? null, type, targetId: member_id });
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          return err(`Erreur lors de l'application de la sanction : ${msg}`);
+        }
+      }
+    );
+  }
+}

--- a/apps/bot/src/api/routes/dashboard.ts
+++ b/apps/bot/src/api/routes/dashboard.ts
@@ -24,6 +24,7 @@ import { handleEventsRoutes } from './dashboard/events.js';
 import { handleGeneralistModulesRoutes } from './dashboard/generalistModules.js';
 import { handleBackupRoutes } from './dashboard/backups.js';
 import { handleScheduleRoutes } from './dashboard/schedules.js';
+import { handleMCPKeyRoutes } from './dashboard/mcp.js';
 
 export async function handleDashboardRoutes(
   req: IncomingMessage,
@@ -171,6 +172,10 @@ export async function handleDashboardRoutes(
       return true;
     }
     if (await handleScheduleRoutes(req, res, parts, url, client, user)) {
+      if (method !== 'GET') await cache.invalidateGuild(guildId);
+      return true;
+    }
+    if (await handleMCPKeyRoutes(req, res, parts, url, client, user, guildId, access)) {
       if (method !== 'GET') await cache.invalidateGuild(guildId);
       return true;
     }

--- a/apps/bot/src/api/routes/dashboard/mcp.ts
+++ b/apps/bot/src/api/routes/dashboard/mcp.ts
@@ -1,0 +1,91 @@
+import { IncomingMessage, ServerResponse } from 'node:http';
+import { Client } from 'discord.js';
+import { json, readJsonBody, type AuthClaims, type DashboardAccess } from '../../shared.js';
+import { logger } from '../../../utils/logger.js';
+import { createMcpKey, getMcpKeys, deactivateMcpKey } from '../../mcp/mcpKeyService.js';
+import type { McpKeyPermission } from '@prisma/client';
+
+const VALID_PERMISSIONS: McpKeyPermission[] = [
+  'READ_STATS',
+  'READ_MEMBERS',
+  'READ_SANCTIONS',
+  'READ_STAFF',
+  'READ_TICKETS',
+  'WRITE_SANCTIONS',
+];
+
+export async function handleMCPKeyRoutes(
+  req: IncomingMessage,
+  res: ServerResponse,
+  parts: string[],
+  _url: URL,
+  _client: Client,
+  _user: AuthClaims,
+  guildId: string,
+  access: DashboardAccess
+): Promise<boolean> {
+  if (parts[4] !== 'mcp-keys') return false;
+
+  const method = req.method;
+
+  if (!access.canManageSettings) {
+    json(res, 403, { error: 'Réservé aux administrateurs du dashboard.' });
+    return true;
+  }
+
+  // GET /api/dashboard/guilds/:guildId/mcp-keys
+  if (parts.length === 5 && method === 'GET') {
+    try {
+      const keys = await getMcpKeys(guildId);
+      json(res, 200, keys);
+    } catch (error) {
+      logger.error('MCPKeyRoutes', 'Error fetching MCP keys:', error);
+      json(res, 500, { error: 'Erreur lors de la récupération des clés MCP' });
+    }
+    return true;
+  }
+
+  // POST /api/dashboard/guilds/:guildId/mcp-keys
+  if (parts.length === 5 && method === 'POST') {
+    try {
+      const body = await readJsonBody<{ name?: string; permissions?: string[] }>(req);
+      if (!body?.name || typeof body.name !== 'string' || !body.name.trim()) {
+        json(res, 400, { error: 'Le champ "name" est requis.' });
+        return true;
+      }
+
+      const permissions: McpKeyPermission[] = (body.permissions ?? ['READ_STATS', 'READ_MEMBERS', 'READ_SANCTIONS'])
+        .filter((p): p is McpKeyPermission => VALID_PERMISSIONS.includes(p as McpKeyPermission));
+
+      const created = await createMcpKey(guildId, body.name.trim(), permissions);
+      json(res, 201, {
+        id: created.id,
+        name: created.name,
+        displayKey: created.displayKey,
+        permissions: created.permissions,
+        isActive: created.isActive,
+        createdAt: created.createdAt,
+        fullKey: created.fullKey,
+      });
+    } catch (error) {
+      logger.error('MCPKeyRoutes', 'Error creating MCP key:', error);
+      json(res, 500, { error: 'Erreur lors de la création de la clé MCP' });
+    }
+    return true;
+  }
+
+  // DELETE /api/dashboard/guilds/:guildId/mcp-keys/:keyId
+  if (parts.length === 6 && method === 'DELETE') {
+    const keyId = parts[5];
+    try {
+      await deactivateMcpKey(guildId, keyId);
+      json(res, 200, { ok: true });
+    } catch (error) {
+      logger.error('MCPKeyRoutes', 'Error deactivating MCP key:', error);
+      json(res, 500, { error: 'Erreur lors de la suppression de la clé MCP' });
+    }
+    return true;
+  }
+
+  return false;
+}

--- a/apps/dashboard/src/App.svelte
+++ b/apps/dashboard/src/App.svelte
@@ -83,6 +83,7 @@
   import UserSettings from "./pages/UserSettings.svelte";
   import Backups from "./pages/Backups.svelte";
   import Schedules from "./pages/Schedules.svelte";
+  import MCPSettings from "./pages/MCPSettings.svelte";
   import FunSettings from "./pages/FunSettings.svelte";
 
   const isPublicPage = $derived(
@@ -153,6 +154,7 @@
     if (path.startsWith("/social-networks")) return "social_networks";
     if (path.startsWith("/backups")) return "settings";
     if (path.startsWith("/schedules")) return "settings";
+    if (path.startsWith("/mcp-settings")) return "settings";
     if (path.startsWith("/fun")) return "fun";
     if (path.startsWith("/admin")) return "centralized_config";
     return null;
@@ -538,7 +540,9 @@
       <Route path="/schedules">
         <Schedules />
       </Route>
-
+      <Route path="/mcp-settings">
+        <MCPSettings />
+      </Route>
 
       <Route path="/events">
         <Events />
@@ -656,6 +660,9 @@
               </Route>
               <Route path="/schedules">
                 <Schedules />
+              </Route>
+              <Route path="/mcp-settings">
+                <MCPSettings />
               </Route>
               <Route path="/automations">
                 <ModuleCatalog />

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -2114,3 +2114,17 @@ export async function updateSanctionTables(tables, guildId = authStore.selectedG
   });
 }
 
+// ── MCP API Keys ────────────────────────────────────────────────────────────
+
+export async function fetchMcpKeys(guildId = authStore.selectedGuildId) {
+  return dashboardRequest('/mcp-keys', { method: 'GET', guildId, errorContext: 'API Error (Fetch MCP Keys):' });
+}
+
+export async function createMcpKey(payload: { name: string; permissions: string[] }, guildId = authStore.selectedGuildId) {
+  return dashboardRequest('/mcp-keys', { method: 'POST', payload, guildId, errorContext: 'API Error (Create MCP Key):' });
+}
+
+export async function deleteMcpKey(keyId: string, guildId = authStore.selectedGuildId) {
+  return dashboardRequest(`/mcp-keys/${keyId}`, { method: 'DELETE', guildId, errorContext: 'API Error (Delete MCP Key):' });
+}
+

--- a/apps/dashboard/src/lib/config/pages.ts
+++ b/apps/dashboard/src/lib/config/pages.ts
@@ -71,6 +71,7 @@ export const configItems: PageConfig[] = [
   { name: "Paramètres",          icon: "settings",      href: "/settings",             featureKey: "settings", beta: false, wip: false },
   { name: "Sauvegardes",         icon: "archive",        href: "/backups",              featureKey: "settings", beta: false, wip: false },
   { name: "Planifications",      icon: "calendar",      href: "/schedules",            featureKey: "settings", beta: true, wip: false },
+  { name: "API MCP",             icon: "cpu",           href: "/mcp-settings",         featureKey: "settings", beta: true, wip: false },
 ];
 
 export const otherPages: PageConfig[] = [

--- a/apps/dashboard/src/pages/MCPSettings.svelte
+++ b/apps/dashboard/src/pages/MCPSettings.svelte
@@ -1,0 +1,317 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { authStore } from '../lib/stores/auth.svelte';
+  import { toast } from '../lib/stores/toast.svelte';
+  import { API_BASE_URL, fetchMcpKeys, createMcpKey, deleteMcpKey } from '../lib/api';
+  import Modal from '../lib/components/Modal.svelte';
+  import ConfirmModal from '../lib/components/ConfirmModal.svelte';
+  import Papicon from '../lib/components/Papicon.svelte';
+
+  const PERMISSIONS = [
+    { value: 'READ_STATS',      label: 'Statistiques du serveur',  desc: 'Accès aux stats (membres, messages, sanctions)' },
+    { value: 'READ_MEMBERS',    label: 'Profils membres',           desc: 'Profils, recherche, messages récents' },
+    { value: 'READ_SANCTIONS',  label: 'Sanctions',                 desc: 'Liste et historique des sanctions' },
+    { value: 'READ_STAFF',      label: 'Staff',                     desc: 'Liste et profils du staff' },
+    { value: 'READ_TICKETS',    label: 'Tickets',                   desc: 'Liste des tickets de support' },
+    { value: 'WRITE_SANCTIONS', label: '⚠ Appliquer des sanctions', desc: 'Permet à l\'IA d\'appliquer des sanctions' },
+  ] as const;
+
+  type McpKey = {
+    id: string;
+    name: string;
+    displayKey: string;
+    permissions: string[];
+    lastUsedAt: string | null;
+    createdAt: string;
+  };
+
+  let keys = $state<McpKey[]>([]);
+  let loading = $state(true);
+
+  // Create modal
+  let createOpen = $state(false);
+  let newKeyName = $state('');
+  let newKeyPerms = $state<string[]>(['READ_STATS', 'READ_MEMBERS', 'READ_SANCTIONS']);
+  let creating = $state(false);
+  let createdKey = $state<{ fullKey: string; name: string } | null>(null);
+  let copied = $state(false);
+
+  // Delete modal
+  let deleteOpen = $state(false);
+  let deletingKeyId = $state<string | null>(null);
+  let deletingKeyName = $state('');
+
+  const guildId = $derived(authStore.selectedGuildId ?? '');
+  const endpointUrl = $derived(guildId ? `${API_BASE_URL}/api/mcp/${guildId}` : '');
+
+  onMount(async () => {
+    await loadKeys();
+  });
+
+  async function loadKeys() {
+    loading = true;
+    try {
+      const result = await fetchMcpKeys();
+      keys = Array.isArray(result) ? result : [];
+    } catch {
+      toast.error('Erreur lors du chargement des clés MCP');
+    } finally {
+      loading = false;
+    }
+  }
+
+  function togglePerm(perm: string) {
+    if (newKeyPerms.includes(perm)) {
+      newKeyPerms = newKeyPerms.filter((p) => p !== perm);
+    } else {
+      newKeyPerms = [...newKeyPerms, perm];
+    }
+  }
+
+  async function handleCreate() {
+    if (!newKeyName.trim()) return;
+    creating = true;
+    try {
+      const result = await createMcpKey({ name: newKeyName.trim(), permissions: newKeyPerms });
+      if (result?.fullKey) {
+        createdKey = { fullKey: result.fullKey, name: result.name };
+        keys = [{ id: result.id, name: result.name, displayKey: result.displayKey, permissions: result.permissions, lastUsedAt: null, createdAt: result.createdAt }, ...keys];
+        newKeyName = '';
+        newKeyPerms = ['READ_STATS', 'READ_MEMBERS', 'READ_SANCTIONS'];
+      }
+    } catch {
+      toast.error('Erreur lors de la création de la clé');
+    } finally {
+      creating = false;
+    }
+  }
+
+  function closeCreateModal() {
+    createOpen = false;
+    createdKey = null;
+    copied = false;
+  }
+
+  async function copyKey(text: string) {
+    await navigator.clipboard.writeText(text).catch(() => {});
+    copied = true;
+    setTimeout(() => { copied = false; }, 2000);
+  }
+
+  function confirmDelete(key: McpKey) {
+    deletingKeyId = key.id;
+    deletingKeyName = key.name;
+    deleteOpen = true;
+  }
+
+  async function handleDelete() {
+    if (!deletingKeyId) return;
+    try {
+      await deleteMcpKey(deletingKeyId);
+      keys = keys.filter((k) => k.id !== deletingKeyId);
+      toast.success('Clé MCP supprimée');
+    } catch {
+      toast.error('Erreur lors de la suppression');
+    } finally {
+      deletingKeyId = null;
+      deletingKeyName = '';
+    }
+  }
+
+  function formatDate(iso: string | null) {
+    if (!iso) return 'Jamais';
+    return new Date(iso).toLocaleDateString('fr-FR', { day: '2-digit', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit' });
+  }
+
+  function permLabel(perm: string) {
+    return PERMISSIONS.find((p) => p.value === perm)?.label ?? perm;
+  }
+</script>
+
+<div class="space-y-8 max-w-4xl">
+
+  <!-- Header -->
+  <div>
+    <h1 class="text-2xl font-bold text-white">MCP (Model Context Protocol)</h1>
+    <p class="mt-1 text-sm text-gray-400">
+      Permet à des agents IA de lire les données de ton serveur Discord et d'effectuer des actions via le protocole MCP.
+    </p>
+  </div>
+
+  <!-- Endpoint URL -->
+  <div class="bg-[#1a1d23] border border-white/8 rounded-xl p-5 space-y-3">
+    <div class="flex items-center gap-2 text-sm font-medium text-gray-300">
+      <Papicon name="Link" size={16} class="text-primary" />
+      Endpoint MCP
+    </div>
+    <div class="flex items-center gap-2">
+      <code class="flex-1 bg-black/30 border border-white/10 rounded-lg px-3 py-2 text-sm text-gray-200 font-mono break-all">
+        {endpointUrl || 'Sélectionne un serveur pour voir l\'URL'}
+      </code>
+      {#if endpointUrl}
+        <button
+          onclick={() => copyKey(endpointUrl)}
+          class="shrink-0 px-3 py-2 rounded-lg border border-white/10 text-sm text-gray-300 hover:bg-white/5 transition-colors"
+        >
+          {copied ? 'Copié !' : 'Copier'}
+        </button>
+      {/if}
+    </div>
+    <p class="text-xs text-gray-500">
+      Utilise cette URL avec <code class="text-gray-400">Authorization: Bearer mcp_...</code> dans ton client MCP.
+    </p>
+  </div>
+
+  <!-- Keys section -->
+  <div class="space-y-4">
+    <div class="flex items-center justify-between">
+      <h2 class="text-base font-semibold text-white">Clés API MCP</h2>
+      <button
+        onclick={() => { createOpen = true; createdKey = null; }}
+        class="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary/90 text-white rounded-lg text-sm font-medium transition-colors shadow-lg shadow-primary/20"
+      >
+        <Papicon name="Plus" size={16} />
+        Créer une clé
+      </button>
+    </div>
+
+    {#if loading}
+      <div class="flex items-center justify-center py-12 text-gray-500">
+        <Papicon name="Loader2" size={20} class="animate-spin mr-2" />
+        Chargement…
+      </div>
+    {:else if keys.length === 0}
+      <div class="bg-[#1a1d23] border border-white/8 rounded-xl p-10 text-center">
+        <Papicon name="Key" size={32} class="text-gray-600 mx-auto mb-3" />
+        <p class="text-gray-400 text-sm">Aucune clé MCP configurée.</p>
+        <p class="text-gray-600 text-xs mt-1">Crée une clé pour connecter ton agent IA.</p>
+      </div>
+    {:else}
+      <div class="bg-[#1a1d23] border border-white/8 rounded-xl overflow-hidden">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-white/8 text-gray-500 text-xs">
+              <th class="text-left px-4 py-3 font-medium">Nom</th>
+              <th class="text-left px-4 py-3 font-medium">Clé (masquée)</th>
+              <th class="text-left px-4 py-3 font-medium">Permissions</th>
+              <th class="text-left px-4 py-3 font-medium">Dernière utilisation</th>
+              <th class="px-4 py-3"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each keys as key (key.id)}
+              <tr class="border-b border-white/5 last:border-0 hover:bg-white/2 transition-colors">
+                <td class="px-4 py-3 font-medium text-white">{key.name}</td>
+                <td class="px-4 py-3 font-mono text-gray-400">{key.displayKey}</td>
+                <td class="px-4 py-3">
+                  <div class="flex flex-wrap gap-1">
+                    {#each key.permissions as perm}
+                      <span class="px-2 py-0.5 rounded-full text-xs font-medium
+                        {perm === 'WRITE_SANCTIONS' ? 'bg-red-500/15 text-red-400' : 'bg-primary/15 text-primary'}">
+                        {permLabel(perm)}
+                      </span>
+                    {/each}
+                  </div>
+                </td>
+                <td class="px-4 py-3 text-gray-500 text-xs">{formatDate(key.lastUsedAt)}</td>
+                <td class="px-4 py-3">
+                  <button
+                    onclick={() => confirmDelete(key)}
+                    class="p-1.5 rounded-lg text-gray-500 hover:text-red-400 hover:bg-red-500/10 transition-colors"
+                    title="Supprimer"
+                  >
+                    <Papicon name="Trash2" size={15} />
+                  </button>
+                </td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+    {/if}
+  </div>
+</div>
+
+<!-- Create Modal -->
+<Modal bind:open={createOpen} onClose={closeCreateModal} title={createdKey ? 'Clé créée !' : 'Créer une clé MCP'}>
+  {#if createdKey}
+    <div class="space-y-4">
+      <div class="flex items-center gap-2 p-3 bg-amber-500/10 border border-amber-500/20 rounded-lg">
+        <Papicon name="AlertTriangle" size={16} class="text-amber-400 shrink-0" />
+        <p class="text-sm text-amber-300">
+          Copie cette clé maintenant. Elle ne sera <strong>plus jamais affichée</strong>.
+        </p>
+      </div>
+      <div>
+        <label class="block text-xs text-gray-500 mb-1">Clé pour <strong class="text-gray-300">{createdKey.name}</strong></label>
+        <div class="flex items-center gap-2">
+          <code class="flex-1 bg-black/30 border border-white/10 rounded-lg px-3 py-2 text-sm font-mono text-green-400 break-all">
+            {createdKey.fullKey}
+          </code>
+          <button
+            onclick={() => copyKey(createdKey!.fullKey)}
+            class="shrink-0 px-3 py-2 rounded-lg border border-white/10 text-sm text-gray-300 hover:bg-white/5 transition-colors"
+          >
+            {copied ? 'Copié !' : 'Copier'}
+          </button>
+        </div>
+      </div>
+      <button onclick={closeCreateModal} class="w-full py-2 rounded-lg bg-primary hover:bg-primary/90 text-white text-sm font-medium transition-colors">
+        C'est fait, j'ai copié la clé
+      </button>
+    </div>
+  {:else}
+    <div class="space-y-5">
+      <div>
+        <label class="block text-sm font-medium text-gray-300 mb-1.5">Nom de la clé</label>
+        <input
+          type="text"
+          bind:value={newKeyName}
+          placeholder="Ex: Claude Desktop, Mon agent IA…"
+          class="w-full bg-black/20 border border-white/10 rounded-lg px-3 py-2 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-primary/50"
+        />
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-gray-300 mb-2">Permissions</label>
+        <div class="space-y-2">
+          {#each PERMISSIONS as perm}
+            <label class="flex items-start gap-3 p-3 rounded-lg border cursor-pointer transition-colors
+              {newKeyPerms.includes(perm.value)
+                ? perm.value === 'WRITE_SANCTIONS' ? 'border-red-500/30 bg-red-500/5' : 'border-primary/30 bg-primary/5'
+                : 'border-white/8 hover:border-white/15'}">
+              <input
+                type="checkbox"
+                checked={newKeyPerms.includes(perm.value)}
+                onchange={() => togglePerm(perm.value)}
+                class="mt-0.5 accent-primary"
+              />
+              <div>
+                <span class="text-sm font-medium text-white">{perm.label}</span>
+                <p class="text-xs text-gray-500 mt-0.5">{perm.desc}</p>
+              </div>
+            </label>
+          {/each}
+        </div>
+      </div>
+
+      <button
+        onclick={handleCreate}
+        disabled={!newKeyName.trim() || newKeyPerms.length === 0 || creating}
+        class="w-full py-2.5 rounded-lg bg-primary hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed text-white text-sm font-medium transition-colors"
+      >
+        {creating ? 'Création…' : 'Créer la clé'}
+      </button>
+    </div>
+  {/if}
+</Modal>
+
+<!-- Delete Confirm -->
+<ConfirmModal
+  bind:open={deleteOpen}
+  title="Supprimer la clé MCP"
+  description="La clé «{deletingKeyName}» sera désactivée immédiatement. Les clients qui l'utilisent perdront l'accès."
+  variant="danger"
+  confirmLabel="Supprimer"
+  onConfirm={handleDelete}
+/>

--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
       "name": "@kotbo/bot",
       "dependencies": {
         "@kotbo/database": "workspace:*",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@napi-rs/canvas": "^0.1.100",
         "@prisma/adapter-pg": "^7.8.0",
         "@prisma/client": "^7.8.0",
@@ -192,6 +193,8 @@
     "@kotbo/database": ["@kotbo/database@workspace:packages/database"],
 
     "@kurkle/color": ["@kurkle/color@0.3.4", "", {}, "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
 
@@ -537,6 +540,8 @@
 
     "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
     "anser": ["anser@1.4.10", "", {}, "sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
@@ -571,6 +576,8 @@
 
     "better-result": ["better-result@2.9.2", "", {}, "sha512-WIFoBPCdnTOdk9inkE1ZRvCZ4P0CpSkAiLlchC65N7n9DcjZ3NhqkBOlafzpOVnO8ixyi37kicmSJ3ENhPZl7Q=="],
 
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
+
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
     "brace-expansion": ["brace-expansion@1.1.15", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg=="],
@@ -589,7 +596,13 @@
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
     "c12": ["c12@3.3.4", "", { "dependencies": { "chokidar": "^5.0.0", "confbox": "^0.2.4", "defu": "^6.1.6", "dotenv": "^17.3.1", "exsolve": "^1.0.8", "giget": "^3.2.0", "jiti": "^2.6.1", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^2.1.0", "pkg-types": "^2.3.0", "rc9": "^3.0.1" }, "peerDependencies": { "magicast": "*" }, "optionalPeers": ["magicast"] }, "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
@@ -639,9 +652,15 @@
 
     "connect": ["connect@3.7.0", "", { "dependencies": { "debug": "2.6.9", "finalhandler": "1.1.2", "parseurl": "~1.3.3", "utils-merge": "1.0.1" } }, "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ=="],
 
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
@@ -703,6 +722,8 @@
 
     "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
@@ -732,6 +753,12 @@
     "env-paths": ["env-paths@3.0.0", "", {}, "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A=="],
 
     "error-stack-parser": ["error-stack-parser@2.1.4", "", { "dependencies": { "stackframe": "^1.3.4" } }, "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -763,7 +790,15 @@
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
+
     "exponential-backoff": ["exponential-backoff@3.1.3", "", {}, "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
 
     "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
 
@@ -795,7 +830,7 @@
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
-    "finalhandler": ["finalhandler@1.1.2", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~1.0.2", "escape-html": "~1.0.3", "on-finished": "~2.3.0", "parseurl": "~1.3.3", "statuses": "~1.5.0", "unpipe": "~1.0.0" } }, "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA=="],
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
@@ -807,6 +842,8 @@
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
     "forwarded-parse": ["forwarded-parse@2.1.2", "", {}, "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw=="],
 
     "frac": ["frac@1.1.2", "", {}, "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA=="],
@@ -815,11 +852,13 @@
 
     "franc-min": ["franc-min@6.2.0", "", { "dependencies": { "trigram-utils": "^2.0.0" } }, "sha512-1uDIEUSlUZgvJa2AKYR/dmJC66v/PvGQ9mWfI9nOr/kPpMFyvswK0gPXOwpYJYiYD008PpHLkGfG58SPjQJFxw=="],
 
-    "fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
     "generate-function": ["generate-function@2.3.1", "", { "dependencies": { "is-property": "^1.0.2" } }, "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ=="],
 
@@ -827,7 +866,11 @@
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
     "get-port-please": ["get-port-please@3.2.0", "", {}, "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "giget": ["giget@3.2.0", "", { "bin": { "giget": "dist/cli.mjs" } }, "sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A=="],
 
@@ -839,6 +882,8 @@
 
     "globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
 
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "grammex": ["grammex@3.1.12", "", {}, "sha512-6ufJOsSA7LcQehIJNCO7HIBykfM7DXQual0Ny780/DEcJIpBlHRvcqEBWGPYd7hrXL2GJ3oJI1MIhaXjWmLQOQ=="],
@@ -848,6 +893,10 @@
     "graphmatch": ["graphmatch@1.1.1", "", {}, "sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
     "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
 
@@ -885,6 +934,10 @@
 
     "ioredis": ["ioredis@5.10.1", "", { "dependencies": { "@ioredis/commands": "1.5.1", "cluster-key-slot": "^1.1.0", "debug": "^4.3.4", "denque": "^2.1.0", "lodash.defaults": "^4.2.0", "lodash.isarguments": "^3.1.0", "redis-errors": "^1.2.0", "redis-parser": "^3.0.0", "standard-as-callback": "^2.1.0" } }, "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA=="],
 
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
     "is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
@@ -896,6 +949,8 @@
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "is-path-inside": ["is-path-inside@3.0.3", "", {}, "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "is-property": ["is-property@1.0.2", "", {}, "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="],
 
@@ -915,6 +970,8 @@
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+
     "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
@@ -928,6 +985,8 @@
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
@@ -1023,9 +1082,15 @@
 
     "marky": ["marky@1.3.0", "", {}, "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
     "mdn-data": ["mdn-data@2.0.14", "", {}, "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="],
 
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
     "memoize-one": ["memoize-one@5.2.1", "", {}, "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 
@@ -1063,9 +1128,9 @@
 
     "mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
 
-    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
-    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
@@ -1113,13 +1178,15 @@
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
 
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
 
-    "on-finished": ["on-finished@2.3.0", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww=="],
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
@@ -1140,6 +1207,8 @@
     "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
 
@@ -1175,6 +1244,8 @@
 
     "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
 
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
     "pkg-types": ["pkg-types@2.3.1", "", { "dependencies": { "confbox": "^0.2.4", "exsolve": "^1.0.8", "pathe": "^2.0.3" } }, "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg=="],
 
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
@@ -1203,11 +1274,15 @@
 
     "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
 
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+
+    "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
 
     "queue": ["queue@6.0.2", "", { "dependencies": { "inherits": "~2.0.3" } }, "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA=="],
 
@@ -1216,6 +1291,8 @@
     "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
 
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "rc9": ["rc9@3.0.1", "", { "dependencies": { "defu": "^6.1.6", "destr": "^2.0.5" } }, "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ=="],
 
@@ -1261,6 +1338,8 @@
 
     "rolldown": ["rolldown@1.0.3", "", { "dependencies": { "@oxc-project/types": "=0.133.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.3", "@rolldown/binding-darwin-arm64": "1.0.3", "@rolldown/binding-darwin-x64": "1.0.3", "@rolldown/binding-freebsd-x64": "1.0.3", "@rolldown/binding-linux-arm-gnueabihf": "1.0.3", "@rolldown/binding-linux-arm64-gnu": "1.0.3", "@rolldown/binding-linux-arm64-musl": "1.0.3", "@rolldown/binding-linux-ppc64-gnu": "1.0.3", "@rolldown/binding-linux-s390x-gnu": "1.0.3", "@rolldown/binding-linux-x64-gnu": "1.0.3", "@rolldown/binding-linux-x64-musl": "1.0.3", "@rolldown/binding-openharmony-arm64": "1.0.3", "@rolldown/binding-wasm32-wasi": "1.0.3", "@rolldown/binding-win32-arm64-msvc": "1.0.3", "@rolldown/binding-win32-x64-msvc": "1.0.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
     "rss-parser": ["rss-parser@3.13.0", "", { "dependencies": { "entities": "^2.0.3", "xml2js": "^0.5.0" } }, "sha512-7jWUBV5yGN3rqMMj7CZufl/291QAhvrrGpDNE4k/02ZchL0npisiYYqULF71jCEKoIiHvK/Q2e6IkDwPziT7+w=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
@@ -1279,13 +1358,13 @@
 
     "semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
 
-    "send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
     "seq-queue": ["seq-queue@0.0.5", "", {}, "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="],
 
     "serialize-error": ["serialize-error@2.1.0", "", {}, "sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw=="],
 
-    "serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
@@ -1294,6 +1373,14 @@
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
     "shell-quote": ["shell-quote@1.8.4", "", {}, "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="],
+
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
@@ -1327,7 +1414,7 @@
 
     "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="],
 
-    "statuses": ["statuses@1.5.0", "", {}, "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="],
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
@@ -1374,6 +1461,8 @@
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
     "type-fest": ["type-fest@0.20.2", "", {}, "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
@@ -1445,6 +1534,10 @@
 
     "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
 
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
@@ -1467,6 +1560,8 @@
 
     "@kotbo/database/dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
 
+    "@modelcontextprotocol/sdk/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
     "@opentelemetry/instrumentation-http/@opentelemetry/core": ["@opentelemetry/core@2.6.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g=="],
 
     "@opentelemetry/instrumentation-pg/@types/pg": ["@types/pg@8.15.6", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ=="],
@@ -1484,6 +1579,8 @@
     "@react-native/codegen/tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
     "@react-native/community-cli-plugin/semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
+
+    "@react-native/dev-middleware/serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
 
     "@react-native/dev-middleware/ws": ["ws@7.5.11", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA=="],
 
@@ -1503,9 +1600,17 @@
 
     "@typescript-eslint/typescript-estree/semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
 
+    "accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "ajv-formats/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
     "c12/dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
 
     "connect/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "connect/finalhandler": ["finalhandler@1.1.2", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~1.0.2", "escape-html": "~1.0.3", "on-finished": "~2.3.0", "parseurl": "~1.3.3", "statuses": "~1.5.0", "unpipe": "~1.0.0" } }, "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA=="],
 
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
@@ -1513,13 +1618,9 @@
 
     "engine.io-client/ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
+    "express/accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
-
-    "finalhandler/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
-
-    "finalhandler/encodeurl": ["encodeurl@1.0.2", "", {}, "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="],
-
-    "http-errors/statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "jest-util/ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
 
@@ -1534,8 +1635,6 @@
     "metro/accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "metro/hermes-parser": ["hermes-parser@0.35.0", "", { "dependencies": { "hermes-estree": "0.35.0" } }, "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA=="],
-
-    "metro/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "metro/source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
 
@@ -1569,17 +1668,13 @@
 
     "react-native/ws": ["ws@7.5.11", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA=="],
 
-    "send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
-
-    "send/on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
-
-    "send/statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
-
     "socket.io-adapter/ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
     "stacktrace-parser/type-fest": ["type-fest@0.7.1", "", {}, "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="],
 
     "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
+
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "@fastify/otel/@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.212.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg=="],
 
@@ -1591,17 +1686,31 @@
 
     "@kotbo/dashboard/vite/tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
+    "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
     "@prisma/instrumentation/@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.207.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ=="],
 
     "@prisma/instrumentation/@opentelemetry/instrumentation/import-in-the-middle": ["import-in-the-middle@2.0.6", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw=="],
 
     "@prisma/streams-local/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
+    "@react-native/dev-middleware/serve-static/send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
+
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.1.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA=="],
+
+    "accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "connect/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
-    "finalhandler/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+    "connect/finalhandler/encodeurl": ["encodeurl@1.0.2", "", {}, "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="],
+
+    "connect/finalhandler/on-finished": ["on-finished@2.3.0", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww=="],
+
+    "connect/finalhandler/statuses": ["statuses@1.5.0", "", {}, "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="],
+
+    "express/accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "lighthouse-logger/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
@@ -1611,11 +1720,7 @@
 
     "metro/hermes-parser/hermes-estree": ["hermes-estree@0.35.0", "", {}, "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg=="],
 
-    "metro/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
-
     "p-locate/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
-
-    "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "@fastify/otel/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
@@ -1652,5 +1757,11 @@
     "@kotbo/dashboard/vite/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.10", "", { "os": "win32", "cpu": "x64" }, "sha512-PYxKHMVHOb5NJuDL53vBUl1VwUjymDcYI6rzpIni0C9+9mTiJedvUxSk7/RPp7OOAm3v+EjgMu9bIy3N6b408w=="],
 
     "@kotbo/dashboard/vite/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.10", "", {}, "sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg=="],
+
+    "@react-native/dev-middleware/serve-static/send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "@react-native/dev-middleware/serve-static/send/fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
+
+    "@react-native/dev-middleware/serve-static/send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
   }
 }

--- a/packages/database/prisma/guild.prisma
+++ b/packages/database/prisma/guild.prisma
@@ -216,6 +216,8 @@ model Guild {
   staffTasks StaffTask[]
   staffCalls StaffCall[]
 
+  mcpApiKeys McpApiKey[]
+
   @@map("guilds")
 }
 

--- a/packages/database/prisma/mcp.prisma
+++ b/packages/database/prisma/mcp.prisma
@@ -1,0 +1,31 @@
+// ============================================================================
+// MCP (MODEL CONTEXT PROTOCOL) — ACCÈS MACHINE-TO-MACHINE POUR AGENTS IA
+// ============================================================================
+
+enum McpKeyPermission {
+  READ_STATS
+  READ_MEMBERS
+  READ_SANCTIONS
+  READ_STAFF
+  READ_TICKETS
+  WRITE_SANCTIONS
+}
+
+model McpApiKey {
+  id          String   @id @default(cuid())
+  guildId     String
+  guild       Guild    @relation(fields: [guildId], references: [id], onDelete: Cascade)
+
+  name        String
+  keyHash     String   @unique
+  displayKey  String
+  permissions McpKeyPermission[]
+  isActive    Boolean  @default(true)
+  lastUsedAt  DateTime?
+
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@index([guildId, isActive])
+  @@map("mcp_api_keys")
+}

--- a/packages/database/prisma/migrations/20260621000000_add_mcp_api_keys/migration.sql
+++ b/packages/database/prisma/migrations/20260621000000_add_mcp_api_keys/migration.sql
@@ -1,0 +1,27 @@
+-- CreateEnum
+CREATE TYPE "McpKeyPermission" AS ENUM ('READ_STATS', 'READ_MEMBERS', 'READ_SANCTIONS', 'READ_STAFF', 'READ_TICKETS', 'WRITE_SANCTIONS');
+
+-- CreateTable
+CREATE TABLE "mcp_api_keys" (
+    "id" TEXT NOT NULL,
+    "guildId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "keyHash" TEXT NOT NULL,
+    "displayKey" TEXT NOT NULL,
+    "permissions" "McpKeyPermission"[] DEFAULT ARRAY[]::"McpKeyPermission"[],
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "lastUsedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "mcp_api_keys_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "mcp_api_keys_keyHash_key" ON "mcp_api_keys"("keyHash");
+
+-- CreateIndex
+CREATE INDEX "mcp_api_keys_guildId_isActive_idx" ON "mcp_api_keys"("guildId", "isActive");
+
+-- AddForeignKey
+ALTER TABLE "mcp_api_keys" ADD CONSTRAINT "mcp_api_keys_guildId_fkey" FOREIGN KEY ("guildId") REFERENCES "guilds"("id") ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION
Expose les données du serveur Discord via le protocole MCP (Model Context Protocol) afin qu'un agent IA puisse interroger stats, sanctions, membres, staff et tickets, et appliquer des sanctions.

- Nouveau modèle McpApiKey avec enum McpKeyPermission (6 permissions granulaires)
- Migration SQL 20260621000000_add_mcp_api_keys
- Endpoint POST /api/mcp/:guildId avec auth Bearer, rate limit 100 req/min
- 10 outils MCP : get_guild_stats, get_recent_messages, get_sanctions, get_sanction_history, get_member_profile, search_members, get_staff_list, get_staff_member, get_tickets, apply_sanction
- Routes CRUD GET/POST/DELETE /api/dashboard/guilds/:guildId/mcp-keys
- Page settings MCPSettings.svelte avec gestion des clés (création one-time display, liste avec permissions, révocation)
- SDK @modelcontextprotocol/sdk@1.29.0 — transport Streamable HTTP stateless