### PR TITLE
Feat/clans Add database schema, migration, API endpoints, bot command, dashboard settings page and public clans ranking page.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,27 +1,55 @@
 ## 📝 Description
-<!-- Décris brièvement les modifications apportées par cette PR (correctif, nouvelle fonctionnalité, optimisation...). -->
+Cette PR implémente le module complet de **Clans** pour Kotbo. Elle intègre la structure de données (Prisma), les APIs d'administration, les services asynchrones sécurisés pour Discord (rate-limiting de masse), les commandes slash pour les membres, et les interfaces web (panneau d'administration et classement public).
 
+---
 
 ## 🎯 Changements principaux
-<!-- Liste les points clés de tes modifications -->
-- 
-- 
 
+### 1. Base de données & Migrations
+- **Schéma Prisma** : Modèles `Clan` (associé à un rôle Discord unique) et `ClanMemberContribution` (suivi de l'XP par joueur, clan et saison).
+- **Migration SQL** : Script `20260713164100_add_clan_system` pour automatiser la mise à jour des tables en production.
+- **Rétention des points** : Les points gagnés par un joueur restent associés au clan d'origine même si le joueur quitte ou change de clan en cours de saison.
+
+### 2. API Backend & Services Discord
+- **REST API** : CRUD pour les clans, exécution de tâches de masse et reset de saison.
+- **API Publique** : Endpoint `/api/public/guilds/:guildId/clans` pour exposer les classements sans authentification.
+- **Auto-mod & Unicité** : Sécurité dans `clanEvents.ts` forçant un seul clan par membre Discord, avec alertes de modération et logs d'audit.
+- **Rate-Limit Guard** : Processus d'arrière-plan (`clanService.ts`) cadencé à 450ms/appel pour distribuer ou retirer les rôles sans subir de ban de l'API Discord.
+- **Gain d'XP** : Intégration dans `levelingService.ts` pour créditer automatiquement l'XP d'activité (écrit/vocal) sur le clan actif du membre.
+
+### 3. Commandes Slash Discord
+- **/clan list** : Liste les clans configurés.
+- **/clan leaderboard** : Affiche le classement général des clans pour la saison active.
+- **/clan info <clan>** : Détails d'un clan et top 10 des contributeurs de la saison (avec autocomplétion).
+- **/clan distribute** & **/clan clear** : Commandes réservées aux administrateurs pour lancer les processus de masse.
+
+### 4. Interface Web (Svelte 5)
+- **Panneau d'administration** : Page `Clans.svelte` pour configurer le module, créer/éditer des clans et suivre l'avancement live des tâches de masse.
+- **Sécurités de confirmation** : Fenêtre de double-validation exigeant la saisie d'un mot-clé (`DISTRIBUER`, `RETIRER`, `RESET`) avant chaque action destructive ou lourde.
+- **Classement Public** : Page responsive `LevelingClanPublic.svelte` (route `/:serverId/leveling/clan`) permettant de consulter le classement des clans et le top des participants (avec recherche par pseudo).
+
+---
 
 ## 🧪 Comment tester ?
-<!-- Explique comment vérifier que tes modifications fonctionnent en dev local -->
-1. 
-2. 
 
+1. **Migration** : Exécuter la migration Prisma sur le serveur de dev.
+2. **Configuration** : Activer le module de clans depuis le Dashboard Kotbo, créer 2 clans et leur assigner des rôles Discord distincts.
+3. **Distribution** : Cliquer sur le bouton **Distribuer** sur le Dashboard, saisir le mot-clé de validation et vérifier le bon déroulement progressif de la tâche (barre de progression).
+4. **Gain de points** : Envoyer des messages ou passer du temps en vocal avec un rôle de clan actif, puis vérifier l'incrémentation via `/clan leaderboard`.
+5. **Changement de clan** : Changer manuellement le rôle de clan d'un membre de test, gagner des points à nouveau, et vérifier avec `/clan info` que l'historique des points dans l'ancien clan est bien préservé.
+6. **Sécurité Unique** : Ajouter manuellement un deuxième rôle de clan à un membre et vérifier que le bot lui retire automatiquement le premier rôle avec un avertissement de log.
+7. **Reset** : Effectuer un reset de saison et vérifier que le compteur passe à la saison supérieure et remet les scores à 0.
+
+---
 
 ## ⚓ Liens / Issues
-<!-- Si cette PR ferme une issue existante, écris "Closes #numéro_issue" -->
-- Closes #
+- Closes # (Clans Integration)
 
+---
 
 ## 📜 Validation des conditions
 *En soumettant cette Pull Request, vous devez valider les points suivants :*
 
-- [ ] Mes modifications respectent le style de code du projet.
-- [ ] J'ai testé mon code en local et il s'exécute sans erreur.
-- [ ] **J'accepte que ma contribution soit intégrée au projet Kotbo sous les termes de sa licence (Source-Available) et cède les droits d'exploitation associés à la structure Kotbo.**
+- [x] Mes modifications respectent le style de code du projet.
+- [x] J'ai testé mon code en local et il s'exécute sans erreur.
+- [x] **J'accepte que ma contribution soit intégrée au projet Kotbo sous les termes de sa licence (Source-Available) et cède les droits d'exploitation associés à la structure Kotbo.**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,55 +1,27 @@
 ## 📝 Description
-Cette PR implémente le module complet de **Clans** pour Kotbo. Elle intègre la structure de données (Prisma), les APIs d'administration, les services asynchrones sécurisés pour Discord (rate-limiting de masse), les commandes slash pour les membres, et les interfaces web (panneau d'administration et classement public).
+<!-- Décris brièvement les modifications apportées par cette PR (correctif, nouvelle fonctionnalité, optimisation...). -->
 
----
 
 ## 🎯 Changements principaux
+<!-- Liste les points clés de tes modifications -->
+- 
+- 
 
-### 1. Base de données & Migrations
-- **Schéma Prisma** : Modèles `Clan` (associé à un rôle Discord unique) et `ClanMemberContribution` (suivi de l'XP par joueur, clan et saison).
-- **Migration SQL** : Script `20260713164100_add_clan_system` pour automatiser la mise à jour des tables en production.
-- **Rétention des points** : Les points gagnés par un joueur restent associés au clan d'origine même si le joueur quitte ou change de clan en cours de saison.
-
-### 2. API Backend & Services Discord
-- **REST API** : CRUD pour les clans, exécution de tâches de masse et reset de saison.
-- **API Publique** : Endpoint `/api/public/guilds/:guildId/clans` pour exposer les classements sans authentification.
-- **Auto-mod & Unicité** : Sécurité dans `clanEvents.ts` forçant un seul clan par membre Discord, avec alertes de modération et logs d'audit.
-- **Rate-Limit Guard** : Processus d'arrière-plan (`clanService.ts`) cadencé à 450ms/appel pour distribuer ou retirer les rôles sans subir de ban de l'API Discord.
-- **Gain d'XP** : Intégration dans `levelingService.ts` pour créditer automatiquement l'XP d'activité (écrit/vocal) sur le clan actif du membre.
-
-### 3. Commandes Slash Discord
-- **/clan list** : Liste les clans configurés.
-- **/clan leaderboard** : Affiche le classement général des clans pour la saison active.
-- **/clan info <clan>** : Détails d'un clan et top 10 des contributeurs de la saison (avec autocomplétion).
-- **/clan distribute** & **/clan clear** : Commandes réservées aux administrateurs pour lancer les processus de masse.
-
-### 4. Interface Web (Svelte 5)
-- **Panneau d'administration** : Page `Clans.svelte` pour configurer le module, créer/éditer des clans et suivre l'avancement live des tâches de masse.
-- **Sécurités de confirmation** : Fenêtre de double-validation exigeant la saisie d'un mot-clé (`DISTRIBUER`, `RETIRER`, `RESET`) avant chaque action destructive ou lourde.
-- **Classement Public** : Page responsive `LevelingClanPublic.svelte` (route `/:serverId/leveling/clan`) permettant de consulter le classement des clans et le top des participants (avec recherche par pseudo).
-
----
 
 ## 🧪 Comment tester ?
+<!-- Explique comment vérifier que tes modifications fonctionnent en dev local -->
+1. 
+2. 
 
-1. **Migration** : Exécuter la migration Prisma sur le serveur de dev.
-2. **Configuration** : Activer le module de clans depuis le Dashboard Kotbo, créer 2 clans et leur assigner des rôles Discord distincts.
-3. **Distribution** : Cliquer sur le bouton **Distribuer** sur le Dashboard, saisir le mot-clé de validation et vérifier le bon déroulement progressif de la tâche (barre de progression).
-4. **Gain de points** : Envoyer des messages ou passer du temps en vocal avec un rôle de clan actif, puis vérifier l'incrémentation via `/clan leaderboard`.
-5. **Changement de clan** : Changer manuellement le rôle de clan d'un membre de test, gagner des points à nouveau, et vérifier avec `/clan info` que l'historique des points dans l'ancien clan est bien préservé.
-6. **Sécurité Unique** : Ajouter manuellement un deuxième rôle de clan à un membre et vérifier que le bot lui retire automatiquement le premier rôle avec un avertissement de log.
-7. **Reset** : Effectuer un reset de saison et vérifier que le compteur passe à la saison supérieure et remet les scores à 0.
-
----
 
 ## ⚓ Liens / Issues
-- Closes # (Clans Integration)
+<!-- Si cette PR ferme une issue existante, écris "Closes #numéro_issue" -->
+- Closes #
 
----
 
 ## 📜 Validation des conditions
 *En soumettant cette Pull Request, vous devez valider les points suivants :*
 
-- [x] Mes modifications respectent le style de code du projet.
-- [x] J'ai testé mon code en local et il s'exécute sans erreur.
-- [x] **J'accepte que ma contribution soit intégrée au projet Kotbo sous les termes de sa licence (Source-Available) et cède les droits d'exploitation associés à la structure Kotbo.**
+- [ ] Mes modifications respectent le style de code du projet.
+- [ ] J'ai testé mon code en local et il s'exécute sans erreur.
+- [ ] **J'accepte que ma contribution soit intégrée au projet Kotbo sous les termes de sa licence (Source-Available) et cède les droits d'exploitation associés à la structure Kotbo.**

--- a/apps/bot/src/api/routes/dashboard.ts
+++ b/apps/bot/src/api/routes/dashboard.ts
@@ -41,6 +41,7 @@ import { handleMarketplaceRoutes } from './dashboard/marketplace.js';
 import { handleQuestRoutes } from './dashboard/quests.js';
 import { handleWidgetRoutes } from './dashboard/widget.js';
 import { handleMessageLogRoutes } from './dashboard/messageLogs.js';
+import { handleClansRoutes } from './dashboard/clans.js';
 
 export async function handleDashboardRoutes(
   req: IncomingMessage,
@@ -257,6 +258,12 @@ export async function handleDashboardRoutes(
     if (await handleMessageLogRoutes(req, res, parts, url, client, user, guildId, access)) {
       if (method !== 'GET') await cache.invalidateGuild(guildId);
       return true;
+    }
+    if (parts[4] === 'clans') {
+      if (await handleClansRoutes(req, res, parts, client, user, guildId, access)) {
+        if (method !== 'GET') await cache.invalidateGuild(guildId);
+        return true;
+      }
     }
   }
 

--- a/apps/bot/src/api/routes/dashboard/clans.ts
+++ b/apps/bot/src/api/routes/dashboard/clans.ts
@@ -1,0 +1,342 @@
+import { IncomingMessage, ServerResponse } from 'node:http';
+import { Client } from 'discord.js';
+import prisma from '../../../utils/db.js';
+import { logger } from '../../../utils/logger.js';
+import { json, readJsonBody, getGuildName, pushAudit, type AuthClaims, type DashboardAccess } from '../../shared.js';
+import { clanTasks, runDistribution, runClear } from '../../../services/community/clanService.js';
+
+export async function handleClansRoutes(
+  req: IncomingMessage,
+  res: ServerResponse,
+  parts: string[],
+  client: Client,
+  user: AuthClaims,
+  guildId: string,
+  _access: DashboardAccess
+): Promise<boolean> {
+  const method = req.method;
+  const auditUser = `${user.username} (${user.userId})`;
+
+  // Path matches: /api/dashboard/guilds/:guildId/clans/...
+  const subAction = parts[5]; // undefined | id | distribute | clear | reset-season
+
+  // GET /api/dashboard/guilds/:guildId/clans
+  if (!subAction && method === 'GET') {
+    try {
+      const guildData = await prisma.guild.findUnique({
+        where: { id: guildId },
+        select: {
+          clansEnabled: true,
+          clansUnique: true,
+          currentClanSeason: true,
+        },
+      });
+
+      if (!guildData) {
+        json(res, 404, { error: 'Serveur non trouvé en base de données.' });
+        return true;
+      }
+
+      const clans = await prisma.clan.findMany({
+        where: { guildId },
+        orderBy: { name: 'asc' },
+      });
+
+      // Calculer dynamiquement le nombre de membres et l'XP de la saison en cours pour chaque clan
+      const discordGuild = client.guilds.cache.get(guildId) || await client.guilds.fetch(guildId).catch(() => null);
+      
+      const clansWithStats = await Promise.all(
+        clans.map(async (clan) => {
+          // Nombre de membres réels ayant le rôle actuellement
+          const memberCount = discordGuild?.roles.cache.get(clan.roleId)?.members.size ?? 0;
+
+          // Somme des contributions d'XP pour la saison active
+          const aggregate = await prisma.clanMemberContribution.aggregate({
+            where: {
+              guildId,
+              clanId: clan.id,
+              season: guildData.currentClanSeason,
+            },
+            _sum: { xp: true },
+          });
+
+          return {
+            ...clan,
+            memberCount,
+            totalXp: aggregate._sum.xp ?? 0,
+          };
+        })
+      );
+
+      const taskInProgress = clanTasks.get(guildId) || null;
+
+      json(res, 200, {
+        clansEnabled: guildData.clansEnabled,
+        clansUnique: guildData.clansUnique,
+        currentClanSeason: guildData.currentClanSeason,
+        clans: clansWithStats,
+        taskInProgress,
+      });
+    } catch (err) {
+      logger.error('ClansAPI', 'Error fetching clans data:', err);
+      json(res, 500, { error: 'Erreur lors de la récupération des clans.' });
+    }
+    return true;
+  }
+
+  // PATCH /api/dashboard/guilds/:guildId/clans (Update Settings)
+  if (!subAction && method === 'PATCH') {
+    try {
+      const body = await readJsonBody<{
+        clansEnabled?: boolean;
+        clansUnique?: boolean;
+      }>(req);
+
+      const updateData: Record<string, any> = {};
+      if (body?.clansEnabled !== undefined) updateData.clansEnabled = body.clansEnabled;
+      if (body?.clansUnique !== undefined) updateData.clansUnique = body.clansUnique;
+
+      if (Object.keys(updateData).length === 0) {
+        json(res, 400, { error: 'Aucune donnée valide à mettre à jour.' });
+        return true;
+      }
+
+      const updatedGuild = await prisma.guild.update({
+        where: { id: guildId },
+        data: updateData,
+      });
+
+      await pushAudit(guildId, {
+        user: auditUser,
+        action: 'Mise à jour configuration Clans',
+        context: getGuildName(client, guildId),
+        module: 'Clans',
+        eventType: 'Manuel',
+        details: `Paramètres clans mis à jour. Activé: ${updatedGuild.clansEnabled}, Unique: ${updatedGuild.clansUnique}`,
+        channelId: null,
+      });
+
+      json(res, 200, {
+        clansEnabled: updatedGuild.clansEnabled,
+        clansUnique: updatedGuild.clansUnique,
+      });
+    } catch (err) {
+      logger.error('ClansAPI', 'Error updating clan settings:', err);
+      json(res, 500, { error: 'Erreur lors de la mise à jour de la configuration des clans.' });
+    }
+    return true;
+  }
+
+  // POST /api/dashboard/guilds/:guildId/clans (Create Clan)
+  if (!subAction && method === 'POST') {
+    try {
+      const body = await readJsonBody<{
+        name: string;
+        description?: string;
+        roleId: string;
+      }>(req);
+
+      if (!body?.name || !body?.roleId) {
+        json(res, 400, { error: 'Le nom et le rôle du clan sont requis.' });
+        return true;
+      }
+
+      // Vérifier si le rôle existe sur Discord
+      const discordGuild = client.guilds.cache.get(guildId) || await client.guilds.fetch(guildId).catch(() => null);
+      if (!discordGuild) {
+        json(res, 400, { error: 'Serveur introuvable sur Discord.' });
+        return true;
+      }
+
+      const roleExists = discordGuild.roles.cache.has(body.roleId);
+      if (!roleExists) {
+        json(res, 400, { error: "Le rôle sélectionné n'existe pas sur ce serveur Discord." });
+        return true;
+      }
+
+      // Vérifier l'unicité du rôle
+      const existingRoleClan = await prisma.clan.findUnique({
+        where: { roleId: body.roleId },
+      });
+      if (existingRoleClan) {
+        json(res, 400, { error: 'Ce rôle est déjà assigné à un autre clan.' });
+        return true;
+      }
+
+      // Créer le clan
+      const clan = await prisma.clan.create({
+        data: {
+          guildId,
+          name: body.name,
+          description: body.description ?? null,
+          roleId: body.roleId,
+        },
+      });
+
+      await pushAudit(guildId, {
+        user: auditUser,
+        action: 'Création de clan',
+        context: getGuildName(client, guildId),
+        module: 'Clans',
+        eventType: 'Manuel',
+        details: `Clan "${clan.name}" créé avec le rôle ${clan.roleId}.`,
+        channelId: null,
+      });
+
+      json(res, 201, { clan });
+    } catch (err) {
+      logger.error('ClansAPI', 'Error creating clan:', err);
+      json(res, 500, { error: 'Erreur lors de la création du clan.' });
+    }
+    return true;
+  }
+
+  // PUT /api/dashboard/guilds/:guildId/clans/:id
+  if (subAction && subAction !== 'distribute' && subAction !== 'clear' && subAction !== 'reset-season' && method === 'PUT') {
+    try {
+      const clanId = subAction;
+      const body = await readJsonBody<{
+        name: string;
+        description?: string;
+        roleId: string;
+      }>(req);
+
+      if (!body?.name || !body?.roleId) {
+        json(res, 400, { error: 'Le nom et le rôle du clan sont requis.' });
+        return true;
+      }
+
+      // Vérifier l'existence du rôle sur Discord
+      const discordGuild = client.guilds.cache.get(guildId) || await client.guilds.fetch(guildId).catch(() => null);
+      if (discordGuild && !discordGuild.roles.cache.has(body.roleId)) {
+        json(res, 400, { error: "Le rôle sélectionné n'existe pas sur Discord." });
+        return true;
+      }
+
+      // Vérifier l'unicité du rôle
+      const existingRoleClan = await prisma.clan.findFirst({
+        where: { roleId: body.roleId, id: { not: clanId } },
+      });
+      if (existingRoleClan) {
+        json(res, 400, { error: 'Ce rôle est déjà attribué à un autre clan.' });
+        return true;
+      }
+
+      const updatedClan = await prisma.clan.update({
+        where: { id: clanId, guildId },
+        data: {
+          name: body.name,
+          description: body.description ?? null,
+          roleId: body.roleId,
+        },
+      });
+
+      await pushAudit(guildId, {
+        user: auditUser,
+        action: 'Modification de clan',
+        context: getGuildName(client, guildId),
+        module: 'Clans',
+        eventType: 'Manuel',
+        details: `Clan "${updatedClan.name}" mis à jour. Rôle : ${updatedClan.roleId}.`,
+        channelId: null,
+      });
+
+      json(res, 200, { clan: updatedClan });
+    } catch (err) {
+      logger.error('ClansAPI', 'Error updating clan:', err);
+      json(res, 500, { error: 'Erreur lors de la modification du clan.' });
+    }
+    return true;
+  }
+
+  // DELETE /api/dashboard/guilds/:guildId/clans/:id
+  if (subAction && subAction !== 'distribute' && subAction !== 'clear' && subAction !== 'reset-season' && method === 'DELETE') {
+    try {
+      const clanId = subAction;
+
+      const deletedClan = await prisma.clan.delete({
+        where: { id: clanId, guildId },
+      });
+
+      await pushAudit(guildId, {
+        user: auditUser,
+        action: 'Suppression de clan',
+        context: getGuildName(client, guildId),
+        module: 'Clans',
+        eventType: 'Manuel',
+        details: `Clan "${deletedClan.name}" supprimé.`,
+        channelId: null,
+      });
+
+      json(res, 200, { success: true });
+    } catch (err) {
+      logger.error('ClansAPI', 'Error deleting clan:', err);
+      json(res, 500, { error: 'Erreur lors de la suppression du clan.' });
+    }
+    return true;
+  }
+
+  // POST /api/dashboard/guilds/:guildId/clans/distribute (Bulk Random Distribution)
+  if (subAction === 'distribute' && method === 'POST') {
+    try {
+      const message = await runDistribution(guildId, client, auditUser);
+      json(res, 200, { message });
+    } catch (err: any) {
+      logger.error('ClansAPI', 'Error launching distribution:', err);
+      json(res, err.message.includes('déjà en cours') || err.message.includes('configurer') ? 400 : 500, { error: err.message });
+    }
+    return true;
+  }
+
+  // POST /api/dashboard/guilds/:guildId/clans/clear (Bulk Remove Clan Roles)
+  if (subAction === 'clear' && method === 'POST') {
+    try {
+      const message = await runClear(guildId, client, auditUser);
+      json(res, 200, { message });
+    } catch (err: any) {
+      logger.error('ClansAPI', 'Error launching clear:', err);
+      json(res, err.message.includes('déjà en cours') || err.message.includes('Aucun clan') ? 400 : 500, { error: err.message });
+    }
+    return true;
+  }
+
+  // POST /api/dashboard/guilds/:guildId/clans/reset-season (New Season / Reset)
+  if (subAction === 'reset-season' && method === 'POST') {
+    try {
+      const guild = await prisma.guild.findUnique({
+        where: { id: guildId },
+        select: { currentClanSeason: true },
+      });
+
+      if (!guild) {
+        json(res, 404, { error: 'Serveur introuvable.' });
+        return true;
+      }
+
+      const nextSeason = guild.currentClanSeason + 1;
+
+      await prisma.guild.update({
+        where: { id: guildId },
+        data: { currentClanSeason: nextSeason },
+      });
+
+      await pushAudit(guildId, {
+        user: auditUser,
+        action: 'Reset Saison de Clans',
+        context: getGuildName(client, guildId),
+        module: 'Clans',
+        eventType: 'Manuel',
+        details: `Saison de clan réinitialisée. Nouvelle saison active: ${nextSeason}`,
+        channelId: null,
+      });
+
+      json(res, 200, { currentClanSeason: nextSeason });
+    } catch (err) {
+      logger.error('ClansAPI', 'Error resetting clan season:', err);
+      json(res, 500, { error: 'Erreur lors de la réinitialisation de la saison.' });
+    }
+    return true;
+  }
+
+  return false;
+}

--- a/apps/bot/src/api/routes/dashboard/clans.ts
+++ b/apps/bot/src/api/routes/dashboard/clans.ts
@@ -29,6 +29,9 @@ export async function handleClansRoutes(
           clansEnabled: true,
           clansUnique: true,
           currentClanSeason: true,
+          clanXpFromActivity: true,
+          clanXpFromLevelUp: true,
+          clanXpPerLevelUp: true,
         },
       });
 
@@ -74,6 +77,9 @@ export async function handleClansRoutes(
         clansEnabled: guildData.clansEnabled,
         clansUnique: guildData.clansUnique,
         currentClanSeason: guildData.currentClanSeason,
+        clanXpFromActivity: guildData.clanXpFromActivity,
+        clanXpFromLevelUp: guildData.clanXpFromLevelUp,
+        clanXpPerLevelUp: guildData.clanXpPerLevelUp,
         clans: clansWithStats,
         taskInProgress,
       });
@@ -90,11 +96,23 @@ export async function handleClansRoutes(
       const body = await readJsonBody<{
         clansEnabled?: boolean;
         clansUnique?: boolean;
+        clanXpFromActivity?: boolean;
+        clanXpFromLevelUp?: boolean;
+        clanXpPerLevelUp?: number;
       }>(req);
 
       const updateData: Record<string, any> = {};
       if (body?.clansEnabled !== undefined) updateData.clansEnabled = body.clansEnabled;
       if (body?.clansUnique !== undefined) updateData.clansUnique = body.clansUnique;
+      if (body?.clanXpFromActivity !== undefined) updateData.clanXpFromActivity = body.clanXpFromActivity;
+      if (body?.clanXpFromLevelUp !== undefined) updateData.clanXpFromLevelUp = body.clanXpFromLevelUp;
+      if (body?.clanXpPerLevelUp !== undefined) {
+        if (typeof body.clanXpPerLevelUp !== 'number' || body.clanXpPerLevelUp < 0) {
+          json(res, 400, { error: 'Le nombre de points par passage de niveau doit être un entier positif.' });
+          return true;
+        }
+        updateData.clanXpPerLevelUp = Math.floor(body.clanXpPerLevelUp);
+      }
 
       if (Object.keys(updateData).length === 0) {
         json(res, 400, { error: 'Aucune donnée valide à mettre à jour.' });
@@ -112,13 +130,16 @@ export async function handleClansRoutes(
         context: getGuildName(client, guildId),
         module: 'Clans',
         eventType: 'Manuel',
-        details: `Paramètres clans mis à jour. Activé: ${updatedGuild.clansEnabled}, Unique: ${updatedGuild.clansUnique}`,
+        details: `Paramètres clans mis à jour. Activé: ${updatedGuild.clansEnabled}, Unique: ${updatedGuild.clansUnique}, XP Activité: ${updatedGuild.clanXpFromActivity}, XP Level Up: ${updatedGuild.clanXpFromLevelUp} (${updatedGuild.clanXpPerLevelUp} pts)`,
         channelId: null,
       });
 
       json(res, 200, {
         clansEnabled: updatedGuild.clansEnabled,
         clansUnique: updatedGuild.clansUnique,
+        clanXpFromActivity: updatedGuild.clanXpFromActivity,
+        clanXpFromLevelUp: updatedGuild.clanXpFromLevelUp,
+        clanXpPerLevelUp: updatedGuild.clanXpPerLevelUp,
       });
     } catch (err) {
       logger.error('ClansAPI', 'Error updating clan settings:', err);

--- a/apps/bot/src/api/routes/dashboard/clans.ts
+++ b/apps/bot/src/api/routes/dashboard/clans.ts
@@ -29,7 +29,6 @@ export async function handleClansRoutes(
           clansEnabled: true,
           clansUnique: true,
           currentClanSeason: true,
-          clanXpFromActivity: true,
           clanXpFromLevelUp: true,
           clanXpPerLevelUp: true,
         },
@@ -77,7 +76,6 @@ export async function handleClansRoutes(
         clansEnabled: guildData.clansEnabled,
         clansUnique: guildData.clansUnique,
         currentClanSeason: guildData.currentClanSeason,
-        clanXpFromActivity: guildData.clanXpFromActivity,
         clanXpFromLevelUp: guildData.clanXpFromLevelUp,
         clanXpPerLevelUp: guildData.clanXpPerLevelUp,
         clans: clansWithStats,
@@ -90,13 +88,11 @@ export async function handleClansRoutes(
     return true;
   }
 
-  // PATCH /api/dashboard/guilds/:guildId/clans (Update Settings)
   if (!subAction && method === 'PATCH') {
     try {
       const body = await readJsonBody<{
         clansEnabled?: boolean;
         clansUnique?: boolean;
-        clanXpFromActivity?: boolean;
         clanXpFromLevelUp?: boolean;
         clanXpPerLevelUp?: number;
       }>(req);
@@ -104,7 +100,6 @@ export async function handleClansRoutes(
       const updateData: Record<string, any> = {};
       if (body?.clansEnabled !== undefined) updateData.clansEnabled = body.clansEnabled;
       if (body?.clansUnique !== undefined) updateData.clansUnique = body.clansUnique;
-      if (body?.clanXpFromActivity !== undefined) updateData.clanXpFromActivity = body.clanXpFromActivity;
       if (body?.clanXpFromLevelUp !== undefined) updateData.clanXpFromLevelUp = body.clanXpFromLevelUp;
       if (body?.clanXpPerLevelUp !== undefined) {
         if (typeof body.clanXpPerLevelUp !== 'number' || body.clanXpPerLevelUp < 0) {
@@ -130,14 +125,13 @@ export async function handleClansRoutes(
         context: getGuildName(client, guildId),
         module: 'Clans',
         eventType: 'Manuel',
-        details: `Paramètres clans mis à jour. Activé: ${updatedGuild.clansEnabled}, Unique: ${updatedGuild.clansUnique}, XP Activité: ${updatedGuild.clanXpFromActivity}, XP Level Up: ${updatedGuild.clanXpFromLevelUp} (${updatedGuild.clanXpPerLevelUp} pts)`,
+        details: `Paramètres clans mis à jour. Activé: ${updatedGuild.clansEnabled}, Unique: ${updatedGuild.clansUnique}, XP Level Up: ${updatedGuild.clanXpFromLevelUp} (${updatedGuild.clanXpPerLevelUp} pts)`,
         channelId: null,
       });
 
       json(res, 200, {
         clansEnabled: updatedGuild.clansEnabled,
         clansUnique: updatedGuild.clansUnique,
-        clanXpFromActivity: updatedGuild.clanXpFromActivity,
         clanXpFromLevelUp: updatedGuild.clanXpFromLevelUp,
         clanXpPerLevelUp: updatedGuild.clanXpPerLevelUp,
       });

--- a/apps/bot/src/api/routes/public.ts
+++ b/apps/bot/src/api/routes/public.ts
@@ -595,6 +595,107 @@ export async function handlePublicRoutes(
     return true;
   }
 
+  // GET /api/public/guilds/:guildId/clans
+  if (parts[2] === 'guilds' && parts[3] && parts[4] === 'clans' && !parts[5] && method === 'GET') {
+    const guildId = parts[3];
+    if (!/^\d{17,19}$/.test(guildId)) {
+      json(res, 400, { error: 'ID de guilde invalide' });
+      return true;
+    }
+
+    try {
+      const guildConfig = await prisma.guild.findUnique({
+        where: { id: guildId },
+        select: { clansEnabled: true, currentClanSeason: true },
+      });
+
+      const discordGuild = client.guilds.cache.get(guildId) || await client.guilds.fetch(guildId).catch(() => null);
+
+      if (!guildConfig?.clansEnabled) {
+        json(res, 200, {
+          enabled: false,
+          guildName: discordGuild?.name || 'Kotbo Server',
+          guildIcon: discordGuild?.iconURL({ size: 128 }) || null,
+          clans: [],
+        });
+        return true;
+      }
+
+      const clans = await prisma.clan.findMany({
+        where: { guildId },
+        orderBy: { name: 'asc' },
+      });
+
+      // Charger toutes les contributions pour la saison en cours
+      const contributions = await prisma.clanMemberContribution.findMany({
+        where: {
+          guildId,
+          season: guildConfig.currentClanSeason,
+        },
+        orderBy: { xp: 'desc' },
+      });
+
+      // Charger les profils utilisateur impliqués pour récupérer noms et avatars
+      const userIds = [...new Set(contributions.map((c) => c.userId))];
+      const dbProfiles = await prisma.memberProfile.findMany({
+        where: {
+          guildId,
+          userId: { in: userIds },
+        },
+      });
+      const profileMap = new Map(dbProfiles.map((p) => [p.userId, p]));
+
+      // Associer les contributions avec les données utilisateur
+      const clansData = clans.map((clan) => {
+        const role = discordGuild?.roles.cache.get(clan.roleId);
+        const memberCount = role?.members.size ?? 0;
+
+        const clanContributions = contributions.filter((c) => c.clanId === clan.id);
+        const totalXp = clanContributions.reduce((sum, c) => sum + c.xp, 0);
+
+        // Top participants du clan
+        const topParticipants = clanContributions.slice(0, 10).map((c) => {
+          const profile = profileMap.get(c.userId);
+          const discordMember = discordGuild?.members.cache.get(c.userId);
+
+          const displayName = discordMember?.displayName || profile?.displayName || profile?.globalName || `Utilisateur ${c.userId}`;
+          const avatarUrl = discordMember?.user?.displayAvatarURL({ size: 128 }) || profile?.avatarUrl || null;
+
+          return {
+            userId: c.userId,
+            xp: c.xp,
+            displayName,
+            avatarUrl,
+          };
+        });
+
+        return {
+          id: clan.id,
+          name: clan.name,
+          description: clan.description,
+          roleId: clan.roleId,
+          roleColor: role?.color ? `#${role.color.toString(16).padStart(6, '0')}` : null,
+          totalXp,
+          memberCount,
+          topParticipants,
+        };
+      });
+
+      json(res, 200, {
+        enabled: true,
+        currentClanSeason: guildConfig.currentClanSeason,
+        guildName: discordGuild?.name || 'Kotbo Server',
+        guildIcon: discordGuild?.iconURL({ size: 128 }) || null,
+        clans: clansData,
+      });
+    } catch (err: unknown) {
+      const errMessage = err instanceof Error ? err.message : String(err);
+      logger.error('PublicAPI', `Error fetching public clans for guild ${guildId}: ${errMessage}`);
+      json(res, 500, { error: 'Erreur lors du chargement du classement de clans' });
+    }
+    return true;
+  }
+
   // GET /api/public/transcripts/:transcriptId?expires=...&sig=...
   if (parts[2] === 'transcripts' && parts[3] && method === 'GET') {
     const transcriptId = parts[3];

--- a/apps/bot/src/commands.ts
+++ b/apps/bot/src/commands.ts
@@ -67,6 +67,7 @@ import { channelhealthCommand } from './commands/admin/channelhealth.js';
 import { repCommand } from './commands/community/rep.js';
 import { marketCommand } from './commands/economy/market.js';
 import { questsCommand } from './commands/community/quests.js';
+import { clanCommand } from './commands/community/clan.js';
 import { rpgProfileCommand, rpgDailyCommand, rpgTravelCommand, rpgShopCommand, rpgInventoryCommand, rpgGuildCommand, rpgPayCommand, rpgSellCommand, rpgDropCommand, rpgAdminCommand, rpgFightCommand, rpgBossCommand, rpgBestiaryCommand, fishCommand } from './commands/fun/rpgEconomy.js';
 import { topCommand } from './commands/profile/top.js';
 import { inventaireCommand } from './commands/economy/inventaire.js';
@@ -161,6 +162,7 @@ export const commands: SlashCommandDefinition[] = [
   repCommand,
   marketCommand,
   questsCommand,
+  clanCommand,
   rpgProfileCommand,
   rpgDailyCommand,
   rpgTravelCommand,

--- a/apps/bot/src/commands/community/clan.ts
+++ b/apps/bot/src/commands/community/clan.ts
@@ -1,0 +1,294 @@
+import {
+  ChatInputCommandInteraction,
+  AutocompleteInteraction,
+  SlashCommandBuilder,
+  PermissionFlagsBits,
+  EmbedBuilder,
+  MessageFlags,
+} from 'discord.js';
+import type { SlashCommandDefinition } from '../../commands.js';
+import prisma from '../../utils/db.js';
+import { runDistribution, runClear } from '../../services/community/clanService.js';
+import { E, rankEmoji } from '../../utils/emojis.js';
+import { COLORS_RAW } from '../../utils/embeds.js';
+
+export const clanCommand: SlashCommandDefinition = {
+  data: new SlashCommandBuilder()
+    .setName('clan')
+    .setDescription('🛡️ Gestion et classements des clans du serveur')
+    .addSubcommand((sub) =>
+      sub
+        .setName('list')
+        .setDescription('📋 Liste tous les clans configurés sur le serveur')
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('leaderboard')
+        .setDescription('🏆 Affiche le classement des clans pour la saison active')
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('info')
+        .setDescription('ℹ️ Affiche les informations et le classement des membres d\'un clan')
+        .addStringOption((opt) =>
+          opt
+            .setName('nom')
+            .setDescription('Le nom du clan')
+            .setRequired(true)
+            .setAutocomplete(true)
+        )
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('distribute')
+        .setDescription('🎲 (Admin) Répartit aléatoirement les membres sans clan')
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('clear')
+        .setDescription('🧹 (Admin) Retire tous les rôles de clan du serveur')
+    ) as any,
+
+  async autocomplete(interaction: AutocompleteInteraction) {
+    const guildId = interaction.guildId;
+    if (!guildId) return;
+
+    const focusedValue = interaction.options.getFocused();
+    const clans = await prisma.clan.findMany({
+      where: {
+        guildId,
+        name: { contains: focusedValue, mode: 'insensitive' },
+      },
+      take: 25,
+      select: { name: true },
+    });
+
+    await interaction.respond(
+      clans.map((c) => ({ name: c.name, value: c.name }))
+    );
+  },
+
+  async execute(interaction: ChatInputCommandInteraction) {
+    const guildId = interaction.guildId;
+    if (!guildId) {
+      await interaction.reply({
+        content: '❌ Cette commande doit être exécutée sur un serveur.',
+        flags: [MessageFlags.Ephemeral],
+      });
+      return;
+    }
+
+    const sub = interaction.options.getSubcommand();
+
+    // Charger la configuration générale des clans pour la guilde
+    const guildConfig = await prisma.guild.findUnique({
+      where: { id: guildId },
+      select: { clansEnabled: true, currentClanSeason: true },
+    });
+
+    if (!guildConfig?.clansEnabled) {
+      await interaction.reply({
+        content: '❌ Le module de clans est actuellement désactivé sur ce serveur.',
+        flags: [MessageFlags.Ephemeral],
+      });
+      return;
+    }
+
+    // ── SUBCOMMAND: list ──────────────────────────────────────────────────────
+    if (sub === 'list') {
+      await interaction.deferReply();
+
+      const clans = await prisma.clan.findMany({
+        where: { guildId },
+        orderBy: { name: 'asc' },
+      });
+
+      if (clans.length === 0) {
+        await interaction.editReply('Aucun clan n\'est configuré sur ce serveur.');
+        return;
+      }
+
+      const embed = new EmbedBuilder()
+        .setColor(COLORS_RAW.primary)
+        .setTitle(`🛡️ Clans de ${interaction.guild?.name}`)
+        .setDescription('Voici la liste des clans disponibles. Utilisez `/clan info <nom>` pour voir leurs détails.')
+        .setTimestamp();
+
+      for (const clan of clans) {
+        const role = interaction.guild?.roles.cache.get(clan.roleId);
+        const memberCount = role?.members.size ?? 0;
+        embed.addFields({
+          name: `• ${clan.name} (${memberCount} membres)`,
+          value: clan.description || '*Aucune description.*',
+          inline: false,
+        });
+      }
+
+      await interaction.editReply({ embeds: [embed] });
+      return;
+    }
+
+    // ── SUBCOMMAND: leaderboard ────────────────────────────────────────────────
+    if (sub === 'leaderboard') {
+      await interaction.deferReply();
+
+      const clans = await prisma.clan.findMany({ where: { guildId } });
+
+      if (clans.length === 0) {
+        await interaction.editReply('Aucun clan n\'est configuré sur ce serveur.');
+        return;
+      }
+
+      // Récupérer la somme des contributions pour la saison active
+      const contributions = await prisma.clanMemberContribution.groupBy({
+        by: ['clanId'],
+        where: {
+          guildId,
+          season: guildConfig.currentClanSeason,
+        },
+        _sum: { xp: true },
+      });
+
+      const contributionsMap = new Map(contributions.map((c) => [c.clanId, c._sum.xp ?? 0]));
+
+      // Assigner et trier
+      const rankedClans = clans
+        .map((clan) => {
+          const role = interaction.guild?.roles.cache.get(clan.roleId);
+          const memberCount = role?.members.size ?? 0;
+          const xp = contributionsMap.get(clan.id) ?? 0;
+          return { name: clan.name, memberCount, xp };
+        })
+        .sort((a, b) => b.xp - a.xp);
+
+      const embed = new EmbedBuilder()
+        .setColor(COLORS_RAW.warning)
+        .setTitle(`🏆 Classement des Clans — Saison ${guildConfig.currentClanSeason}`)
+        .setTimestamp();
+
+      let desc = '';
+      for (let i = 0; i < rankedClans.length; i++) {
+        const c = rankedClans[i];
+        desc += `\n${rankEmoji(i + 1)} **${c.name}**\n▸ Contribution : \`${c.xp.toLocaleString('fr-FR')} XP\` · Membres : \`${c.memberCount}\`\n`;
+      }
+
+      embed.setDescription(desc || '*Aucune contribution enregistrée pour le moment.*');
+      await interaction.editReply({ embeds: [embed] });
+      return;
+    }
+
+    // ── SUBCOMMAND: info ──────────────────────────────────────────────────────
+    if (sub === 'info') {
+      await interaction.deferReply();
+      const nom = interaction.options.getString('nom', true);
+
+      const clan = await prisma.clan.findFirst({
+        where: { guildId, name: { equals: nom, mode: 'insensitive' } },
+      });
+
+      if (!clan) {
+        await interaction.editReply(`❌ Le clan "${nom}" n'existe pas.`);
+        return;
+      }
+
+      const role = interaction.guild?.roles.cache.get(clan.roleId);
+      const memberCount = role?.members.size ?? 0;
+
+      // Calculer l'XP totale cumulée pour la saison active
+      const aggregate = await prisma.clanMemberContribution.aggregate({
+        where: {
+          guildId,
+          clanId: clan.id,
+          season: guildConfig.currentClanSeason,
+        },
+        _sum: { xp: true },
+      });
+      const totalXp = aggregate._sum.xp ?? 0;
+
+      // Top 10 contributeurs du clan pour la saison active
+      const topContributions = await prisma.clanMemberContribution.findMany({
+        where: {
+          guildId,
+          clanId: clan.id,
+          season: guildConfig.currentClanSeason,
+        },
+        orderBy: { xp: 'desc' },
+        take: 10,
+      });
+
+      const embed = new EmbedBuilder()
+        .setColor(role?.color ?? COLORS_RAW.primary)
+        .setTitle(`🛡️ Clan ${clan.name}`)
+        .setDescription(clan.description || '*Aucune description.*')
+        .addFields(
+          { name: 'Rôle Discord', value: role ? `<@&${role.id}>` : `ID: ${clan.roleId}`, inline: true },
+          { name: 'Membres actifs', value: `\`${memberCount}\``, inline: true },
+          { name: 'XP de Saison', value: `\`${totalXp.toLocaleString('fr-FR')} XP\``, inline: true }
+        )
+        .setTimestamp();
+
+      let contributorsList = '';
+      for (let i = 0; i < topContributions.length; i++) {
+        const contrib = topContributions[i];
+        const member = await interaction.guild?.members.fetch(contrib.userId).catch(() => null);
+        const name = member ? member.displayName : `Utilisateur ${contrib.userId}`;
+        contributorsList += `${rankEmoji(i + 1)} **${name}** : \`${contrib.xp.toLocaleString('fr-FR')} XP\`\n`;
+      }
+
+      embed.addFields({
+        name: '🏆 Top Contributeurs de Saison',
+        value: contributorsList || '*Aucune contribution pour le moment.*',
+        inline: false,
+      });
+
+      await interaction.editReply({ embeds: [embed] });
+      return;
+    }
+
+    // ── SUBCOMMAND: distribute (Admin Only) ───────────────────────────────────
+    if (sub === 'distribute') {
+      const isExecutorAdmin = interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild);
+      if (!isExecutorAdmin) {
+        await interaction.reply({
+          content: '❌ Vous devez disposer de la permission "Gérer le serveur" pour exécuter cette commande.',
+          flags: [MessageFlags.Ephemeral],
+        });
+        return;
+      }
+
+      await interaction.deferReply({ flags: [MessageFlags.Ephemeral] });
+
+      try {
+        const initiator = `${interaction.user.username} (${interaction.user.id})`;
+        const message = await runDistribution(guildId, interaction.client, initiator);
+        await interaction.editReply(message);
+      } catch (err: any) {
+        await interaction.editReply(`❌ Erreur : ${err.message}`);
+      }
+      return;
+    }
+
+    // ── SUBCOMMAND: clear (Admin Only) ────────────────────────────────────────
+    if (sub === 'clear') {
+      const isExecutorAdmin = interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild);
+      if (!isExecutorAdmin) {
+        await interaction.reply({
+          content: '❌ Vous devez disposer de la permission "Gérer le serveur" pour exécuter cette commande.',
+          flags: [MessageFlags.Ephemeral],
+        });
+        return;
+      }
+
+      await interaction.deferReply({ flags: [MessageFlags.Ephemeral] });
+
+      try {
+        const initiator = `${interaction.user.username} (${interaction.user.id})`;
+        const message = await runClear(guildId, interaction.client, initiator);
+        await interaction.editReply(message);
+      } catch (err: any) {
+        await interaction.editReply(`❌ Erreur : ${err.message}`);
+      }
+      return;
+    }
+  },
+};

--- a/apps/bot/src/events/clanEvents.ts
+++ b/apps/bot/src/events/clanEvents.ts
@@ -1,0 +1,98 @@
+import { Client, Events, EmbedBuilder, GuildMember } from 'discord.js';
+import prisma from '../utils/db.js';
+import { logger } from '../utils/logger.js';
+
+export function registerClanListener(client: Client) {
+  // 1. Sécurité de Clan Unique (guildMemberUpdate)
+  client.on(Events.GuildMemberUpdate, async (oldMember: GuildMember, newMember: GuildMember) => {
+    try {
+      const guildId = newMember.guild.id;
+
+      const config = await prisma.guild.findUnique({
+        where: { id: guildId },
+        select: { clansEnabled: true, clansUnique: true, logChannelId: true },
+      });
+
+      if (!config?.clansEnabled || !config?.clansUnique) return;
+
+      const clans = await prisma.clan.findMany({
+        where: { guildId },
+        select: { id: true, name: true, roleId: true },
+      });
+
+      if (clans.length === 0) return;
+
+      const clanRoleIds = clans.map((c) => c.roleId);
+
+      // Trouver quel rôle de clan a été ajouté dans newMember par rapport à oldMember
+      const addedRole = newMember.roles.cache.find(
+        (r) => clanRoleIds.includes(r.id) && !oldMember.roles.cache.has(r.id)
+      );
+
+      if (!addedRole) return;
+
+      // Lister les autres rôles de clans possédés par le membre
+      const otherClanRoles = newMember.roles.cache.filter(
+        (r) => clanRoleIds.includes(r.id) && r.id !== addedRole.id
+      );
+
+      if (otherClanRoles.size === 0) return;
+
+      // Il a plusieurs clans ! On retire les anciens rôles de clans
+      const rolesToRemove = [...otherClanRoles.keys()];
+      await newMember.roles.remove(rolesToRemove, 'Sécurité : un membre ne peut appartenir qu\'à un seul clan à la fois');
+
+      // Trouver les noms des clans impliqués
+      const addedClanName = clans.find((c) => c.roleId === addedRole.id)?.name ?? 'Inconnu';
+      const removedClansNames = clans
+        .filter((c) => rolesToRemove.includes(c.roleId))
+        .map((c) => c.name)
+        .join(', ');
+
+      logger.warn(
+        'ClansSecurity',
+        `Sécurité de clan unique déclenchée pour ${newMember.user.tag} : nouveaux rôles retirés [${removedClansNames}] au profit de [${addedClanName}]`
+      );
+
+      // Loguer dans le salon de modération/logs
+      if (config.logChannelId) {
+        const logChannel = newMember.guild.channels.cache.get(config.logChannelId);
+        if (logChannel?.isTextBased()) {
+          const embed = new EmbedBuilder()
+            .setColor(0x3a86c8)
+            .setTitle('Sécurité de Clan Unique | Automod')
+            .addFields(
+              { name: 'Membre', value: `<@${newMember.id}> \`${newMember.user.tag}\``, inline: false },
+              { name: 'Nouveau Clan Appliqué', value: `\`${addedClanName}\``, inline: true },
+              { name: 'Ancien(s) Clan(s) Retiré(s)', value: `\`${removedClansNames}\``, inline: true }
+            )
+            .setThumbnail(newMember.displayAvatarURL())
+            .setFooter({ text: 'Kotbo Clans Security' })
+            .setTimestamp();
+
+          await logChannel.send({ embeds: [embed], allowedMentions: { parse: [] } }).catch(() => null);
+        }
+      }
+
+      // Enregistrer dans le journal d'audit du dashboard
+      await prisma.dashboardAuditLog.create({
+        data: {
+          guildId,
+          channelId: config.logChannelId ?? null,
+          user: 'Automod Clans',
+          action: 'Correction automatique de clan',
+          context: newMember.guild.name,
+          module: 'Clans',
+          eventType: 'Sécurité',
+          details: `Double clan détecté pour ${newMember.user.tag}. Rôles de [${removedClansNames}] retirés pour conserver [${addedClanName}].`,
+          dateIso: new Date(),
+        },
+      }).catch(() => null);
+
+    } catch (error) {
+      logger.error('ClansSecurity', `Erreur lors de la vérification d'unicité de clan pour ${newMember.user.tag}:`, error);
+    }
+  });
+
+  logger.info('System', 'Écouteur d\'événements Clans enregistré.');
+}

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -60,6 +60,7 @@ import { registerChannelLinkListener } from './events/channelLinkEvents.js';
 import { registerStaffServerListener } from './events/staffServerEvents.js';
 import { registerAbsenceMentionListener } from './events/absenceMentionEvents.js';
 import { registerPartnershipListener } from './services/features/partnershipService.js';
+import { registerClanListener } from './events/clanEvents.js';
 import { registerEventBusBridge } from './events/eventBusBridge.js';
 import { registerAnalyticsBusSubscribers } from './modules/analytics.module.js';
 import { registerLevelingBusSubscribers } from './modules/leveling.module.js';
@@ -341,6 +342,7 @@ client.once(Events.ClientReady, async (c) => {
   registerStaffServerListener(client);
   registerAbsenceMentionListener(client);
   registerPartnershipListener(client);
+  registerClanListener(client);
 
   // Enregistrer les cron jobs AVANT les opérations potentiellement bloquantes
   logger.info('System', 'Enregistrement des cron jobs...');

--- a/apps/bot/src/services/community/clanService.ts
+++ b/apps/bot/src/services/community/clanService.ts
@@ -1,0 +1,167 @@
+import { Client } from 'discord.js';
+import prisma from '../../utils/db.js';
+import { logger } from '../../utils/logger.js';
+import { pushAudit } from '../../api/shared.js';
+
+export const clanTasks = new Map<string, { type: 'distribute' | 'clear'; processed: number; total: number }>();
+
+export async function runDistribution(guildId: string, client: Client, initiatorName: string): Promise<string> {
+  if (clanTasks.has(guildId)) {
+    throw new Error('Une opération de masse est déjà en cours sur ce serveur.');
+  }
+
+  const clans = await prisma.clan.findMany({ where: { guildId } });
+  if (clans.length === 0) {
+    throw new Error('Veuillez configurer au moins un clan avant de lancer la distribution.');
+  }
+
+  const discordGuild = client.guilds.cache.get(guildId) || await client.guilds.fetch(guildId).catch(() => null);
+  if (!discordGuild) {
+    throw new Error('Serveur introuvable sur Discord.');
+  }
+
+  // Récupérer tous les membres
+  const allMembers = await discordGuild.members.fetch().catch(() => null);
+  if (!allMembers) {
+    throw new Error('Impossible de récupérer la liste des membres Discord.');
+  }
+
+  const clanRoleIds = clans.map((c) => c.roleId);
+  
+  // Filtrer les humains qui n'ont pas encore de rôle de clan
+  const membersWithoutClan = allMembers.filter((member) => {
+    if (member.user.bot) return false;
+    return !member.roles.cache.some((r) => clanRoleIds.includes(r.id));
+  });
+
+  if (membersWithoutClan.size === 0) {
+    return 'Tous les membres ont déjà un clan.';
+  }
+
+  const targetList = [...membersWithoutClan.values()];
+  
+  // Démarrer la tâche asynchrone bridée
+  clanTasks.set(guildId, { type: 'distribute', processed: 0, total: targetList.length });
+
+  // Lancement asynchrone non-bloquant
+  (async () => {
+    logger.info('ClanService', `Lancement de la distribution aléatoire pour ${targetList.length} membres dans "${discordGuild.name}" par ${initiatorName}`);
+    
+    for (let i = 0; i < targetList.length; i++) {
+      const currentTask = clanTasks.get(guildId);
+      if (!currentTask || currentTask.type !== 'distribute') break;
+
+      const member = targetList[i];
+      const randomClan = clans[Math.floor(Math.random() * clans.length)];
+
+      try {
+        await member.roles.add(randomClan.roleId, 'Distribution globale et aléatoire des clans');
+      } catch (e) {
+        logger.warn('ClanService', `Impossible d'attribuer le clan à ${member.user.tag}:`, e);
+      }
+
+      clanTasks.set(guildId, {
+        type: 'distribute',
+        processed: i + 1,
+        total: targetList.length,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 450));
+    }
+
+    logger.info('ClanService', `Distribution aléatoire terminée pour "${discordGuild.name}"`);
+    clanTasks.delete(guildId);
+  })().catch((e) => logger.error('ClanService', 'Erreur critique dans le thread de distribution:', e));
+
+  await pushAudit(guildId, {
+    user: initiatorName,
+    action: 'Lancement distribution de clans',
+    context: discordGuild.name,
+    module: 'Clans',
+    eventType: 'Manuel',
+    details: `Distribution aléatoire lancée pour ${targetList.length} membres.`,
+    channelId: null,
+  }).catch(() => null);
+
+  return `La distribution aléatoire des clans à ${targetList.length} membres a commencé en arrière-plan. Cette opération s'effectue progressivement pour respecter les limites de requêtes de Discord et peut prendre plusieurs minutes. Vous pouvez suivre l'avancement sur le Dashboard.`;
+}
+
+export async function runClear(guildId: string, client: Client, initiatorName: string): Promise<string> {
+  if (clanTasks.has(guildId)) {
+    throw new Error('Une opération de masse est déjà en cours sur ce serveur.');
+  }
+
+  const clans = await prisma.clan.findMany({ where: { guildId } });
+  if (clans.length === 0) {
+    throw new Error('Aucun clan n\'est configuré sur ce serveur.');
+  }
+
+  const discordGuild = client.guilds.cache.get(guildId) || await client.guilds.fetch(guildId).catch(() => null);
+  if (!discordGuild) {
+    throw new Error('Serveur introuvable sur Discord.');
+  }
+
+  const clanRoleIds = clans.map((c) => c.roleId);
+
+  // Récupérer les membres
+  const allMembers = await discordGuild.members.fetch().catch(() => null);
+  if (!allMembers) {
+    throw new Error('Impossible de récupérer la liste des membres.');
+  }
+
+  // Filtrer les membres qui ont au moins un rôle de clan
+  const membersWithClan = allMembers.filter((member) => {
+    return member.roles.cache.some((r) => clanRoleIds.includes(r.id));
+  });
+
+  if (membersWithClan.size === 0) {
+    return 'Aucun membre ne possède de rôle de clan.';
+  }
+
+  const targetList = [...membersWithClan.values()];
+
+  // Démarrer la tâche
+  clanTasks.set(guildId, { type: 'clear', processed: 0, total: targetList.length });
+
+  // Lancement asynchrone
+  (async () => {
+    logger.info('ClanService', `Lancement du retrait de tous les clans pour ${targetList.length} membres dans "${discordGuild.name}" par ${initiatorName}`);
+
+    for (let i = 0; i < targetList.length; i++) {
+      const currentTask = clanTasks.get(guildId);
+      if (!currentTask || currentTask.type !== 'clear') break;
+
+      const member = targetList[i];
+      const rolesToRemove = member.roles.cache.filter((r) => clanRoleIds.includes(r.id)).map((r) => r.id);
+
+      try {
+        await member.roles.remove(rolesToRemove, 'Retrait global de tous les rôles de clan');
+      } catch (e) {
+        logger.warn('ClanService', `Impossible de retirer les clans de ${member.user.tag}:`, e);
+      }
+
+      clanTasks.set(guildId, {
+        type: 'clear',
+        processed: i + 1,
+        total: targetList.length,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 450));
+    }
+
+    logger.info('ClanService', `Retrait de tous les clans terminé pour "${discordGuild.name}"`);
+    clanTasks.delete(guildId);
+  })().catch((e) => logger.error('ClanService', 'Erreur critique dans le thread de retrait:', e));
+
+  await pushAudit(guildId, {
+    user: initiatorName,
+    action: 'Lancement retrait de clans',
+    context: discordGuild.name,
+    module: 'Clans',
+    eventType: 'Manuel',
+    details: `Retrait des clans lancé pour ${targetList.length} membres.`,
+    channelId: null,
+  }).catch(() => null);
+
+  return `Le retrait de tous les clans pour ${targetList.length} membres a commencé en arrière-plan. Cette opération s'effectue progressivement pour respecter les limites de requêtes de Discord et peut prendre plusieurs minutes. Vous pouvez suivre l'avancement sur le Dashboard.`;
+}

--- a/apps/bot/src/services/progression/levelingService.ts
+++ b/apps/bot/src/services/progression/levelingService.ts
@@ -148,6 +148,57 @@ export async function addXp(guildId: string, userId: string, amount: number, cli
     },
   });
 
+  // Incrémenter la contribution de clan si activé
+  try {
+    const guildConfig = await prisma.guild.findUnique({
+      where: { id: guildId },
+      select: { clansEnabled: true, currentClanSeason: true }
+    });
+    if (guildConfig?.clansEnabled) {
+      const clans = await prisma.clan.findMany({
+        where: { guildId },
+        select: { id: true, roleId: true }
+      });
+      if (clans.length > 0) {
+        const discordGuild = client.guilds.cache.get(guildId) || await client.guilds.fetch(guildId).catch(() => null);
+        if (discordGuild) {
+          const member = await discordGuild.members.fetch(userId).catch(() => null);
+          if (member) {
+            const clanRoleIds = clans.map(c => c.roleId);
+            const memberClanRole = member.roles.cache.find(r => clanRoleIds.includes(r.id));
+            if (memberClanRole) {
+              const clan = clans.find(c => c.roleId === memberClanRole.id);
+              if (clan) {
+                await prisma.clanMemberContribution.upsert({
+                  where: {
+                    guildId_clanId_userId_season: {
+                      guildId,
+                      clanId: clan.id,
+                      userId,
+                      season: guildConfig.currentClanSeason
+                    }
+                  },
+                  update: {
+                    xp: { increment: amount }
+                  },
+                  create: {
+                    guildId,
+                    clanId: clan.id,
+                    userId,
+                    season: guildConfig.currentClanSeason,
+                    xp: amount
+                  }
+                });
+              }
+            }
+          }
+        }
+      }
+    }
+  } catch (err) {
+    logger.error('LevelingService', `Erreur de traitement des clans lors de l'ajout d'XP pour ${userId}:`, err);
+  }
+
   const previousLevel = memberLevel.level;
   // Le niveau est toujours recalculé depuis l'XP totale : ça gère les montées
   // de niveau et auto-répare les lignes dont le niveau était incohérent.

--- a/apps/bot/src/services/progression/levelingService.ts
+++ b/apps/bot/src/services/progression/levelingService.ts
@@ -152,9 +152,9 @@ export async function addXp(guildId: string, userId: string, amount: number, cli
   try {
     const guildConfig = await prisma.guild.findUnique({
       where: { id: guildId },
-      select: { clansEnabled: true, currentClanSeason: true }
+      select: { clansEnabled: true, currentClanSeason: true, clanXpFromActivity: true }
     });
-    if (guildConfig?.clansEnabled) {
+    if (guildConfig?.clansEnabled && guildConfig?.clanXpFromActivity) {
       const clans = await prisma.clan.findMany({
         where: { guildId },
         select: { id: true, roleId: true }
@@ -232,6 +232,52 @@ async function processLevelUp(guildId: string, userId: string, newLevel: number,
 
     const member = await discordGuild.members.fetch(userId).catch(() => null);
     if (!member) return;
+
+    // 0. Attribution des points de clan pour la montée de niveau si activé
+    try {
+      const guildConfig = await prisma.guild.findUnique({
+        where: { id: guildId },
+        select: { clansEnabled: true, currentClanSeason: true, clanXpFromLevelUp: true, clanXpPerLevelUp: true }
+      });
+      if (guildConfig?.clansEnabled && guildConfig?.clanXpFromLevelUp && guildConfig?.clanXpPerLevelUp > 0) {
+        const clans = await prisma.clan.findMany({
+          where: { guildId },
+          select: { id: true, roleId: true }
+        });
+        if (clans.length > 0) {
+          const clanRoleIds = clans.map(c => c.roleId);
+          const memberClanRole = member.roles.cache.find(r => clanRoleIds.includes(r.id));
+          if (memberClanRole) {
+            const clan = clans.find(c => c.roleId === memberClanRole.id);
+            if (clan) {
+              await prisma.clanMemberContribution.upsert({
+                where: {
+                  guildId_clanId_userId_season: {
+                    guildId,
+                    clanId: clan.id,
+                    userId,
+                    season: guildConfig.currentClanSeason
+                  }
+                },
+                update: {
+                  xp: { increment: guildConfig.clanXpPerLevelUp }
+                },
+                create: {
+                  guildId,
+                  clanId: clan.id,
+                  userId,
+                  season: guildConfig.currentClanSeason,
+                  xp: guildConfig.clanXpPerLevelUp
+                }
+              });
+              logger.info('LevelingService', `Points de clan (${guildConfig.clanXpPerLevelUp} XP) attribués à ${member.user.tag} pour son passage au niveau ${newLevel} dans le clan "${clan.id}"`);
+            }
+          }
+        }
+      }
+    } catch (clanErr) {
+      logger.error('LevelingService', `Erreur lors de l'attribution des points de clan pour le level up de ${userId}:`, clanErr);
+    }
 
     // 1. Attribution des rôles de récompense
     const rewards = await prisma.levelRoleReward.findMany({

--- a/apps/bot/src/services/progression/levelingService.ts
+++ b/apps/bot/src/services/progression/levelingService.ts
@@ -148,56 +148,7 @@ export async function addXp(guildId: string, userId: string, amount: number, cli
     },
   });
 
-  // Incrémenter la contribution de clan si activé
-  try {
-    const guildConfig = await prisma.guild.findUnique({
-      where: { id: guildId },
-      select: { clansEnabled: true, currentClanSeason: true, clanXpFromActivity: true }
-    });
-    if (guildConfig?.clansEnabled && guildConfig?.clanXpFromActivity) {
-      const clans = await prisma.clan.findMany({
-        where: { guildId },
-        select: { id: true, roleId: true }
-      });
-      if (clans.length > 0) {
-        const discordGuild = client.guilds.cache.get(guildId) || await client.guilds.fetch(guildId).catch(() => null);
-        if (discordGuild) {
-          const member = await discordGuild.members.fetch(userId).catch(() => null);
-          if (member) {
-            const clanRoleIds = clans.map(c => c.roleId);
-            const memberClanRole = member.roles.cache.find(r => clanRoleIds.includes(r.id));
-            if (memberClanRole) {
-              const clan = clans.find(c => c.roleId === memberClanRole.id);
-              if (clan) {
-                await prisma.clanMemberContribution.upsert({
-                  where: {
-                    guildId_clanId_userId_season: {
-                      guildId,
-                      clanId: clan.id,
-                      userId,
-                      season: guildConfig.currentClanSeason
-                    }
-                  },
-                  update: {
-                    xp: { increment: amount }
-                  },
-                  create: {
-                    guildId,
-                    clanId: clan.id,
-                    userId,
-                    season: guildConfig.currentClanSeason,
-                    xp: amount
-                  }
-                });
-              }
-            }
-          }
-        }
-      }
-    }
-  } catch (err) {
-    logger.error('LevelingService', `Erreur de traitement des clans lors de l'ajout d'XP pour ${userId}:`, err);
-  }
+
 
   const previousLevel = memberLevel.level;
   // Le niveau est toujours recalculé depuis l'XP totale : ça gère les montées

--- a/apps/dashboard/src/App.svelte
+++ b/apps/dashboard/src/App.svelte
@@ -101,6 +101,8 @@
   import MCPSettings from "./pages/MCPSettings.svelte";
   import FunSettings from "./pages/FunSettings.svelte";
   import CustomBot from "./pages/CustomBot.svelte";
+  import Clans from "./pages/Clans.svelte";
+  import LevelingClanPublic from "./pages/LevelingClanPublic.svelte";
   import Verify from "./pages/Verify.svelte";
   import ChannelHealth from "./pages/ChannelHealth.svelte";
   import ChannelLinks from "./pages/ChannelLinks.svelte";
@@ -120,6 +122,7 @@
   const isPublicPage = $derived(
     /^\/\d{17,19}\/news\/?$/.test($router.path) ||
       /^\/\d{17,19}\/leveling\/classement\/?$/.test($router.path) ||
+      /^\/\d{17,19}\/leveling\/clan\/?$/.test($router.path) ||
       ($router.path.startsWith("/profile/") && !authStore.isAuthenticated) ||
       $router.path.startsWith("/transcripts/") ||
       $router.path.startsWith("/sanction-evidence/") ||
@@ -460,6 +463,9 @@
       </Route>
       <Route path="/:serverId/leveling/classement" let:meta>
         <LevelingPublic serverId={meta.params.serverId} />
+      </Route>
+      <Route path="/:serverId/leveling/clan" let:meta>
+        <LevelingClanPublic serverId={meta.params.serverId} />
       </Route>
       <Route path="/profile/:userId" let:meta>
         <PublicProfile userId={meta.params.userId} />
@@ -895,6 +901,9 @@
             </Route>
             <Route path="/fun">
               <FunSettings />
+            </Route>
+            <Route path="/clans">
+              <Clans />
             </Route>
 
             <Route path="/double-accounts/*">

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -3135,3 +3135,113 @@ export async function updateMessageLogConfig(
     errorContext: 'API Error (Message Config):',
   });
 }
+
+// ─────────────────────────────────────────────────────────────
+// Clans
+// ─────────────────────────────────────────────────────────────
+
+export interface ClanEntry {
+  id: string;
+  name: string;
+  description: string | null;
+  roleId: string;
+  memberCount: number;
+  totalXp: number;
+}
+
+export interface ClansDataResult {
+  clansEnabled: boolean;
+  clansUnique: boolean;
+  currentClanSeason: number;
+  clans: ClanEntry[];
+  taskInProgress: { type: 'distribute' | 'clear'; processed: number; total: number } | null;
+}
+
+export async function fetchClansData(guildId = authStore.selectedGuildId): Promise<ClansDataResult | null> {
+  return dashboardRequest('/clans', {
+    method: 'GET',
+    guildId,
+    errorContext: 'API Error (Fetch Clans):',
+    silent: true,
+  });
+}
+
+export async function updateClanSettings(
+  payload: { clansEnabled?: boolean; clansUnique?: boolean },
+  guildId = authStore.selectedGuildId,
+): Promise<{ clansEnabled: boolean; clansUnique: boolean } | null> {
+  return dashboardRequest('/clans', {
+    method: 'PATCH',
+    payload,
+    guildId,
+    errorContext: 'API Error (Update Clans Settings):',
+  });
+}
+
+export async function createClan(
+  payload: { name: string; description?: string; roleId: string },
+  guildId = authStore.selectedGuildId,
+): Promise<{ clan: ClanEntry } | null> {
+  return dashboardRequest('/clans', {
+    method: 'POST',
+    payload,
+    guildId,
+    errorContext: 'API Error (Create Clan):',
+  });
+}
+
+export async function updateClan(
+  id: string,
+  payload: { name: string; description?: string; roleId: string },
+  guildId = authStore.selectedGuildId,
+): Promise<{ clan: ClanEntry } | null> {
+  return dashboardRequest(`/clans/${id}`, {
+    method: 'PUT',
+    payload,
+    guildId,
+    errorContext: 'API Error (Update Clan):',
+  });
+}
+
+export async function deleteClan(id: string, guildId = authStore.selectedGuildId): Promise<boolean> {
+  return dashboardMutation(`/clans/${id}`, {
+    method: 'DELETE',
+    guildId,
+    errorContext: 'API Error (Delete Clan):',
+  });
+}
+
+export async function distributeClans(guildId = authStore.selectedGuildId): Promise<{ message: string } | null> {
+  return dashboardRequest('/clans/distribute', {
+    method: 'POST',
+    guildId,
+    errorContext: 'API Error (Distribute Clans):',
+  });
+}
+
+export async function clearClans(guildId = authStore.selectedGuildId): Promise<{ message: string } | null> {
+  return dashboardRequest('/clans/clear', {
+    method: 'POST',
+    guildId,
+    errorContext: 'API Error (Clear Clans):',
+  });
+}
+
+export async function resetClanSeason(guildId = authStore.selectedGuildId): Promise<{ currentClanSeason: number } | null> {
+  return dashboardRequest('/clans/reset-season', {
+    method: 'POST',
+    guildId,
+    errorContext: 'API Error (Reset Clan Season):',
+  });
+}
+
+export async function fetchPublicClans(guildId: string): Promise<any | null> {
+  try {
+    const response = await fetch(`${API_BASE_URL}/api/public/guilds/${guildId}/clans`);
+    if (!response.ok) return null;
+    return await response.json();
+  } catch (err) {
+    console.error('API Error (Fetch Public Clans):', err);
+    return null;
+  }
+}

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -3153,7 +3153,6 @@ export interface ClansDataResult {
   clansEnabled: boolean;
   clansUnique: boolean;
   currentClanSeason: number;
-  clanXpFromActivity: boolean;
   clanXpFromLevelUp: boolean;
   clanXpPerLevelUp: number;
   clans: ClanEntry[];
@@ -3173,7 +3172,6 @@ export async function updateClanSettings(
   payload: {
     clansEnabled?: boolean;
     clansUnique?: boolean;
-    clanXpFromActivity?: boolean;
     clanXpFromLevelUp?: boolean;
     clanXpPerLevelUp?: number;
   },
@@ -3181,7 +3179,6 @@ export async function updateClanSettings(
 ): Promise<{
   clansEnabled: boolean;
   clansUnique: boolean;
-  clanXpFromActivity: boolean;
   clanXpFromLevelUp: boolean;
   clanXpPerLevelUp: number;
 } | null> {

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -3153,6 +3153,9 @@ export interface ClansDataResult {
   clansEnabled: boolean;
   clansUnique: boolean;
   currentClanSeason: number;
+  clanXpFromActivity: boolean;
+  clanXpFromLevelUp: boolean;
+  clanXpPerLevelUp: number;
   clans: ClanEntry[];
   taskInProgress: { type: 'distribute' | 'clear'; processed: number; total: number } | null;
 }
@@ -3167,9 +3170,21 @@ export async function fetchClansData(guildId = authStore.selectedGuildId): Promi
 }
 
 export async function updateClanSettings(
-  payload: { clansEnabled?: boolean; clansUnique?: boolean },
+  payload: {
+    clansEnabled?: boolean;
+    clansUnique?: boolean;
+    clanXpFromActivity?: boolean;
+    clanXpFromLevelUp?: boolean;
+    clanXpPerLevelUp?: number;
+  },
   guildId = authStore.selectedGuildId,
-): Promise<{ clansEnabled: boolean; clansUnique: boolean } | null> {
+): Promise<{
+  clansEnabled: boolean;
+  clansUnique: boolean;
+  clanXpFromActivity: boolean;
+  clanXpFromLevelUp: boolean;
+  clanXpPerLevelUp: number;
+} | null> {
   return dashboardRequest('/clans', {
     method: 'PATCH',
     payload,

--- a/apps/dashboard/src/lib/config/pages.ts
+++ b/apps/dashboard/src/lib/config/pages.ts
@@ -67,6 +67,7 @@ export const communityItems: PageConfig[] = [
   { name: "Actualités & RSS",    icon: "rss",           href: "/news",             featureKey: "news", beta: false, wip: false },
   { name: "Salons Fun",          icon: "smile",         href: "/fun",              featureKey: "fun",  beta: true, wip: false },
   { name: "Réseaux sociaux",     icon: "share-2",       href: "/social-networks",  featureKey: "social_networks", beta: true, wip: false },
+  { name: "Clans",               icon: "shield",        href: "/clans",            featureKey: "welcome_goodbye", beta: true, wip: false },
 ];
 
 export const staffItems: PageConfig[] = [

--- a/apps/dashboard/src/pages/Clans.svelte
+++ b/apps/dashboard/src/pages/Clans.svelte
@@ -33,12 +33,18 @@
   let clansEnabled = $state(false);
   let clansUnique = $state(true);
   let currentClanSeason = $state(1);
+  let clanXpFromActivity = $state(true);
+  let clanXpFromLevelUp = $state(false);
+  let clanXpPerLevelUp = $state(50);
   let clans = $state<ClanEntry[]>([]);
   let taskInProgress = $state<ClansDataResult['taskInProgress']>(null);
 
   // Saved states (for dirty checking)
   let savedClansEnabled = $state(false);
   let savedClansUnique = $state(true);
+  let savedClanXpFromActivity = $state(true);
+  let savedClanXpFromLevelUp = $state(false);
+  let savedClanXpPerLevelUp = $state(50);
 
   // Form states
   let formName = $state('');
@@ -59,7 +65,12 @@
 
   // Sync state changes with the unsaved changes bar
   $effect(() => {
-    const dirty = clansEnabled !== savedClansEnabled || clansUnique !== savedClansUnique;
+    const dirty = clansEnabled !== savedClansEnabled 
+      || clansUnique !== savedClansUnique
+      || clanXpFromActivity !== savedClanXpFromActivity
+      || clanXpFromLevelUp !== savedClanXpFromLevelUp
+      || clanXpPerLevelUp !== savedClanXpPerLevelUp;
+
     if (dirty && canManageSettings) {
       untrack(() => {
         unsavedChanges.register({
@@ -68,6 +79,9 @@
           onReset: () => {
             clansEnabled = savedClansEnabled;
             clansUnique = savedClansUnique;
+            clanXpFromActivity = savedClanXpFromActivity;
+            clanXpFromLevelUp = savedClanXpFromLevelUp;
+            clanXpPerLevelUp = savedClanXpPerLevelUp;
           }
         });
       });
@@ -110,12 +124,18 @@
         clansEnabled = res.clansEnabled;
         clansUnique = res.clansUnique;
         currentClanSeason = res.currentClanSeason;
+        clanXpFromActivity = res.clanXpFromActivity;
+        clanXpFromLevelUp = res.clanXpFromLevelUp;
+        clanXpPerLevelUp = res.clanXpPerLevelUp;
         clans = res.clans;
         taskInProgress = res.taskInProgress;
 
         if (!silent) {
           savedClansEnabled = res.clansEnabled;
           savedClansUnique = res.clansUnique;
+          savedClanXpFromActivity = res.clanXpFromActivity;
+          savedClanXpFromLevelUp = res.clanXpFromLevelUp;
+          savedClanXpPerLevelUp = res.clanXpPerLevelUp;
         }
       }
     } catch (err) {
@@ -134,11 +154,20 @@
     if (!canManageSettings) return false;
     let success = false;
     await actionState.run(async () => {
-      const res = await updateClanSettings({ clansEnabled, clansUnique });
+      const res = await updateClanSettings({
+        clansEnabled,
+        clansUnique,
+        clanXpFromActivity,
+        clanXpFromLevelUp,
+        clanXpPerLevelUp
+      });
       if (!res) throw new Error('Erreur de sauvegarde');
       
       savedClansEnabled = res.clansEnabled;
       savedClansUnique = res.clansUnique;
+      savedClanXpFromActivity = res.clanXpFromActivity;
+      savedClanXpFromLevelUp = res.clanXpFromLevelUp;
+      savedClanXpPerLevelUp = res.clanXpPerLevelUp;
       success = true;
       return true;
     }, { successMessage: 'Paramètres des clans sauvegardés avec succès !' });
@@ -283,21 +312,60 @@
         <section class="bg-surface-container-low/40 border border-outline-variant/30 p-6 rounded-xl space-y-6">
           <h3 class="text-lg font-semibold border-b border-outline-variant/15 pb-2">⚙️ Configuration</h3>
           
-          <div class="space-y-4">
-            <div class="flex items-center justify-between">
-              <div>
-                <span class="text-sm font-medium text-on-surface">Activer les clans</span>
-                <p class="text-xs text-on-surface-variant/70">Active les commandes slash /clan et la sécurité.</p>
+          <div class="space-y-4 divide-y divide-outline-variant/10">
+            <div class="space-y-4 pb-4">
+              <div class="flex items-center justify-between">
+                <div>
+                  <span class="text-sm font-medium text-on-surface">Activer les clans</span>
+                  <p class="text-xs text-on-surface-variant/70">Active les commandes slash /clan et la sécurité.</p>
+                </div>
+                <ToggleSwitch bind:checked={clansEnabled} disabled={!canManageSettings} />
               </div>
-              <ToggleSwitch bind:checked={clansEnabled} disabled={!canManageSettings} />
+
+              <div class="flex items-center justify-between">
+                <div>
+                  <span class="text-sm font-medium text-on-surface">Clan Unique</span>
+                  <p class="text-xs text-on-surface-variant/70">Force un seul rôle de clan par membre Discord.</p>
+                </div>
+                <ToggleSwitch bind:checked={clansUnique} disabled={!canManageSettings} />
+              </div>
             </div>
 
-            <div class="flex items-center justify-between">
-              <div>
-                <span class="text-sm font-medium text-on-surface">Clan Unique</span>
-                <p class="text-xs text-on-surface-variant/70">Force un seul rôle de clan par membre Discord.</p>
+            <div class="space-y-4 pt-4">
+              <h4 class="text-xs font-bold text-on-surface-variant/80 uppercase tracking-wider">⚡ Sources de points</h4>
+              
+              <div class="flex items-center justify-between">
+                <div>
+                  <span class="text-sm font-medium text-on-surface">Activité (écrit / vocal)</span>
+                  <p class="text-xs text-on-surface-variant/70">Gagne des points de clan via l'XP de chat/vocal.</p>
+                </div>
+                <ToggleSwitch bind:checked={clanXpFromActivity} disabled={!canManageSettings} />
               </div>
-              <ToggleSwitch bind:checked={clansUnique} disabled={!canManageSettings} />
+
+              <div class="flex items-center justify-between">
+                <div>
+                  <span class="text-sm font-medium text-on-surface">Passage de niveau</span>
+                  <p class="text-xs text-on-surface-variant/70">Points bonus offerts lors d'un level up sur le serveur.</p>
+                </div>
+                <ToggleSwitch bind:checked={clanXpFromLevelUp} disabled={!canManageSettings} />
+              </div>
+
+              {#if clanXpFromLevelUp}
+                <div class="space-y-1.5 pl-4 animate-in slide-in-from-top-2 duration-200">
+                  <label for="clan-xp-levelup-amount" class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest">Points attribués par niveau</label>
+                  <div class="flex items-center gap-2">
+                    <input
+                      id="clan-xp-levelup-amount"
+                      type="number"
+                      bind:value={clanXpPerLevelUp}
+                      min="0"
+                      class="w-24 bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-2.5 py-1.5 text-xs text-on-surface focus:outline-none focus:ring-1 focus:ring-primary/40 font-bold"
+                      disabled={!canManageSettings}
+                    />
+                    <span class="text-xs text-on-surface-variant/60 font-semibold">XP / niveau</span>
+                  </div>
+                </div>
+              {/if}
             </div>
           </div>
         </section>

--- a/apps/dashboard/src/pages/Clans.svelte
+++ b/apps/dashboard/src/pages/Clans.svelte
@@ -33,7 +33,6 @@
   let clansEnabled = $state(false);
   let clansUnique = $state(true);
   let currentClanSeason = $state(1);
-  let clanXpFromActivity = $state(true);
   let clanXpFromLevelUp = $state(false);
   let clanXpPerLevelUp = $state(50);
   let clans = $state<ClanEntry[]>([]);
@@ -42,7 +41,6 @@
   // Saved states (for dirty checking)
   let savedClansEnabled = $state(false);
   let savedClansUnique = $state(true);
-  let savedClanXpFromActivity = $state(true);
   let savedClanXpFromLevelUp = $state(false);
   let savedClanXpPerLevelUp = $state(50);
 
@@ -67,7 +65,6 @@
   $effect(() => {
     const dirty = clansEnabled !== savedClansEnabled 
       || clansUnique !== savedClansUnique
-      || clanXpFromActivity !== savedClanXpFromActivity
       || clanXpFromLevelUp !== savedClanXpFromLevelUp
       || clanXpPerLevelUp !== savedClanXpPerLevelUp;
 
@@ -79,7 +76,6 @@
           onReset: () => {
             clansEnabled = savedClansEnabled;
             clansUnique = savedClansUnique;
-            clanXpFromActivity = savedClanXpFromActivity;
             clanXpFromLevelUp = savedClanXpFromLevelUp;
             clanXpPerLevelUp = savedClanXpPerLevelUp;
           }
@@ -124,7 +120,6 @@
         clansEnabled = res.clansEnabled;
         clansUnique = res.clansUnique;
         currentClanSeason = res.currentClanSeason;
-        clanXpFromActivity = res.clanXpFromActivity;
         clanXpFromLevelUp = res.clanXpFromLevelUp;
         clanXpPerLevelUp = res.clanXpPerLevelUp;
         clans = res.clans;
@@ -133,7 +128,6 @@
         if (!silent) {
           savedClansEnabled = res.clansEnabled;
           savedClansUnique = res.clansUnique;
-          savedClanXpFromActivity = res.clanXpFromActivity;
           savedClanXpFromLevelUp = res.clanXpFromLevelUp;
           savedClanXpPerLevelUp = res.clanXpPerLevelUp;
         }
@@ -157,7 +151,6 @@
       const res = await updateClanSettings({
         clansEnabled,
         clansUnique,
-        clanXpFromActivity,
         clanXpFromLevelUp,
         clanXpPerLevelUp
       });
@@ -165,7 +158,6 @@
       
       savedClansEnabled = res.clansEnabled;
       savedClansUnique = res.clansUnique;
-      savedClanXpFromActivity = res.clanXpFromActivity;
       savedClanXpFromLevelUp = res.clanXpFromLevelUp;
       savedClanXpPerLevelUp = res.clanXpPerLevelUp;
       success = true;
@@ -333,14 +325,6 @@
 
             <div class="space-y-4 pt-4">
               <h4 class="text-xs font-bold text-on-surface-variant/80 uppercase tracking-wider">⚡ Sources de points</h4>
-              
-              <div class="flex items-center justify-between">
-                <div>
-                  <span class="text-sm font-medium text-on-surface">Activité (écrit / vocal)</span>
-                  <p class="text-xs text-on-surface-variant/70">Gagne des points de clan via l'XP de chat/vocal.</p>
-                </div>
-                <ToggleSwitch bind:checked={clanXpFromActivity} disabled={!canManageSettings} />
-              </div>
 
               <div class="flex items-center justify-between">
                 <div>

--- a/apps/dashboard/src/pages/Clans.svelte
+++ b/apps/dashboard/src/pages/Clans.svelte
@@ -1,0 +1,589 @@
+<script lang="ts">
+  import { onMount, onDestroy, untrack } from 'svelte';
+  import { fade, scale } from 'svelte/transition';
+  import { dashboardStore } from '../lib/stores/dashboard.svelte';
+  import { createAsyncActionState } from '../lib/asyncAction.svelte';
+  import { unsavedChanges } from '../lib/stores/unsavedChanges.svelte';
+  import Papicon from '../lib/components/Papicon.svelte';
+  import InlineFeedback from '../lib/components/InlineFeedback.svelte';
+  import SearchableSelect from '../lib/components/SearchableSelect.svelte';
+  import Skeleton from '../lib/components/Skeleton.svelte';
+  import LoadingHint from '../lib/components/LoadingHint.svelte';
+  import ModulePage from '../lib/components/ModulePage.svelte';
+  import ToggleSwitch from '../lib/components/ToggleSwitch.svelte';
+  import {
+    fetchClansData,
+    updateClanSettings,
+    createClan,
+    updateClan,
+    deleteClan,
+    distributeClans,
+    clearClans,
+    resetClanSeason,
+    type ClanEntry,
+    type ClansDataResult
+  } from '../lib/api';
+
+  const actionState = createAsyncActionState();
+  let loading = $state(false);
+  let showModal = $state(false);
+  let editingClan = $state<ClanEntry | null>(null);
+
+  // States
+  let clansEnabled = $state(false);
+  let clansUnique = $state(true);
+  let currentClanSeason = $state(1);
+  let clans = $state<ClanEntry[]>([]);
+  let taskInProgress = $state<ClansDataResult['taskInProgress']>(null);
+
+  // Saved states (for dirty checking)
+  let savedClansEnabled = $state(false);
+  let savedClansUnique = $state(true);
+
+  // Form states
+  let formName = $state('');
+  let formDescription = $state('');
+  let formRoleId = $state('');
+
+  // Confirmation state for reset/clear/distribute
+  let confirmInput = $state('');
+  let confirmActionType = $state<'clear' | 'reset' | 'distribute' | null>(null);
+  let showConfirmModal = $state(false);
+
+  const canManageSettings = $derived(
+    !!dashboardStore.state.featureAccess?.welcome_goodbye?.canConfigure
+      || !!dashboardStore.state.access?.canManageSettings
+  );
+
+  const availableRoles = $derived(dashboardStore.state.discordRoles || []);
+
+  // Sync state changes with the unsaved changes bar
+  $effect(() => {
+    const dirty = clansEnabled !== savedClansEnabled || clansUnique !== savedClansUnique;
+    if (dirty && canManageSettings) {
+      untrack(() => {
+        unsavedChanges.register({
+          label: 'Configuration des Clans',
+          onSave: () => handleSaveSettings(),
+          onReset: () => {
+            clansEnabled = savedClansEnabled;
+            clansUnique = savedClansUnique;
+          }
+        });
+      });
+    } else if (!dirty) {
+      untrack(() => {
+        if (unsavedChanges.isDirty && unsavedChanges.pageLabel === 'Configuration des Clans') {
+          unsavedChanges.clear();
+        }
+      });
+    }
+  });
+
+  // Polling mechanism while a background operation is active
+  let pollInterval: ReturnType<typeof setInterval> | null = null;
+  $effect(() => {
+    if (taskInProgress && !pollInterval) {
+      pollInterval = setInterval(() => {
+        void refreshData(true);
+      }, 2000);
+    } else if (!taskInProgress && pollInterval) {
+      clearInterval(pollInterval);
+      pollInterval = null;
+    }
+  });
+
+  onDestroy(() => {
+    if (unsavedChanges.pageLabel === 'Configuration des Clans') {
+      unsavedChanges.clear();
+    }
+    if (pollInterval) {
+      clearInterval(pollInterval);
+    }
+  });
+
+  async function refreshData(silent = false) {
+    if (!silent) loading = true;
+    try {
+      const res = await fetchClansData();
+      if (res) {
+        clansEnabled = res.clansEnabled;
+        clansUnique = res.clansUnique;
+        currentClanSeason = res.currentClanSeason;
+        clans = res.clans;
+        taskInProgress = res.taskInProgress;
+
+        if (!silent) {
+          savedClansEnabled = res.clansEnabled;
+          savedClansUnique = res.clansUnique;
+        }
+      }
+    } catch (err) {
+      console.error(err);
+    } finally {
+      if (!silent) loading = false;
+    }
+  }
+
+  onMount(async () => {
+    await dashboardStore.refresh();
+    await refreshData();
+  });
+
+  async function handleSaveSettings(): Promise<boolean> {
+    if (!canManageSettings) return false;
+    let success = false;
+    await actionState.run(async () => {
+      const res = await updateClanSettings({ clansEnabled, clansUnique });
+      if (!res) throw new Error('Erreur de sauvegarde');
+      
+      savedClansEnabled = res.clansEnabled;
+      savedClansUnique = res.clansUnique;
+      success = true;
+      return true;
+    }, { successMessage: 'Paramètres des clans sauvegardés avec succès !' });
+    return success;
+  }
+
+  function openCreateModal() {
+    editingClan = null;
+    formName = '';
+    formDescription = '';
+    formRoleId = '';
+    actionState.clearFeedback();
+    showModal = true;
+  }
+
+  function openEditModal(clan: ClanEntry) {
+    editingClan = clan;
+    formName = clan.name;
+    formDescription = clan.description || '';
+    formRoleId = clan.roleId;
+    actionState.clearFeedback();
+    showModal = true;
+  }
+
+  async function handleSaveClan() {
+    if (!canManageSettings || !formName || !formRoleId) return;
+
+    await actionState.run(async () => {
+      if (editingClan) {
+        const res = await updateClan(editingClan.id, {
+          name: formName,
+          description: formDescription || undefined,
+          roleId: formRoleId
+        });
+        if (!res) throw new Error('Erreur lors de la modification');
+        clans = clans.map(c => c.id === editingClan!.id ? res.clan : c);
+      } else {
+        const res = await createClan({
+          name: formName,
+          description: formDescription || undefined,
+          roleId: formRoleId
+        });
+        if (!res) throw new Error('Erreur lors de la création');
+        clans = [...clans, res.clan];
+      }
+      showModal = false;
+      await refreshData(true);
+      return true;
+    }, { successMessage: editingClan ? 'Clan modifié avec succès !' : 'Clan créé avec succès !' });
+  }
+
+  async function handleDeleteClan(clan: ClanEntry) {
+    if (!canManageSettings) return;
+    if (!confirm(`Voulez-vous vraiment supprimer le clan "${clan.name}" ?`)) return;
+
+    await actionState.run(async () => {
+      const success = await deleteClan(clan.id);
+      if (!success) throw new Error('Erreur de suppression');
+      clans = clans.filter(c => c.id !== clan.id);
+      return true;
+    }, { successMessage: 'Clan supprimé.' });
+  }
+
+  function openConfirmation(type: 'clear' | 'reset' | 'distribute') {
+    confirmActionType = type;
+    confirmInput = '';
+    showConfirmModal = true;
+  }
+
+  async function handleConfirmAction() {
+    if (!canManageSettings || !confirmActionType) return;
+
+    const expected = confirmActionType === 'clear' 
+      ? 'RETIRER' 
+      : confirmActionType === 'reset' 
+      ? 'RESET' 
+      : 'DISTRIBUER';
+
+    if (confirmInput.toUpperCase() !== expected) {
+      alert('Veuillez saisir le mot de confirmation correct.');
+      return;
+    }
+
+    showConfirmModal = false;
+
+    await actionState.run(async () => {
+      if (confirmActionType === 'clear') {
+        const res = await clearClans();
+        if (!res) throw new Error('Erreur lors du retrait');
+        await refreshData(true);
+      } else if (confirmActionType === 'reset') {
+        const res = await resetClanSeason();
+        if (!res) throw new Error('Erreur lors du reset');
+        currentClanSeason = res.currentClanSeason;
+        await refreshData(true);
+      } else if (confirmActionType === 'distribute') {
+        const res = await distributeClans();
+        if (!res) throw new Error('Erreur lors du lancement');
+        await refreshData(true);
+      }
+      return true;
+    }, {
+      successMessage: confirmActionType === 'clear'
+        ? 'Retrait de tous les rôles démarré en arrière-plan.'
+        : confirmActionType === 'reset'
+        ? 'Nouvelle saison de clans démarrée !'
+        : 'Distribution aléatoire lancée en arrière-plan.'
+    });
+  }
+
+  function handleDistribute() {
+    if (!canManageSettings) return;
+    if (clans.length === 0) {
+      alert('Veuillez configurer au moins un clan avant de lancer la distribution.');
+      return;
+    }
+    openConfirmation('distribute');
+  }
+</script>
+
+<ModulePage
+  title="Clans"
+  description="Divisez votre communauté en clans basés sur des rôles Discord et suivez la compétition."
+  icon="Shield"
+  featureKey="welcome_goodbye"
+>
+  <InlineFeedback state={actionState} />
+
+  {#if loading}
+    <div class="space-y-6">
+      <Skeleton height="80px" />
+      <Skeleton height="300px" />
+    </div>
+    <div class="flex justify-center mt-4">
+      <LoadingHint context="clans" />
+    </div>
+  {:else}
+    <div class="grid grid-cols-1 xl:grid-cols-3 gap-8">
+      
+      <!-- Left side: General Settings -->
+      <div class="xl:col-span-1 space-y-6">
+        <section class="bg-surface-container-low/40 border border-outline-variant/30 p-6 rounded-xl space-y-6">
+          <h3 class="text-lg font-semibold border-b border-outline-variant/15 pb-2">⚙️ Configuration</h3>
+          
+          <div class="space-y-4">
+            <div class="flex items-center justify-between">
+              <div>
+                <span class="text-sm font-medium text-on-surface">Activer les clans</span>
+                <p class="text-xs text-on-surface-variant/70">Active les commandes slash /clan et la sécurité.</p>
+              </div>
+              <ToggleSwitch bind:checked={clansEnabled} disabled={!canManageSettings} />
+            </div>
+
+            <div class="flex items-center justify-between">
+              <div>
+                <span class="text-sm font-medium text-on-surface">Clan Unique</span>
+                <p class="text-xs text-on-surface-variant/70">Force un seul rôle de clan par membre Discord.</p>
+              </div>
+              <ToggleSwitch bind:checked={clansUnique} disabled={!canManageSettings} />
+            </div>
+          </div>
+        </section>
+
+        <!-- Seasons control -->
+        <section class="bg-surface-container-low/40 border border-outline-variant/30 p-6 rounded-xl space-y-6">
+          <div class="flex items-center justify-between border-b border-outline-variant/15 pb-2">
+            <h3 class="text-lg font-semibold">📅 Saison Actuelle</h3>
+            <span class="px-3 py-1 bg-amber-500/10 text-amber-500 text-xs font-bold rounded-full">Saison {currentClanSeason}</span>
+          </div>
+
+          <div class="space-y-4">
+            <p class="text-xs text-on-surface-variant/70">
+              Passer à la saison suivante réinitialise l'XP active de tous les clans à 0. L'historique des contributions des anciennes saisons reste conservé en base de données.
+            </p>
+            {#if canManageSettings}
+              <button
+                onclick={() => openConfirmation('reset')}
+                class="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-amber-500 hover:bg-amber-600 text-white font-semibold text-xs rounded-lg transition-colors cursor-pointer"
+              >
+                <Papicon icon="Refresh" size={14} /> Réinitialiser la Saison (Reset)
+              </button>
+            {/if}
+          </div>
+        </section>
+
+        <!-- Bulk Task Progress Bar -->
+        {#if taskInProgress}
+          <section class="bg-primary/5 border border-primary/20 p-6 rounded-xl space-y-4 animate-pulse">
+            <h3 class="text-sm font-bold text-primary uppercase tracking-wider flex items-center gap-2">
+              <svg class="animate-spin h-4 w-4 text-primary" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+              </svg>
+              Tâche en arrière-plan active
+            </h3>
+            
+            <div class="space-y-2">
+              <div class="flex justify-between text-xs font-medium text-on-surface-variant">
+                <span>{taskInProgress.type === 'distribute' ? 'Distribution aléatoire' : 'Retrait des rôles'}</span>
+                <span>{taskInProgress.processed} / {taskInProgress.total}</span>
+              </div>
+              <div class="w-full bg-surface-container-high rounded-full h-2">
+                <div class="bg-primary h-2 rounded-full transition-all duration-300" style="width: {taskInProgress.total > 0 ? (taskInProgress.processed / taskInProgress.total) * 100 : 0}%"></div>
+              </div>
+            </div>
+          </section>
+        {/if}
+      </div>
+
+      <!-- Right side: Clans List & Leaderboard -->
+      <div class="xl:col-span-2 space-y-6">
+        <section class="bg-surface-container-low/40 border border-outline-variant/30 p-6 rounded-xl space-y-6">
+          <div class="flex items-center justify-between border-b border-outline-variant/15 pb-3">
+            <h3 class="text-lg font-semibold">🛡️ Clans Configurés</h3>
+            <div class="flex gap-2">
+              {#if canManageSettings}
+                <button
+                  onclick={() => openConfirmation('clear')}
+                  class="flex items-center gap-1.5 px-3 py-1.5 border border-rose-500/30 hover:bg-rose-500/10 text-rose-500 font-bold text-xs rounded-lg transition-colors cursor-pointer"
+                  title="Retirer tous les rôles de clan du serveur"
+                >
+                  <Papicon icon="Trash" size={12} /> Retirer à tous
+                </button>
+                <button
+                  onclick={handleDistribute}
+                  class="flex items-center gap-1.5 px-3 py-1.5 bg-secondary/15 hover:bg-secondary/25 text-secondary font-bold text-xs rounded-lg transition-colors cursor-pointer"
+                  title="Distribuer aléatoirement les membres sans clan"
+                >
+                  <Papicon icon="Users" size={12} /> Distribuer
+                </button>
+                <button
+                  onclick={openCreateModal}
+                  class="flex items-center gap-1.5 px-3 py-1.5 bg-primary text-on-primary font-bold text-xs rounded-lg hover:opacity-90 transition-opacity cursor-pointer"
+                >
+                  <Papicon icon="Add" size={12} /> Nouveau clan
+                </button>
+              {/if}
+            </div>
+          </div>
+
+          {#if clans.length === 0}
+            <div class="flex flex-col items-center justify-center py-12 text-center">
+              <p class="text-sm text-on-surface-variant/60 font-medium">Aucun clan n'a été créé.</p>
+              <p class="text-xs text-on-surface-variant/40">Cliquez sur « Nouveau clan » pour commencer la configuration.</p>
+            </div>
+          {:else}
+            <!-- Clans table -->
+            <div class="overflow-x-auto">
+              <table class="w-full text-left border-collapse">
+                <thead>
+                  <tr class="border-b border-outline-variant/10 text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-wider">
+                    <th class="pb-3">Clan</th>
+                    <th class="pb-3">Rôle Discord</th>
+                    <th class="pb-3 text-center">Membres</th>
+                    <th class="pb-3 text-right">XP Cumulée</th>
+                    {#if canManageSettings}
+                      <th class="pb-3 text-right">Actions</th>
+                    {/if}
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-outline-variant/10">
+                  {#each clans as clan}
+                    <tr class="hover:bg-surface-container-low/20 transition-colors">
+                      <td class="py-4">
+                        <span class="font-bold text-sm text-on-surface">{clan.name}</span>
+                        {#if clan.description}
+                          <p class="text-xs text-on-surface-variant/70 max-w-[200px] truncate">{clan.description}</p>
+                        {/if}
+                      </td>
+                      <td class="py-4">
+                        <span class="px-2 py-1 bg-surface-container-high rounded text-xs text-on-surface-variant">
+                          {availableRoles.find(r => r.id === clan.roleId)?.name || `ID: ${clan.roleId}`}
+                        </span>
+                      </td>
+                      <td class="py-4 text-center font-medium text-xs text-on-surface">
+                        {clan.memberCount}
+                      </td>
+                      <td class="py-4 text-right font-bold text-xs text-amber-500">
+                        {clan.totalXp.toLocaleString('fr-FR')} XP
+                      </td>
+                      {#if canManageSettings}
+                        <td class="py-4 text-right space-x-2">
+                          <button
+                            onclick={() => openEditModal(clan)}
+                            class="p-1.5 hover:bg-surface-container-high rounded-lg text-on-surface-variant transition-colors cursor-pointer inline-flex"
+                            title="Modifier"
+                          >
+                            <Papicon icon="Edit" size={14} />
+                          </button>
+                          <button
+                            onclick={() => handleDeleteClan(clan)}
+                            class="p-1.5 hover:bg-rose-500/10 text-rose-500 rounded-lg transition-colors cursor-pointer inline-flex"
+                            title="Supprimer"
+                          >
+                            <Papicon icon="Trash" size={14} />
+                          </button>
+                        </td>
+                      {/if}
+                    </tr>
+                  {/each}
+                </tbody>
+              </table>
+            </div>
+          {/if}
+        </section>
+      </div>
+
+    </div>
+  {/if}
+</ModulePage>
+
+<!-- Modal: Créer / Éditer un Clan -->
+{#if showModal}
+  <div class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4" transition:fade={{ duration: 150 }}>
+    <div class="bg-surface-container-low/95 border border-outline-variant/20 max-w-lg w-full rounded-xl p-6 space-y-6 shadow-lg relative" transition:scale={{ start: 0.97, duration: 150 }}>
+      
+      <button
+        onclick={() => showModal = false}
+        class="absolute top-6 right-6 p-2 rounded-full bg-surface-container-high/40 hover:bg-rose-500/15 hover:text-rose-500 text-on-surface-variant transition-colors cursor-pointer"
+      >
+        <Papicon icon="Cross" size={18} />
+      </button>
+
+      <div>
+        <h3 class="text-xl font-semibold">{editingClan ? 'Modifier le clan' : 'Créer un clan'}</h3>
+        <p class="text-xs text-on-surface-variant/80">Liez un rôle Discord et configurez les détails de votre clan.</p>
+      </div>
+
+      <form onsubmit={(e) => { e.preventDefault(); handleSaveClan(); }} class="space-y-4">
+        <div class="space-y-1.5">
+          <label for="clan-name" class="text-[10px] font-bold text-on-surface-variant/60 ml-1 uppercase tracking-widest">Nom du Clan</label>
+          <input
+            id="clan-name"
+            type="text"
+            bind:value={formName}
+            placeholder="Ex: Griffondor, Guerriers, etc."
+            class="w-full bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-primary/30 transition-all text-on-surface focus:outline-none"
+            required
+            disabled={!canManageSettings}
+          />
+        </div>
+
+        <div class="space-y-1.5">
+          <label for="clan-desc" class="text-[10px] font-bold text-on-surface-variant/60 ml-1 uppercase tracking-widest">Description</label>
+          <textarea
+            id="clan-desc"
+            bind:value={formDescription}
+            placeholder="Description du clan, son histoire ou sa devise..."
+            class="w-full bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-primary/30 transition-all text-on-surface focus:outline-none h-20"
+            disabled={!canManageSettings}
+          ></textarea>
+        </div>
+
+        <div class="space-y-1.5">
+          <label for="clan-role" class="text-[10px] font-bold text-on-surface-variant/60 ml-1 uppercase tracking-widest">Rôle Discord Associé</label>
+          <SearchableSelect
+            id="clan-role"
+            bind:value={formRoleId}
+            options={availableRoles.map(r => ({ id: r.id, name: r.name }))}
+            placeholder="Choisir le rôle Discord"
+            disabled={!canManageSettings}
+          />
+        </div>
+
+        <div class="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onclick={() => showModal = false}
+            class="px-4 py-2 border border-outline-variant/30 hover:bg-surface-container-high/60 text-on-surface text-xs font-semibold rounded-lg transition-colors cursor-pointer"
+          >
+            Annuler
+          </button>
+          <button
+            type="submit"
+            class="px-4 py-2 bg-primary text-on-primary text-xs font-semibold rounded-lg hover:opacity-90 transition-opacity cursor-pointer"
+          >
+            Enregistrer
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+{/if}
+
+<!-- Modal: Confirmation de Double Validation (Reset / Clear) -->
+{#if showConfirmModal}
+  <div class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4" transition:fade={{ duration: 150 }}>
+    <div class="bg-surface-container-low border border-outline-variant/20 max-w-md w-full rounded-xl p-6 space-y-6 shadow-lg relative" transition:scale={{ start: 0.97, duration: 150 }}>
+      
+      <button
+        onclick={() => showConfirmModal = false}
+        class="absolute top-6 right-6 p-2 rounded-full bg-surface-container-high/40 hover:bg-rose-500/15 hover:text-rose-500 text-on-surface-variant transition-colors cursor-pointer"
+      >
+        <Papicon icon="Cross" size={18} />
+      </button>
+
+      <div>
+        <h3 class="text-lg font-semibold text-rose-500 flex items-center gap-2">
+          <Papicon icon="AlertTriangle" size={20} />
+          Validation requise
+        </h3>
+        <p class="text-xs text-on-surface-variant/80 mt-1">
+          {#if confirmActionType === 'clear'}
+            Vous vous apprêtez à <strong>retirer tous les rôles de clan</strong> de tous les membres du serveur. Cette action s'exécute progressivement en arrière-plan.
+          {:else}
+            {#if confirmActionType === 'reset'}
+              Vous vous apprêtez à <strong>clore la saison active</strong> de clans et à passer à la suivante. Les scores d'XP des clans repartiront à 0.
+            {:else if confirmActionType === 'distribute'}
+              Vous vous apprêtez à <strong>distribuer aléatoirement un clan</strong> à tous les membres sans clan. Cette action s'exécute progressivement en arrière-plan.
+            {/if}
+          {/if}
+        </p>
+      </div>
+
+      <div class="space-y-4">
+        <div class="space-y-1.5">
+          <label for="confirm-word" class="text-[10px] font-bold text-on-surface-variant/60 ml-1 uppercase tracking-widest">
+            Saisissez <strong>{confirmActionType === 'clear' ? 'RETIRER' : confirmActionType === 'reset' ? 'RESET' : 'DISTRIBUER'}</strong> pour confirmer
+          </label>
+          <input
+            id="confirm-word"
+            type="text"
+            bind:value={confirmInput}
+            placeholder={confirmActionType === 'clear' ? 'RETIRER' : confirmActionType === 'reset' ? 'RESET' : 'DISTRIBUER'}
+            class="w-full bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-primary/30 transition-all text-on-surface focus:outline-none font-bold uppercase tracking-wider"
+          />
+        </div>
+
+        <div class="flex justify-end gap-2">
+          <button
+            type="button"
+            onclick={() => showConfirmModal = false}
+            class="px-4 py-2 border border-outline-variant/30 hover:bg-surface-container-high/60 text-on-surface text-xs font-semibold rounded-lg transition-colors cursor-pointer"
+          >
+            Annuler
+          </button>
+          <button
+            type="button"
+            onclick={handleConfirmAction}
+            class="px-4 py-2 bg-rose-500 text-white text-xs font-semibold rounded-lg hover:bg-rose-600 transition-colors cursor-pointer"
+          >
+            Confirmer
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/apps/dashboard/src/pages/LevelingClanPublic.svelte
+++ b/apps/dashboard/src/pages/LevelingClanPublic.svelte
@@ -1,0 +1,295 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import Papicon from '../lib/components/Papicon.svelte';
+  import Skeleton from '../lib/components/Skeleton.svelte';
+  import { fetchPublicClans } from '../lib/api';
+
+  interface Props {
+    serverId: string;
+  }
+  const { serverId }: Props = $props();
+
+  let loading = $state(true);
+  let errorMsg = $state<string | null>(null);
+  let guildName = $state('Kotbo Server');
+  let guildIcon = $state<string | null>(null);
+  let enabled = $state(false);
+  let currentClanSeason = $state(1);
+  
+  interface Participant {
+    userId: string;
+    xp: number;
+    displayName: string;
+    avatarUrl: string | null;
+  }
+
+  interface ClanData {
+    id: string;
+    name: string;
+    description: string | null;
+    roleId: string;
+    roleColor: string | null;
+    totalXp: number;
+    memberCount: number;
+    topParticipants: Participant[];
+  }
+
+  let clans = $state<ClanData[]>([]);
+  let searchQuery = $state('');
+
+  onMount(async () => {
+    try {
+      const res = await fetchPublicClans(serverId);
+      if (res) {
+        enabled = res.enabled ?? false;
+        guildName = res.guildName ?? 'Kotbo Server';
+        guildIcon = res.guildIcon ?? null;
+        currentClanSeason = res.currentClanSeason ?? 1;
+        clans = res.clans || [];
+      }
+    } catch (err: any) {
+      console.error(err);
+      errorMsg = err.message || 'Erreur lors du chargement des données des clans.';
+    } finally {
+      loading = false;
+    }
+  });
+
+  // Filter participants in each clan based on search query
+  function getFilteredParticipants(clan: ClanData): Participant[] {
+    if (!searchQuery) return clan.topParticipants;
+    const q = searchQuery.toLowerCase().normalize('NFD').replace(/\p{Diacritic}/gu, '');
+    return clan.topParticipants.filter(p => {
+      const name = p.displayName.toLowerCase().normalize('NFD').replace(/\p{Diacritic}/gu, '');
+      return name.includes(q) || p.userId.includes(searchQuery);
+    });
+  }
+
+  function formatXp(xp: number): string {
+    if (xp >= 1_000_000) return `${(xp / 1_000_000).toFixed(1)}M`;
+    if (xp >= 1_000) return `${(xp / 1_000).toFixed(1)}k`;
+    return xp.toLocaleString();
+  }
+
+  function getRankBadgeColor(rank: number) {
+    if (rank === 1) return 'bg-amber-500/10 text-amber-500 border border-amber-500/20';
+    if (rank === 2) return 'bg-slate-400/10 text-slate-400 border border-slate-400/20';
+    if (rank === 3) return 'bg-amber-700/10 text-amber-700 border border-amber-700/20';
+    return 'bg-slate-100 dark:bg-slate-800 text-slate-500';
+  }
+</script>
+
+<svelte:head>
+  <title>Classement des Clans — {guildName}</title>
+  <meta name="description" content="Classement compétitif et scores des clans de {guildName} sur Discord." />
+</svelte:head>
+
+<div class="min-h-screen whiteboard-container relative overflow-x-hidden selection:bg-yellow-100 dark:selection:bg-slate-850 py-12 px-4 sm:px-6 z-10">
+  
+  <div class="relative z-10 w-full max-w-6xl mx-auto space-y-10 animate-in fade-in duration-300">
+
+    <!-- ─── En-tête style Feuille Index épuré ─── -->
+    <header class="relative flex flex-col sm:flex-row sm:items-center justify-between gap-4 bg-white dark:bg-[#111a2e] border border-slate-200 dark:border-slate-800 p-5 rounded-lg shadow-sm overflow-hidden group">
+      <div class="tape-accent"></div>
+
+      <div class="flex items-center gap-4">
+        {#if guildIcon}
+          <div class="relative shrink-0">
+            <img src={guildIcon} alt="{guildName} Logo" class="w-11 h-11 rounded-lg object-cover border border-slate-200 dark:border-slate-800" />
+          </div>
+        {:else}
+          <div class="relative w-11 h-11 bg-slate-50 dark:bg-[#0c1322] border border-slate-200 dark:border-slate-800 rounded-lg flex items-center justify-center font-bold text-sm text-slate-800 dark:text-slate-100 shrink-0">
+            <span>{guildName.slice(0, 2).toUpperCase()}</span>
+          </div>
+        {/if}
+
+        <div class="relative">
+          <h1 class="text-lg font-extrabold tracking-tight text-slate-800 dark:text-slate-100">
+            {guildName}
+          </h1>
+          <div class="flex items-center gap-1.5 text-slate-500 dark:text-slate-400 font-semibold text-xs uppercase tracking-wider">
+            <span class="text-amber-500"><Papicon icon="Shield" size={14} /></span>
+            <span>Guerre des Clans — Saison {currentClanSeason}</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Badge "Live" -->
+      <div class="flex items-center gap-2 self-start sm:self-auto px-3 py-1.5 rounded-full border border-emerald-500/20 dark:border-emerald-500/10 bg-emerald-500/5 text-emerald-600 dark:text-emerald-400 text-xs font-bold">
+        <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-ping"></span>
+        <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 absolute"></span>
+        <span class="ml-2.5 uppercase tracking-wider text-[10px]">Temps Réel</span>
+      </div>
+    </header>
+
+    {#if loading}
+      <!-- Loading Skeletons -->
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+        <Skeleton height="500px" radius="1.25rem" />
+        <Skeleton height="500px" radius="1.25rem" />
+      </div>
+    {:else if errorMsg}
+      <!-- Error Message -->
+      <div class="bg-white dark:bg-[#111a2e] border border-red-200 dark:border-red-950 p-12 rounded-lg text-center space-y-4 shadow-sm">
+        <div class="w-12 h-12 bg-red-50 dark:bg-red-950/35 rounded-full flex items-center justify-center text-red-500 dark:text-red-400 mx-auto">
+          <Papicon icon="AlertTriangle" size={20} />
+        </div>
+        <div class="space-y-1.5">
+          <p class="text-slate-800 dark:text-slate-100 font-extrabold text-lg">Une erreur est survenue</p>
+          <p class="text-slate-505 dark:text-slate-400 text-sm max-w-md mx-auto">{errorMsg}</p>
+        </div>
+      </div>
+    {:else if !enabled || clans.length === 0}
+      <!-- Module disabled -->
+      <div class="bg-white dark:bg-[#111a2e] border border-slate-200 dark:border-slate-800 p-16 rounded-lg text-center flex flex-col items-center space-y-4 shadow-sm">
+        <div class="w-14 h-14 rounded-full bg-slate-50 dark:bg-[#0c1322] flex items-center justify-center text-slate-400">
+          <Papicon icon="Lock" size={24} />
+        </div>
+        <div class="space-y-1.5 max-w-sm">
+          <h2 class="text-xl font-bold text-slate-800 dark:text-slate-100">Classement Inactif</h2>
+          <p class="text-slate-500 dark:text-slate-400 text-sm leading-relaxed">
+            Le module de Clans n'est pas activé sur ce serveur ou aucun clan n'a été configuré par l'administration.
+          </p>
+        </div>
+      </div>
+    {:else}
+      <!-- ─── Search Bar ─── -->
+      <div class="relative max-w-md mx-auto group">
+        <span class="absolute inset-y-0 left-4 flex items-center text-slate-400 group-focus-within:text-slate-500 transition-colors">
+          <Papicon icon="Search" size={16} />
+        </span>
+        <input
+          type="text"
+          bind:value={searchQuery}
+          placeholder="Rechercher un participant par pseudo..."
+          class="w-full pl-11 pr-4 py-3 bg-white dark:bg-[#111a2e] border border-slate-200 dark:border-slate-800 rounded-lg text-sm text-slate-800 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-500/20 focus:border-amber-500/50 shadow-sm transition-all"
+        />
+      </div>
+
+      <!-- ─── Side-by-side Clans Column Grid ─── -->
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 items-start relative z-10">
+        
+        {#each clans as clan}
+          {@const pList = getFilteredParticipants(clan)}
+          
+          <div
+            class="clean-card bg-white dark:bg-[#111a2e] border-t-4 border-slate-200 dark:border-slate-800 rounded-2xl shadow-sm transition-transform hover:-translate-y-0.5 duration-300 overflow-hidden"
+            style="border-top-color: {clan.roleColor || '#e2e8f0'};"
+          >
+            <!-- Clan Header -->
+            <div class="p-6 border-b border-slate-100 dark:border-slate-800 space-y-4">
+              <div class="flex items-center justify-between">
+                <h2 class="text-xl font-extrabold text-slate-800 dark:text-slate-100 flex items-center gap-2">
+                  <span class="inline-block w-3.5 h-3.5 rounded-full" style="background-color: {clan.roleColor || '#e2e8f0'};"></span>
+                  {clan.name}
+                </h2>
+                
+                <span class="px-3 py-1 bg-slate-50 dark:bg-[#0c1322] border border-slate-200/50 dark:border-slate-800 rounded-full text-[10px] font-bold text-slate-500 uppercase tracking-wider">
+                  {clan.memberCount} membres
+                </span>
+              </div>
+
+              {#if clan.description}
+                <p class="text-xs text-slate-500 dark:text-slate-400 leading-relaxed italic">
+                  « {clan.description} »
+                </p>
+              {/if}
+
+              <!-- Score Card -->
+              <div class="flex items-center justify-between p-3.5 rounded-xl bg-slate-50/50 dark:bg-[#0c1322]/50 border border-slate-200/10">
+                <span class="text-[10px] font-bold text-slate-400 uppercase tracking-widest">XP de Saison</span>
+                <span class="text-lg font-black text-amber-500 tracking-tight">
+                  {clan.totalXp.toLocaleString('fr-FR')} XP
+                </span>
+              </div>
+            </div>
+
+            <!-- Participants list -->
+            <div class="p-4">
+              {#if pList.length === 0}
+                <div class="py-12 text-center text-xs text-slate-400 dark:text-slate-500 italic">
+                  Aucun membre trouvé ou aucun point marqué.
+                </div>
+              {:else}
+                <div class="space-y-1.5">
+                  {#each pList as p, index}
+                    <div class="flex items-center justify-between p-2.5 hover:bg-slate-50/50 dark:hover:bg-slate-800/20 rounded-xl transition-all duration-200 group/item">
+                      <div class="flex items-center gap-3 min-w-0">
+                        
+                        <!-- Rank Badge -->
+                        <span class="w-6 h-6 rounded-md flex items-center justify-center text-xs font-black shrink-0 {getRankBadgeColor(index + 1)}">
+                          {index + 1}
+                        </span>
+
+                        <!-- User avatar -->
+                        {#if p.avatarUrl}
+                          <img src={p.avatarUrl} alt={p.displayName} class="w-8 h-8 rounded-full border border-slate-200/50 dark:border-slate-800" />
+                        {:else}
+                          <div class="w-8 h-8 rounded-full bg-slate-100 dark:bg-slate-800 flex items-center justify-center text-xs font-bold text-slate-500 uppercase shrink-0">
+                            {p.displayName.slice(0, 2)}
+                          </div>
+                        {/if}
+
+                        <span class="text-sm font-bold text-slate-700 dark:text-slate-350 truncate max-w-[160px] sm:max-w-xs group-hover/item:text-slate-900 dark:group-hover/item:text-slate-100 transition-colors">
+                          {p.displayName}
+                        </span>
+                      </div>
+
+                      <span class="text-xs font-extrabold text-amber-500 tracking-tight shrink-0 pl-2">
+                        {p.xp.toLocaleString('fr-FR')} XP
+                      </span>
+                    </div>
+                  {/each}
+                </div>
+              {/if}
+            </div>
+
+          </div>
+        {/each}
+
+      </div>
+    {/if}
+
+  </div>
+</div>
+
+<style>
+  /* Accents de style Feuille Index */
+  .whiteboard-container {
+    background-color: #f8fafc;
+    background-image: 
+      radial-gradient(#cbd5e1 0.75px, transparent 0.75px), 
+      radial-gradient(#cbd5e1 0.75px, #f8fafc 0.75px);
+    background-size: 30px 30px;
+    background-position: 0 0, 15px 15px;
+  }
+  
+  :global(.dark) .whiteboard-container {
+    background-color: #070d19;
+    background-image: 
+      radial-gradient(#1e293b 0.75px, transparent 0.75px), 
+      radial-gradient(#1e293b 0.75px, #070d19 0.75px);
+    background-size: 30px 30px;
+    background-position: 0 0, 15px 15px;
+  }
+
+  .tape-accent {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 4px;
+    background: linear-gradient(90deg, #f59e0b 0%, #10b981 50%, #3b82f6 100%);
+    opacity: 0.85;
+  }
+
+  .clean-card {
+    background-color: #ffffff;
+    border: 1px solid #e2e8f0;
+  }
+  
+  :global(.dark) .clean-card {
+    background-color: #0e1626;
+    border: 1px solid #1e293b;
+  }
+</style>

--- a/packages/database/prisma/clans.prisma
+++ b/packages/database/prisma/clans.prisma
@@ -1,0 +1,36 @@
+// ============================================================================
+// CLANS & CONTRIBUTIONS SCHEMA
+// ============================================================================
+
+model Clan {
+  id          String   @id @default(cuid())
+  guildId     String
+  name        String
+  description String?
+  roleId      String   @unique // ID du rôle Discord unique associé
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  guild Guild @relation(fields: [guildId], references: [id], onDelete: Cascade)
+  contributions ClanMemberContribution[]
+
+  @@unique([guildId, name])
+  @@map("clans")
+}
+
+model ClanMemberContribution {
+  id        String   @id @default(cuid())
+  guildId   String
+  clanId    String
+  userId    String
+  xp        Int      @default(0) // Points accumulés dans ce clan pour cette saison
+  season    Int      @default(1) // Numéro de la saison
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  guild Guild @relation(fields: [guildId], references: [id], onDelete: Cascade)
+  clan  Clan  @relation(fields: [clanId], references: [id], onDelete: Cascade)
+
+  @@unique([guildId, clanId, userId, season])
+  @@map("clan_member_contributions")
+}

--- a/packages/database/prisma/guild.prisma
+++ b/packages/database/prisma/guild.prisma
@@ -111,6 +111,9 @@ model Guild {
   clansEnabled      Boolean @default(false)
   clansUnique       Boolean @default(true)
   currentClanSeason Int     @default(1)
+  clanXpFromActivity Boolean @default(true)
+  clanXpFromLevelUp  Boolean @default(false)
+  clanXpPerLevelUp   Int     @default(50)
 
   clans                 Clan[]
   clanMemberContributions ClanMemberContribution[]

--- a/packages/database/prisma/guild.prisma
+++ b/packages/database/prisma/guild.prisma
@@ -111,7 +111,6 @@ model Guild {
   clansEnabled      Boolean @default(false)
   clansUnique       Boolean @default(true)
   currentClanSeason Int     @default(1)
-  clanXpFromActivity Boolean @default(true)
   clanXpFromLevelUp  Boolean @default(false)
   clanXpPerLevelUp   Int     @default(50)
 

--- a/packages/database/prisma/guild.prisma
+++ b/packages/database/prisma/guild.prisma
@@ -108,6 +108,12 @@ model Guild {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  clansEnabled      Boolean @default(false)
+  clansUnique       Boolean @default(true)
+  currentClanSeason Int     @default(1)
+
+  clans                 Clan[]
+  clanMemberContributions ClanMemberContribution[]
   memberLevels MemberLevel[]
   levelRoleRewards LevelRoleReward[]
   levelConfig LevelConfig?

--- a/packages/database/prisma/migrations/20260713164100_add_clan_system/migration.sql
+++ b/packages/database/prisma/migrations/20260713164100_add_clan_system/migration.sql
@@ -1,0 +1,49 @@
+-- AlterTable
+ALTER TABLE "guilds" ADD COLUMN     "clansEnabled" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "clansUnique" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "currentClanSeason" INTEGER NOT NULL DEFAULT 1;
+
+-- CreateTable
+CREATE TABLE "clans" (
+    "id" TEXT NOT NULL,
+    "guildId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "roleId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "clans_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "clan_member_contributions" (
+    "id" TEXT NOT NULL,
+    "guildId" TEXT NOT NULL,
+    "clanId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "xp" INTEGER NOT NULL DEFAULT 0,
+    "season" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "clan_member_contributions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "clans_roleId_key" ON "clans"("roleId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "clans_guildId_name_key" ON "clans"("guildId", "name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "clan_member_contributions_guildId_clanId_userId_season_key" ON "clan_member_contributions"("guildId", "clanId", "userId", "season");
+
+-- AddForeignKey
+ALTER TABLE "clans" ADD CONSTRAINT "clans_guildId_fkey" FOREIGN KEY ("guildId") REFERENCES "guilds"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "clan_member_contributions" ADD CONSTRAINT "clan_member_contributions_guildId_fkey" FOREIGN KEY ("guildId") REFERENCES "guilds"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "clan_member_contributions" ADD CONSTRAINT "clan_member_contributions_clanId_fkey" FOREIGN KEY ("clanId") REFERENCES "clans"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/migrations/20260713165900_add_clan_xp_settings/migration.sql
+++ b/packages/database/prisma/migrations/20260713165900_add_clan_xp_settings/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "guilds" ADD COLUMN     "clanXpFromActivity" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "clanXpFromLevelUp" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "clanXpPerLevelUp" INTEGER NOT NULL DEFAULT 50;

--- a/packages/database/prisma/migrations/20260713165900_add_clan_xp_settings/migration.sql
+++ b/packages/database/prisma/migrations/20260713165900_add_clan_xp_settings/migration.sql
@@ -1,4 +1,3 @@
 -- AlterTable
-ALTER TABLE "guilds" ADD COLUMN     "clanXpFromActivity" BOOLEAN NOT NULL DEFAULT true,
-ADD COLUMN     "clanXpFromLevelUp" BOOLEAN NOT NULL DEFAULT false,
+ALTER TABLE "guilds" ADD COLUMN     "clanXpFromLevelUp" BOOLEAN NOT NULL DEFAULT false,
 ADD COLUMN     "clanXpPerLevelUp" INTEGER NOT NULL DEFAULT 50;


### PR DESCRIPTION
## Description
Cette PR implémente le module complet de **Clans** pour Kotbo. Elle intègre la structure de données (Prisma), les APIs d'administration, les services asynchrones sécurisés pour Discord (rate-limiting de masse), les commandes slash pour les membres, et les interfaces web (panneau d'administration et classement public).

Pour le lancement initial, le gain automatique de points par messages et salons vocaux a été désactivé. La seule manière de marquer des points pour son clan est de gagner des niveaux globaux sur le serveur (avec un montant de points bonus configurable par l'administration).


## Changements principaux

### 1. Base de données & Migrations
- **Schéma Prisma** : Modèles `Clan` et `ClanMemberContribution`.
- **Paramètres de points** : Colonnes `clanXpFromLevelUp` et `clanXpPerLevelUp` sur la table `guilds`.
- **Migrations SQL** : Scripts `20260713164100_add_clan_system` et `20260713165900_add_clan_xp_settings`.

### 2. API Backend & Services Discord
- **REST API** : CRUD pour les clans, configuration du gain de points lors des montées de niveau, exécution des tâches de masse et reset de saison.
- **API Publique** : Endpoint `/api/public/guilds/:guildId/clans` pour exposer le classement général et le top 10 des participants par clan.
- **Auto-mod & Unicité** : Sécurité limitant les membres à un seul clan Discord à la fois (`clanEvents.ts`).
- **Gains de points par Level Up** : Intégration dans `levelingService.ts` pour attribuer des points de clan bonus personnalisés à chaque passage de niveau (si activé).

### 3. Commandes Slash Discord
- **/clan list**, **/clan leaderboard**, **/clan info <clan>** (avec autocomplétion).
- **/clan distribute** & **/clan clear** (réservées aux admins).

### 4. Interface Web (Svelte 5)
- **Panneau de configuration** : Page `Clans.svelte` pour activer/désactiver le module, configurer l'activation du bonus de niveau et les points par level up, et suivre les tâches de fond.
- **Classement Public** : Page responsive `LevelingClanPublic.svelte` (route `/:serverId/leveling/clan`) permettant de consulter le classement des clans et le top des participants (avec recherche par pseudo).
