### PR TITLE
Feat/clans Implementation clans

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,27 +1,55 @@
 ## 📝 Description
-<!-- Décris brièvement les modifications apportées par cette PR (correctif, nouvelle fonctionnalité, optimisation...). -->
+Cette PR implémente le module complet de **Clans** pour Kotbo. Elle intègre la structure de données (Prisma), les APIs d'administration, les services asynchrones sécurisés pour Discord (rate-limiting de masse), les commandes slash pour les membres, et les interfaces web (panneau d'administration et classement public).
 
+---
 
 ## 🎯 Changements principaux
-<!-- Liste les points clés de tes modifications -->
-- 
-- 
 
+### 1. Base de données & Migrations
+- **Schéma Prisma** : Modèles `Clan` (associé à un rôle Discord unique) et `ClanMemberContribution` (suivi de l'XP par joueur, clan et saison).
+- **Migration SQL** : Script `20260713164100_add_clan_system` pour automatiser la mise à jour des tables en production.
+- **Rétention des points** : Les points gagnés par un joueur restent associés au clan d'origine même si le joueur quitte ou change de clan en cours de saison.
+
+### 2. API Backend & Services Discord
+- **REST API** : CRUD pour les clans, exécution de tâches de masse et reset de saison.
+- **API Publique** : Endpoint `/api/public/guilds/:guildId/clans` pour exposer les classements sans authentification.
+- **Auto-mod & Unicité** : Sécurité dans `clanEvents.ts` forçant un seul clan par membre Discord, avec alertes de modération et logs d'audit.
+- **Rate-Limit Guard** : Processus d'arrière-plan (`clanService.ts`) cadencé à 450ms/appel pour distribuer ou retirer les rôles sans subir de ban de l'API Discord.
+- **Gain d'XP** : Intégration dans `levelingService.ts` pour créditer automatiquement l'XP d'activité (écrit/vocal) sur le clan actif du membre.
+
+### 3. Commandes Slash Discord
+- **/clan list** : Liste les clans configurés.
+- **/clan leaderboard** : Affiche le classement général des clans pour la saison active.
+- **/clan info <clan>** : Détails d'un clan et top 10 des contributeurs de la saison (avec autocomplétion).
+- **/clan distribute** & **/clan clear** : Commandes réservées aux administrateurs pour lancer les processus de masse.
+
+### 4. Interface Web (Svelte 5)
+- **Panneau d'administration** : Page `Clans.svelte` pour configurer le module, créer/éditer des clans et suivre l'avancement live des tâches de masse.
+- **Sécurités de confirmation** : Fenêtre de double-validation exigeant la saisie d'un mot-clé (`DISTRIBUER`, `RETIRER`, `RESET`) avant chaque action destructive ou lourde.
+- **Classement Public** : Page responsive `LevelingClanPublic.svelte` (route `/:serverId/leveling/clan`) permettant de consulter le classement des clans et le top des participants (avec recherche par pseudo).
+
+---
 
 ## 🧪 Comment tester ?
-<!-- Explique comment vérifier que tes modifications fonctionnent en dev local -->
-1. 
-2. 
 
+1. **Migration** : Exécuter la migration Prisma sur le serveur de dev.
+2. **Configuration** : Activer le module de clans depuis le Dashboard Kotbo, créer 2 clans et leur assigner des rôles Discord distincts.
+3. **Distribution** : Cliquer sur le bouton **Distribuer** sur le Dashboard, saisir le mot-clé de validation et vérifier le bon déroulement progressif de la tâche (barre de progression).
+4. **Gain de points** : Envoyer des messages ou passer du temps en vocal avec un rôle de clan actif, puis vérifier l'incrémentation via `/clan leaderboard`.
+5. **Changement de clan** : Changer manuellement le rôle de clan d'un membre de test, gagner des points à nouveau, et vérifier avec `/clan info` que l'historique des points dans l'ancien clan est bien préservé.
+6. **Sécurité Unique** : Ajouter manuellement un deuxième rôle de clan à un membre et vérifier que le bot lui retire automatiquement le premier rôle avec un avertissement de log.
+7. **Reset** : Effectuer un reset de saison et vérifier que le compteur passe à la saison supérieure et remet les scores à 0.
+
+---
 
 ## ⚓ Liens / Issues
-<!-- Si cette PR ferme une issue existante, écris "Closes #numéro_issue" -->
-- Closes #
+- Closes # (Clans Integration)
 
+---
 
 ## 📜 Validation des conditions
 *En soumettant cette Pull Request, vous devez valider les points suivants :*
 
-- [ ] Mes modifications respectent le style de code du projet.
-- [ ] J'ai testé mon code en local et il s'exécute sans erreur.
-- [ ] **J'accepte que ma contribution soit intégrée au projet Kotbo sous les termes de sa licence (Source-Available) et cède les droits d'exploitation associés à la structure Kotbo.**
+- [x] Mes modifications respectent le style de code du projet.
+- [x] J'ai testé mon code en local et il s'exécute sans erreur.
+- [x] **J'accepte que ma contribution soit intégrée au projet Kotbo sous les termes de sa licence (Source-Available) et cède les droits d'exploitation associés à la structure Kotbo.**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,55 +1,27 @@
 ## 📝 Description
-Cette PR implémente le module complet de **Clans** pour Kotbo. Elle intègre la structure de données (Prisma), les APIs d'administration, les services asynchrones sécurisés pour Discord (rate-limiting de masse), les commandes slash pour les membres, et les interfaces web (panneau d'administration et classement public).
+<!-- Décris brièvement les modifications apportées par cette PR (correctif, nouvelle fonctionnalité, optimisation...). -->
 
----
 
 ## 🎯 Changements principaux
+<!-- Liste les points clés de tes modifications -->
+- 
+- 
 
-### 1. Base de données & Migrations
-- **Schéma Prisma** : Modèles `Clan` (associé à un rôle Discord unique) et `ClanMemberContribution` (suivi de l'XP par joueur, clan et saison).
-- **Migration SQL** : Script `20260713164100_add_clan_system` pour automatiser la mise à jour des tables en production.
-- **Rétention des points** : Les points gagnés par un joueur restent associés au clan d'origine même si le joueur quitte ou change de clan en cours de saison.
-
-### 2. API Backend & Services Discord
-- **REST API** : CRUD pour les clans, exécution de tâches de masse et reset de saison.
-- **API Publique** : Endpoint `/api/public/guilds/:guildId/clans` pour exposer les classements sans authentification.
-- **Auto-mod & Unicité** : Sécurité dans `clanEvents.ts` forçant un seul clan par membre Discord, avec alertes de modération et logs d'audit.
-- **Rate-Limit Guard** : Processus d'arrière-plan (`clanService.ts`) cadencé à 450ms/appel pour distribuer ou retirer les rôles sans subir de ban de l'API Discord.
-- **Gain d'XP** : Intégration dans `levelingService.ts` pour créditer automatiquement l'XP d'activité (écrit/vocal) sur le clan actif du membre.
-
-### 3. Commandes Slash Discord
-- **/clan list** : Liste les clans configurés.
-- **/clan leaderboard** : Affiche le classement général des clans pour la saison active.
-- **/clan info <clan>** : Détails d'un clan et top 10 des contributeurs de la saison (avec autocomplétion).
-- **/clan distribute** & **/clan clear** : Commandes réservées aux administrateurs pour lancer les processus de masse.
-
-### 4. Interface Web (Svelte 5)
-- **Panneau d'administration** : Page `Clans.svelte` pour configurer le module, créer/éditer des clans et suivre l'avancement live des tâches de masse.
-- **Sécurités de confirmation** : Fenêtre de double-validation exigeant la saisie d'un mot-clé (`DISTRIBUER`, `RETIRER`, `RESET`) avant chaque action destructive ou lourde.
-- **Classement Public** : Page responsive `LevelingClanPublic.svelte` (route `/:serverId/leveling/clan`) permettant de consulter le classement des clans et le top des participants (avec recherche par pseudo).
-
----
 
 ## 🧪 Comment tester ?
+<!-- Explique comment vérifier que tes modifications fonctionnent en dev local -->
+1. 
+2. 
 
-1. **Migration** : Exécuter la migration Prisma sur le serveur de dev.
-2. **Configuration** : Activer le module de clans depuis le Dashboard Kotbo, créer 2 clans et leur assigner des rôles Discord distincts.
-3. **Distribution** : Cliquer sur le bouton **Distribuer** sur le Dashboard, saisir le mot-clé de validation et vérifier le bon déroulement progressif de la tâche (barre de progression).
-4. **Gain de points** : Envoyer des messages ou passer du temps en vocal avec un rôle de clan actif, puis vérifier l'incrémentation via `/clan leaderboard`.
-5. **Changement de clan** : Changer manuellement le rôle de clan d'un membre de test, gagner des points à nouveau, et vérifier avec `/clan info` que l'historique des points dans l'ancien clan est bien préservé.
-6. **Sécurité Unique** : Ajouter manuellement un deuxième rôle de clan à un membre et vérifier que le bot lui retire automatiquement le premier rôle avec un avertissement de log.
-7. **Reset** : Effectuer un reset de saison et vérifier que le compteur passe à la saison supérieure et remet les scores à 0.
-
----
 
 ## ⚓ Liens / Issues
-- Closes # (Clans Integration)
+<!-- Si cette PR ferme une issue existante, écris "Closes #numéro_issue" -->
+- Closes #
 
----
 
 ## 📜 Validation des conditions
 *En soumettant cette Pull Request, vous devez valider les points suivants :*
 
-- [x] Mes modifications respectent le style de code du projet.
-- [x] J'ai testé mon code en local et il s'exécute sans erreur.
-- [x] **J'accepte que ma contribution soit intégrée au projet Kotbo sous les termes de sa licence (Source-Available) et cède les droits d'exploitation associés à la structure Kotbo.**
+- [ ] Mes modifications respectent le style de code du projet.
+- [ ] J'ai testé mon code en local et il s'exécute sans erreur.
+- [ ] **J'accepte que ma contribution soit intégrée au projet Kotbo sous les termes de sa licence (Source-Available) et cède les droits d'exploitation associés à la structure Kotbo.**

--- a/apps/bot/src/api/routes/dashboard.ts
+++ b/apps/bot/src/api/routes/dashboard.ts
@@ -41,6 +41,7 @@ import { handleMarketplaceRoutes } from './dashboard/marketplace.js';
 import { handleQuestRoutes } from './dashboard/quests.js';
 import { handleWidgetRoutes } from './dashboard/widget.js';
 import { handleMessageLogRoutes } from './dashboard/messageLogs.js';
+import { handleClansRoutes } from './dashboard/clans.js';
 
 export async function handleDashboardRoutes(
   req: IncomingMessage,
@@ -257,6 +258,12 @@ export async function handleDashboardRoutes(
     if (await handleMessageLogRoutes(req, res, parts, url, client, user, guildId, access)) {
       if (method !== 'GET') await cache.invalidateGuild(guildId);
       return true;
+    }
+    if (parts[4] === 'clans') {
+      if (await handleClansRoutes(req, res, parts, client, user, guildId, access)) {
+        if (method !== 'GET') await cache.invalidateGuild(guildId);
+        return true;
+      }
     }
   }
 

--- a/apps/bot/src/api/routes/dashboard/clans.ts
+++ b/apps/bot/src/api/routes/dashboard/clans.ts
@@ -1,0 +1,342 @@
+import { IncomingMessage, ServerResponse } from 'node:http';
+import { Client } from 'discord.js';
+import prisma from '../../../utils/db.js';
+import { logger } from '../../../utils/logger.js';
+import { json, readJsonBody, getGuildName, pushAudit, type AuthClaims, type DashboardAccess } from '../../shared.js';
+import { clanTasks, runDistribution, runClear } from '../../../services/community/clanService.js';
+
+export async function handleClansRoutes(
+  req: IncomingMessage,
+  res: ServerResponse,
+  parts: string[],
+  client: Client,
+  user: AuthClaims,
+  guildId: string,
+  _access: DashboardAccess
+): Promise<boolean> {
+  const method = req.method;
+  const auditUser = `${user.username} (${user.userId})`;
+
+  // Path matches: /api/dashboard/guilds/:guildId/clans/...
+  const subAction = parts[5]; // undefined | id | distribute | clear | reset-season
+
+  // GET /api/dashboard/guilds/:guildId/clans
+  if (!subAction && method === 'GET') {
+    try {
+      const guildData = await prisma.guild.findUnique({
+        where: { id: guildId },
+        select: {
+          clansEnabled: true,
+          clansUnique: true,
+          currentClanSeason: true,
+        },
+      });
+
+      if (!guildData) {
+        json(res, 404, { error: 'Serveur non trouvé en base de données.' });
+        return true;
+      }
+
+      const clans = await prisma.clan.findMany({
+        where: { guildId },
+        orderBy: { name: 'asc' },
+      });
+
+      // Calculer dynamiquement le nombre de membres et l'XP de la saison en cours pour chaque clan
+      const discordGuild = client.guilds.cache.get(guildId) || await client.guilds.fetch(guildId).catch(() => null);
+      
+      const clansWithStats = await Promise.all(
+        clans.map(async (clan) => {
+          // Nombre de membres réels ayant le rôle actuellement
+          const memberCount = discordGuild?.roles.cache.get(clan.roleId)?.members.size ?? 0;
+
+          // Somme des contributions d'XP pour la saison active
+          const aggregate = await prisma.clanMemberContribution.aggregate({
+            where: {
+              guildId,
+              clanId: clan.id,
+              season: guildData.currentClanSeason,
+            },
+            _sum: { xp: true },
+          });
+
+          return {
+            ...clan,
+            memberCount,
+            totalXp: aggregate._sum.xp ?? 0,
+          };
+        })
+      );
+
+      const taskInProgress = clanTasks.get(guildId) || null;
+
+      json(res, 200, {
+        clansEnabled: guildData.clansEnabled,
+        clansUnique: guildData.clansUnique,
+        currentClanSeason: guildData.currentClanSeason,
+        clans: clansWithStats,
+        taskInProgress,
+      });
+    } catch (err) {
+      logger.error('ClansAPI', 'Error fetching clans data:', err);
+      json(res, 500, { error: 'Erreur lors de la récupération des clans.' });
+    }
+    return true;
+  }
+
+  // PATCH /api/dashboard/guilds/:guildId/clans (Update Settings)
+  if (!subAction && method === 'PATCH') {
+    try {
+      const body = await readJsonBody<{
+        clansEnabled?: boolean;
+        clansUnique?: boolean;
+      }>(req);
+
+      const updateData: Record<string, any> = {};
+      if (body?.clansEnabled !== undefined) updateData.clansEnabled = body.clansEnabled;
+      if (body?.clansUnique !== undefined) updateData.clansUnique = body.clansUnique;
+
+      if (Object.keys(updateData).length === 0) {
+        json(res, 400, { error: 'Aucune donnée valide à mettre à jour.' });
+        return true;
+      }
+
+      const updatedGuild = await prisma.guild.update({
+        where: { id: guildId },
+        data: updateData,
+      });
+
+      await pushAudit(guildId, {
+        user: auditUser,
+        action: 'Mise à jour configuration Clans',
+        context: getGuildName(client, guildId),
+        module: 'Clans',
+        eventType: 'Manuel',
+        details: `Paramètres clans mis à jour. Activé: ${updatedGuild.clansEnabled}, Unique: ${updatedGuild.clansUnique}`,
+        channelId: null,
+      });
+
+      json(res, 200, {
+        clansEnabled: updatedGuild.clansEnabled,
+        clansUnique: updatedGuild.clansUnique,
+      });
+    } catch (err) {
+      logger.error('ClansAPI', 'Error updating clan settings:', err);
+      json(res, 500, { error: 'Erreur lors de la mise à jour de la configuration des clans.' });
+    }
+    return true;
+  }
+
+  // POST /api/dashboard/guilds/:guildId/clans (Create Clan)
+  if (!subAction && method === 'POST') {
+    try {
+      const body = await readJsonBody<{
+        name: string;
+        description?: string;
+        roleId: string;
+      }>(req);
+
+      if (!body?.name || !body?.roleId) {
+        json(res, 400, { error: 'Le nom et le rôle du clan sont requis.' });
+        return true;
+      }
+
+      // Vérifier si le rôle existe sur Discord
+      const discordGuild = client.guilds.cache.get(guildId) || await client.guilds.fetch(guildId).catch(() => null);
+      if (!discordGuild) {
+        json(res, 400, { error: 'Serveur introuvable sur Discord.' });
+        return true;
+      }
+
+      const roleExists = discordGuild.roles.cache.has(body.roleId);
+      if (!roleExists) {
+        json(res, 400, { error: "Le rôle sélectionné n'existe pas sur ce serveur Discord." });
+        return true;
+      }
+
+      // Vérifier l'unicité du rôle
+      const existingRoleClan = await prisma.clan.findUnique({
+        where: { roleId: body.roleId },
+      });
+      if (existingRoleClan) {
+        json(res, 400, { error: 'Ce rôle est déjà assigné à un autre clan.' });
+        return true;
+      }
+
+      // Créer le clan
+      const clan = await prisma.clan.create({
+        data: {
+          guildId,
+          name: body.name,
+          description: body.description ?? null,
+          roleId: body.roleId,
+        },
+      });
+
+      await pushAudit(guildId, {
+        user: auditUser,
+        action: 'Création de clan',
+        context: getGuildName(client, guildId),
+        module: 'Clans',
+        eventType: 'Manuel',
+        details: `Clan "${clan.name}" créé avec le rôle ${clan.roleId}.`,
+        channelId: null,
+      });
+
+      json(res, 201, { clan });
+    } catch (err) {
+      logger.error('ClansAPI', 'Error creating clan:', err);
+      json(res, 500, { error: 'Erreur lors de la création du clan.' });
+    }
+    return true;
+  }
+
+  // PUT /api/dashboard/guilds/:guildId/clans/:id
+  if (subAction && subAction !== 'distribute' && subAction !== 'clear' && subAction !== 'reset-season' && method === 'PUT') {
+    try {
+      const clanId = subAction;
+      const body = await readJsonBody<{
+        name: string;
+        description?: string;
+        roleId: string;
+      }>(req);
+
+      if (!body?.name || !body?.roleId) {
+        json(res, 400, { error: 'Le nom et le rôle du clan sont requis.' });
+        return true;
+      }
+
+      // Vérifier l'existence du rôle sur Discord
+      const discordGuild = client.guilds.cache.get(guildId) || await client.guilds.fetch(guildId).catch(() => null);
+      if (discordGuild && !discordGuild.roles.cache.has(body.roleId)) {
+        json(res, 400, { error: "Le rôle sélectionné n'existe pas sur Discord." });
+        return true;
+      }
+
+      // Vérifier l'unicité du rôle
+      const existingRoleClan = await prisma.clan.findFirst({
+        where: { roleId: body.roleId, id: { not: clanId } },
+      });
+      if (existingRoleClan) {
+        json(res, 400, { error: 'Ce rôle est déjà attribué à un autre clan.' });
+        return true;
+      }
+
+      const updatedClan = await prisma.clan.update({
+        where: { id: clanId, guildId },
+        data: {
+          name: body.name,
+          description: body.description ?? null,
+          roleId: body.roleId,
+        },
+      });
+
+      await pushAudit(guildId, {
+        user: auditUser,
+        action: 'Modification de clan',
+        context: getGuildName(client, guildId),
+        module: 'Clans',
+        eventType: 'Manuel',
+        details: `Clan "${updatedClan.name}" mis à jour. Rôle : ${updatedClan.roleId}.`,
+        channelId: null,
+      });
+
+      json(res, 200, { clan: updatedClan });
+    } catch (err) {
+      logger.error('ClansAPI', 'Error updating clan:', err);
+      json(res, 500, { error: 'Erreur lors de la modification du clan.' });
+    }
+    return true;
+  }
+
+  // DELETE /api/dashboard/guilds/:guildId/clans/:id
+  if (subAction && subAction !== 'distribute' && subAction !== 'clear' && subAction !== 'reset-season' && method === 'DELETE') {
+    try {
+      const clanId = subAction;
+
+      const deletedClan = await prisma.clan.delete({
+        where: { id: clanId, guildId },
+      });
+
+      await pushAudit(guildId, {
+        user: auditUser,
+        action: 'Suppression de clan',
+        context: getGuildName(client, guildId),
+        module: 'Clans',
+        eventType: 'Manuel',
+        details: `Clan "${deletedClan.name}" supprimé.`,
+        channelId: null,
+      });
+
+      json(res, 200, { success: true });
+    } catch (err) {
+      logger.error('ClansAPI', 'Error deleting clan:', err);
+      json(res, 500, { error: 'Erreur lors de la suppression du clan.' });
+    }
+    return true;
+  }
+
+  // POST /api/dashboard/guilds/:guildId/clans/distribute (Bulk Random Distribution)
+  if (subAction === 'distribute' && method === 'POST') {
+    try {
+      const message = await runDistribution(guildId, client, auditUser);
+      json(res, 200, { message });
+    } catch (err: any) {
+      logger.error('ClansAPI', 'Error launching distribution:', err);
+      json(res, err.message.includes('déjà en cours') || err.message.includes('configurer') ? 400 : 500, { error: err.message });
+    }
+    return true;
+  }
+
+  // POST /api/dashboard/guilds/:guildId/clans/clear (Bulk Remove Clan Roles)
+  if (subAction === 'clear' && method === 'POST') {
+    try {
+      const message = await runClear(guildId, client, auditUser);
+      json(res, 200, { message });
+    } catch (err: any) {
+      logger.error('ClansAPI', 'Error launching clear:', err);
+      json(res, err.message.includes('déjà en cours') || err.message.includes('Aucun clan') ? 400 : 500, { error: err.message });
+    }
+    return true;
+  }
+
+  // POST /api/dashboard/guilds/:guildId/clans/reset-season (New Season / Reset)
+  if (subAction === 'reset-season' && method === 'POST') {
+    try {
+      const guild = await prisma.guild.findUnique({
+        where: { id: guildId },
+        select: { currentClanSeason: true },
+      });
+
+      if (!guild) {
+        json(res, 404, { error: 'Serveur introuvable.' });
+        return true;
+      }
+
+      const nextSeason = guild.currentClanSeason + 1;
+
+      await prisma.guild.update({
+        where: { id: guildId },
+        data: { currentClanSeason: nextSeason },
+      });
+
+      await pushAudit(guildId, {
+        user: auditUser,
+        action: 'Reset Saison de Clans',
+        context: getGuildName(client, guildId),
+        module: 'Clans',
+        eventType: 'Manuel',
+        details: `Saison de clan réinitialisée. Nouvelle saison active: ${nextSeason}`,
+        channelId: null,
+      });
+
+      json(res, 200, { currentClanSeason: nextSeason });
+    } catch (err) {
+      logger.error('ClansAPI', 'Error resetting clan season:', err);
+      json(res, 500, { error: 'Erreur lors de la réinitialisation de la saison.' });
+    }
+    return true;
+  }
+
+  return false;
+}

--- a/apps/bot/src/api/routes/dashboard/clans.ts
+++ b/apps/bot/src/api/routes/dashboard/clans.ts
@@ -29,6 +29,9 @@ export async function handleClansRoutes(
           clansEnabled: true,
           clansUnique: true,
           currentClanSeason: true,
+          clanXpFromActivity: true,
+          clanXpFromLevelUp: true,
+          clanXpPerLevelUp: true,
         },
       });
 
@@ -74,6 +77,9 @@ export async function handleClansRoutes(
         clansEnabled: guildData.clansEnabled,
         clansUnique: guildData.clansUnique,
         currentClanSeason: guildData.currentClanSeason,
+        clanXpFromActivity: guildData.clanXpFromActivity,
+        clanXpFromLevelUp: guildData.clanXpFromLevelUp,
+        clanXpPerLevelUp: guildData.clanXpPerLevelUp,
         clans: clansWithStats,
         taskInProgress,
       });
@@ -90,11 +96,23 @@ export async function handleClansRoutes(
       const body = await readJsonBody<{
         clansEnabled?: boolean;
         clansUnique?: boolean;
+        clanXpFromActivity?: boolean;
+        clanXpFromLevelUp?: boolean;
+        clanXpPerLevelUp?: number;
       }>(req);
 
       const updateData: Record<string, any> = {};
       if (body?.clansEnabled !== undefined) updateData.clansEnabled = body.clansEnabled;
       if (body?.clansUnique !== undefined) updateData.clansUnique = body.clansUnique;
+      if (body?.clanXpFromActivity !== undefined) updateData.clanXpFromActivity = body.clanXpFromActivity;
+      if (body?.clanXpFromLevelUp !== undefined) updateData.clanXpFromLevelUp = body.clanXpFromLevelUp;
+      if (body?.clanXpPerLevelUp !== undefined) {
+        if (typeof body.clanXpPerLevelUp !== 'number' || body.clanXpPerLevelUp < 0) {
+          json(res, 400, { error: 'Le nombre de points par passage de niveau doit être un entier positif.' });
+          return true;
+        }
+        updateData.clanXpPerLevelUp = Math.floor(body.clanXpPerLevelUp);
+      }
 
       if (Object.keys(updateData).length === 0) {
         json(res, 400, { error: 'Aucune donnée valide à mettre à jour.' });
@@ -112,13 +130,16 @@ export async function handleClansRoutes(
         context: getGuildName(client, guildId),
         module: 'Clans',
         eventType: 'Manuel',
-        details: `Paramètres clans mis à jour. Activé: ${updatedGuild.clansEnabled}, Unique: ${updatedGuild.clansUnique}`,
+        details: `Paramètres clans mis à jour. Activé: ${updatedGuild.clansEnabled}, Unique: ${updatedGuild.clansUnique}, XP Activité: ${updatedGuild.clanXpFromActivity}, XP Level Up: ${updatedGuild.clanXpFromLevelUp} (${updatedGuild.clanXpPerLevelUp} pts)`,
         channelId: null,
       });
 
       json(res, 200, {
         clansEnabled: updatedGuild.clansEnabled,
         clansUnique: updatedGuild.clansUnique,
+        clanXpFromActivity: updatedGuild.clanXpFromActivity,
+        clanXpFromLevelUp: updatedGuild.clanXpFromLevelUp,
+        clanXpPerLevelUp: updatedGuild.clanXpPerLevelUp,
       });
     } catch (err) {
       logger.error('ClansAPI', 'Error updating clan settings:', err);

--- a/apps/bot/src/api/routes/dashboard/clans.ts
+++ b/apps/bot/src/api/routes/dashboard/clans.ts
@@ -3,7 +3,7 @@ import { Client } from 'discord.js';
 import prisma from '../../../utils/db.js';
 import { logger } from '../../../utils/logger.js';
 import { json, readJsonBody, getGuildName, pushAudit, type AuthClaims, type DashboardAccess } from '../../shared.js';
-import { clanTasks, runDistribution, runClear } from '../../../services/community/clanService.js';
+import { clanTasks, runDistribution, runClear, handleEndSeason } from '../../../services/community/clanService.js';
 
 export async function handleClansRoutes(
   req: IncomingMessage,
@@ -31,6 +31,14 @@ export async function handleClansRoutes(
           currentClanSeason: true,
           clanXpFromLevelUp: true,
           clanXpPerLevelUp: true,
+          clanAnnouncementChannelId: true,
+          clanRewardGiveaway: true,
+          clanRewardXpBoost: true,
+          clanRewardXpBoostRate: true,
+          clanRewardLeaderRole: true,
+          lastWinningClanId: true,
+          clanSeasonStartsAt: true,
+          clanSeasonEndsAt: true,
         },
       });
 
@@ -78,6 +86,14 @@ export async function handleClansRoutes(
         currentClanSeason: guildData.currentClanSeason,
         clanXpFromLevelUp: guildData.clanXpFromLevelUp,
         clanXpPerLevelUp: guildData.clanXpPerLevelUp,
+        clanAnnouncementChannelId: guildData.clanAnnouncementChannelId,
+        clanRewardGiveaway: guildData.clanRewardGiveaway,
+        clanRewardXpBoost: guildData.clanRewardXpBoost,
+        clanRewardXpBoostRate: guildData.clanRewardXpBoostRate,
+        clanRewardLeaderRole: guildData.clanRewardLeaderRole,
+        lastWinningClanId: guildData.lastWinningClanId,
+        clanSeasonStartsAt: guildData.clanSeasonStartsAt,
+        clanSeasonEndsAt: guildData.clanSeasonEndsAt,
         clans: clansWithStats,
         taskInProgress,
       });
@@ -95,6 +111,13 @@ export async function handleClansRoutes(
         clansUnique?: boolean;
         clanXpFromLevelUp?: boolean;
         clanXpPerLevelUp?: number;
+        clanAnnouncementChannelId?: string | null;
+        clanRewardGiveaway?: boolean;
+        clanRewardXpBoost?: boolean;
+        clanRewardXpBoostRate?: number;
+        clanRewardLeaderRole?: boolean;
+        clanSeasonStartsAt?: string | null;
+        clanSeasonEndsAt?: string | null;
       }>(req);
 
       const updateData: Record<string, any> = {};
@@ -107,6 +130,23 @@ export async function handleClansRoutes(
           return true;
         }
         updateData.clanXpPerLevelUp = Math.floor(body.clanXpPerLevelUp);
+      }
+      if (body?.clanAnnouncementChannelId !== undefined) updateData.clanAnnouncementChannelId = body.clanAnnouncementChannelId || null;
+      if (body?.clanRewardGiveaway !== undefined) updateData.clanRewardGiveaway = body.clanRewardGiveaway;
+      if (body?.clanRewardXpBoost !== undefined) updateData.clanRewardXpBoost = body.clanRewardXpBoost;
+      if (body?.clanRewardXpBoostRate !== undefined) {
+        if (typeof body.clanRewardXpBoostRate !== 'number' || body.clanRewardXpBoostRate < 1.0) {
+          json(res, 400, { error: "Le taux de boost d'XP doit être supérieur ou égal à 1.0." });
+          return true;
+        }
+        updateData.clanRewardXpBoostRate = body.clanRewardXpBoostRate;
+      }
+      if (body?.clanRewardLeaderRole !== undefined) updateData.clanRewardLeaderRole = body.clanRewardLeaderRole;
+      if (body?.clanSeasonStartsAt !== undefined) {
+        updateData.clanSeasonStartsAt = body.clanSeasonStartsAt ? new Date(body.clanSeasonStartsAt) : null;
+      }
+      if (body?.clanSeasonEndsAt !== undefined) {
+        updateData.clanSeasonEndsAt = body.clanSeasonEndsAt ? new Date(body.clanSeasonEndsAt) : null;
       }
 
       if (Object.keys(updateData).length === 0) {
@@ -134,6 +174,13 @@ export async function handleClansRoutes(
         clansUnique: updatedGuild.clansUnique,
         clanXpFromLevelUp: updatedGuild.clanXpFromLevelUp,
         clanXpPerLevelUp: updatedGuild.clanXpPerLevelUp,
+        clanAnnouncementChannelId: updatedGuild.clanAnnouncementChannelId,
+        clanRewardGiveaway: updatedGuild.clanRewardGiveaway,
+        clanRewardXpBoost: updatedGuild.clanRewardXpBoost,
+        clanRewardXpBoostRate: updatedGuild.clanRewardXpBoostRate,
+        clanRewardLeaderRole: updatedGuild.clanRewardLeaderRole,
+        clanSeasonStartsAt: updatedGuild.clanSeasonStartsAt,
+        clanSeasonEndsAt: updatedGuild.clanSeasonEndsAt,
       });
     } catch (err) {
       logger.error('ClansAPI', 'Error updating clan settings:', err);
@@ -149,6 +196,8 @@ export async function handleClansRoutes(
         name: string;
         description?: string;
         roleId: string;
+        generalChannelId?: string | null;
+        leaderRoleId?: string | null;
       }>(req);
 
       if (!body?.name || !body?.roleId) {
@@ -185,6 +234,8 @@ export async function handleClansRoutes(
           name: body.name,
           description: body.description ?? null,
           roleId: body.roleId,
+          generalChannelId: body.generalChannelId ?? null,
+          leaderRoleId: body.leaderRoleId ?? null,
         },
       });
 
@@ -214,6 +265,8 @@ export async function handleClansRoutes(
         name: string;
         description?: string;
         roleId: string;
+        generalChannelId?: string | null;
+        leaderRoleId?: string | null;
       }>(req);
 
       if (!body?.name || !body?.roleId) {
@@ -243,6 +296,8 @@ export async function handleClansRoutes(
           name: body.name,
           description: body.description ?? null,
           roleId: body.roleId,
+          generalChannelId: body.generalChannelId ?? null,
+          leaderRoleId: body.leaderRoleId ?? null,
         },
       });
 
@@ -330,6 +385,10 @@ export async function handleClansRoutes(
 
       const nextSeason = guild.currentClanSeason + 1;
 
+      // 1. Décerner les bonus, renommer les QG et publier les annonces de fin de saison
+      await handleEndSeason(guildId, client, auditUser, guild.currentClanSeason, nextSeason);
+
+      // 2. Mettre à jour la saison en base de données
       await prisma.guild.update({
         where: { id: guildId },
         data: { currentClanSeason: nextSeason },
@@ -349,6 +408,82 @@ export async function handleClansRoutes(
     } catch (err) {
       logger.error('ClansAPI', 'Error resetting clan season:', err);
       json(res, 500, { error: 'Erreur lors de la réinitialisation de la saison.' });
+    }
+    return true;
+  }
+
+  // POST /api/dashboard/guilds/:guildId/clans/points (Add points manually to a clan or a member)
+  if (subAction === 'points' && method === 'POST') {
+    try {
+      const body = await readJsonBody<{
+        clanId: string;
+        userId?: string | null;
+        amount: number;
+      }>(req);
+
+      if (!body?.clanId || typeof body.amount !== 'number') {
+        json(res, 400, { error: 'Paramètres clanId et amount (nombre) requis.' });
+        return true;
+      }
+
+      // 1. Vérifier si le clan existe
+      const clan = await prisma.clan.findUnique({
+        where: { id: body.clanId }
+      });
+      if (!clan || clan.guildId !== guildId) {
+        json(res, 404, { error: 'Clan introuvable pour ce serveur.' });
+        return true;
+      }
+
+      // 2. Récupérer la saison en cours
+      const guild = await prisma.guild.findUnique({
+        where: { id: guildId },
+        select: { currentClanSeason: true }
+      });
+      if (!guild) {
+        json(res, 404, { error: 'Serveur introuvable.' });
+        return true;
+      }
+
+      const season = guild.currentClanSeason;
+      const targetUserId = body.userId?.trim() || 'system_manual_points';
+
+      // 3. Upsert la contribution
+      const contribution = await prisma.clanMemberContribution.upsert({
+        where: {
+          guildId_clanId_userId_season: {
+            guildId,
+            clanId: body.clanId,
+            userId: targetUserId,
+            season,
+          }
+        },
+        update: {
+          xp: { increment: body.amount }
+        },
+        create: {
+          guildId,
+          clanId: body.clanId,
+          userId: targetUserId,
+          season,
+          xp: body.amount
+        }
+      });
+
+      await pushAudit(guildId, {
+        user: auditUser,
+        action: 'Ajout de points de clan',
+        context: getGuildName(client, guildId),
+        module: 'Clans',
+        eventType: 'Manuel',
+        details: `Ajout manuel de ${body.amount} XP au clan "${clan.name}"` + (body.userId ? ` pour l'utilisateur ${body.userId}` : ' (global)'),
+        channelId: null,
+      });
+
+      json(res, 200, { success: true, contribution });
+    } catch (err) {
+      logger.error('ClansAPI', 'Error adding manual points:', err);
+      json(res, 500, { error: 'Erreur lors de l\'ajout de points manuel.' });
     }
     return true;
   }

--- a/apps/bot/src/api/routes/dashboard/clans.ts
+++ b/apps/bot/src/api/routes/dashboard/clans.ts
@@ -29,7 +29,6 @@ export async function handleClansRoutes(
           clansEnabled: true,
           clansUnique: true,
           currentClanSeason: true,
-          clanXpFromActivity: true,
           clanXpFromLevelUp: true,
           clanXpPerLevelUp: true,
         },
@@ -77,7 +76,6 @@ export async function handleClansRoutes(
         clansEnabled: guildData.clansEnabled,
         clansUnique: guildData.clansUnique,
         currentClanSeason: guildData.currentClanSeason,
-        clanXpFromActivity: guildData.clanXpFromActivity,
         clanXpFromLevelUp: guildData.clanXpFromLevelUp,
         clanXpPerLevelUp: guildData.clanXpPerLevelUp,
         clans: clansWithStats,
@@ -90,13 +88,11 @@ export async function handleClansRoutes(
     return true;
   }
 
-  // PATCH /api/dashboard/guilds/:guildId/clans (Update Settings)
   if (!subAction && method === 'PATCH') {
     try {
       const body = await readJsonBody<{
         clansEnabled?: boolean;
         clansUnique?: boolean;
-        clanXpFromActivity?: boolean;
         clanXpFromLevelUp?: boolean;
         clanXpPerLevelUp?: number;
       }>(req);
@@ -104,7 +100,6 @@ export async function handleClansRoutes(
       const updateData: Record<string, any> = {};
       if (body?.clansEnabled !== undefined) updateData.clansEnabled = body.clansEnabled;
       if (body?.clansUnique !== undefined) updateData.clansUnique = body.clansUnique;
-      if (body?.clanXpFromActivity !== undefined) updateData.clanXpFromActivity = body.clanXpFromActivity;
       if (body?.clanXpFromLevelUp !== undefined) updateData.clanXpFromLevelUp = body.clanXpFromLevelUp;
       if (body?.clanXpPerLevelUp !== undefined) {
         if (typeof body.clanXpPerLevelUp !== 'number' || body.clanXpPerLevelUp < 0) {
@@ -130,14 +125,13 @@ export async function handleClansRoutes(
         context: getGuildName(client, guildId),
         module: 'Clans',
         eventType: 'Manuel',
-        details: `Paramètres clans mis à jour. Activé: ${updatedGuild.clansEnabled}, Unique: ${updatedGuild.clansUnique}, XP Activité: ${updatedGuild.clanXpFromActivity}, XP Level Up: ${updatedGuild.clanXpFromLevelUp} (${updatedGuild.clanXpPerLevelUp} pts)`,
+        details: `Paramètres clans mis à jour. Activé: ${updatedGuild.clansEnabled}, Unique: ${updatedGuild.clansUnique}, XP Level Up: ${updatedGuild.clanXpFromLevelUp} (${updatedGuild.clanXpPerLevelUp} pts)`,
         channelId: null,
       });
 
       json(res, 200, {
         clansEnabled: updatedGuild.clansEnabled,
         clansUnique: updatedGuild.clansUnique,
-        clanXpFromActivity: updatedGuild.clanXpFromActivity,
         clanXpFromLevelUp: updatedGuild.clanXpFromLevelUp,
         clanXpPerLevelUp: updatedGuild.clanXpPerLevelUp,
       });

--- a/apps/bot/src/api/routes/public.ts
+++ b/apps/bot/src/api/routes/public.ts
@@ -595,6 +595,107 @@ export async function handlePublicRoutes(
     return true;
   }
 
+  // GET /api/public/guilds/:guildId/clans
+  if (parts[2] === 'guilds' && parts[3] && parts[4] === 'clans' && !parts[5] && method === 'GET') {
+    const guildId = parts[3];
+    if (!/^\d{17,19}$/.test(guildId)) {
+      json(res, 400, { error: 'ID de guilde invalide' });
+      return true;
+    }
+
+    try {
+      const guildConfig = await prisma.guild.findUnique({
+        where: { id: guildId },
+        select: { clansEnabled: true, currentClanSeason: true },
+      });
+
+      const discordGuild = client.guilds.cache.get(guildId) || await client.guilds.fetch(guildId).catch(() => null);
+
+      if (!guildConfig?.clansEnabled) {
+        json(res, 200, {
+          enabled: false,
+          guildName: discordGuild?.name || 'Kotbo Server',
+          guildIcon: discordGuild?.iconURL({ size: 128 }) || null,
+          clans: [],
+        });
+        return true;
+      }
+
+      const clans = await prisma.clan.findMany({
+        where: { guildId },
+        orderBy: { name: 'asc' },
+      });
+
+      // Charger toutes les contributions pour la saison en cours
+      const contributions = await prisma.clanMemberContribution.findMany({
+        where: {
+          guildId,
+          season: guildConfig.currentClanSeason,
+        },
+        orderBy: { xp: 'desc' },
+      });
+
+      // Charger les profils utilisateur impliqués pour récupérer noms et avatars
+      const userIds = [...new Set(contributions.map((c) => c.userId))];
+      const dbProfiles = await prisma.memberProfile.findMany({
+        where: {
+          guildId,
+          userId: { in: userIds },
+        },
+      });
+      const profileMap = new Map(dbProfiles.map((p) => [p.userId, p]));
+
+      // Associer les contributions avec les données utilisateur
+      const clansData = clans.map((clan) => {
+        const role = discordGuild?.roles.cache.get(clan.roleId);
+        const memberCount = role?.members.size ?? 0;
+
+        const clanContributions = contributions.filter((c) => c.clanId === clan.id);
+        const totalXp = clanContributions.reduce((sum, c) => sum + c.xp, 0);
+
+        // Top participants du clan
+        const topParticipants = clanContributions.slice(0, 10).map((c) => {
+          const profile = profileMap.get(c.userId);
+          const discordMember = discordGuild?.members.cache.get(c.userId);
+
+          const displayName = discordMember?.displayName || profile?.displayName || profile?.globalName || `Utilisateur ${c.userId}`;
+          const avatarUrl = discordMember?.user?.displayAvatarURL({ size: 128 }) || profile?.avatarUrl || null;
+
+          return {
+            userId: c.userId,
+            xp: c.xp,
+            displayName,
+            avatarUrl,
+          };
+        });
+
+        return {
+          id: clan.id,
+          name: clan.name,
+          description: clan.description,
+          roleId: clan.roleId,
+          roleColor: role?.color ? `#${role.color.toString(16).padStart(6, '0')}` : null,
+          totalXp,
+          memberCount,
+          topParticipants,
+        };
+      });
+
+      json(res, 200, {
+        enabled: true,
+        currentClanSeason: guildConfig.currentClanSeason,
+        guildName: discordGuild?.name || 'Kotbo Server',
+        guildIcon: discordGuild?.iconURL({ size: 128 }) || null,
+        clans: clansData,
+      });
+    } catch (err: unknown) {
+      const errMessage = err instanceof Error ? err.message : String(err);
+      logger.error('PublicAPI', `Error fetching public clans for guild ${guildId}: ${errMessage}`);
+      json(res, 500, { error: 'Erreur lors du chargement du classement de clans' });
+    }
+    return true;
+  }
+
   // GET /api/public/transcripts/:transcriptId?expires=...&sig=...
   if (parts[2] === 'transcripts' && parts[3] && method === 'GET') {
     const transcriptId = parts[3];

--- a/apps/bot/src/commands.ts
+++ b/apps/bot/src/commands.ts
@@ -67,6 +67,7 @@ import { channelhealthCommand } from './commands/admin/channelhealth.js';
 import { repCommand } from './commands/community/rep.js';
 import { marketCommand } from './commands/economy/market.js';
 import { questsCommand } from './commands/community/quests.js';
+import { clanCommand } from './commands/community/clan.js';
 import { rpgProfileCommand, rpgDailyCommand, rpgTravelCommand, rpgShopCommand, rpgInventoryCommand, rpgGuildCommand, rpgPayCommand, rpgSellCommand, rpgDropCommand, rpgAdminCommand, rpgFightCommand, rpgBossCommand, rpgBestiaryCommand, fishCommand } from './commands/fun/rpgEconomy.js';
 import { topCommand } from './commands/profile/top.js';
 import { inventaireCommand } from './commands/economy/inventaire.js';
@@ -161,6 +162,7 @@ export const commands: SlashCommandDefinition[] = [
   repCommand,
   marketCommand,
   questsCommand,
+  clanCommand,
   rpgProfileCommand,
   rpgDailyCommand,
   rpgTravelCommand,

--- a/apps/bot/src/commands/community/clan.ts
+++ b/apps/bot/src/commands/community/clan.ts
@@ -12,44 +12,43 @@ import { runDistribution, runClear } from '../../services/community/clanService.
 import { E, rankEmoji } from '../../utils/emojis.js';
 import { COLORS_RAW } from '../../utils/embeds.js';
 
-export const clanCommand: SlashCommandDefinition = {
-  data: new SlashCommandBuilder()
-    .setName('clan')
-    .setDescription('🛡️ Gestion et classements des clans du serveur')
-    .addSubcommand((sub) =>
-      sub
-        .setName('list')
-        .setDescription('📋 Liste tous les clans configurés sur le serveur')
-    )
-    .addSubcommand((sub) =>
-      sub
-        .setName('leaderboard')
-        .setDescription('🏆 Affiche le classement des clans pour la saison active')
-    )
-    .addSubcommand((sub) =>
-      sub
-        .setName('info')
-        .setDescription('ℹ️ Affiche les informations et le classement des membres d\'un clan')
-        .addStringOption((opt) =>
-          opt
-            .setName('nom')
-            .setDescription('Le nom du clan')
-            .setRequired(true)
-            .setAutocomplete(true)
-        )
-    )
-    .addSubcommand((sub) =>
-      sub
-        .setName('distribute')
-        .setDescription('🎲 (Admin) Répartit aléatoirement les membres sans clan')
-    )
-    .addSubcommand((sub) =>
-      sub
-        .setName('clear')
-        .setDescription('🧹 (Admin) Retire tous les rôles de clan du serveur')
-    ) as any,
+export const data = new SlashCommandBuilder()
+  .setName('clan')
+  .setDescription('🛡️ Gestion et classements des clans du serveur')
+  .addSubcommand((sub) =>
+    sub
+      .setName('list')
+      .setDescription('📋 Liste tous les clans configurés sur le serveur')
+  )
+  .addSubcommand((sub) =>
+    sub
+      .setName('leaderboard')
+      .setDescription('🏆 Affiche le classement des clans pour la saison active')
+  )
+  .addSubcommand((sub) =>
+    sub
+      .setName('info')
+      .setDescription('ℹ️ Affiche les informations et le classement des membres d\'un clan')
+      .addStringOption((opt) =>
+        opt
+          .setName('nom')
+          .setDescription('Le nom du clan')
+          .setRequired(true)
+          .setAutocomplete(true)
+      )
+  )
+  .addSubcommand((sub) =>
+    sub
+      .setName('distribute')
+      .setDescription('🎲 (Admin) Répartit aléatoirement les membres sans clan')
+  )
+  .addSubcommand((sub) =>
+    sub
+      .setName('clear')
+      .setDescription('🧹 (Admin) Retire tous les rôles de clan du serveur')
+  ) as any;
 
-  async autocomplete(interaction: AutocompleteInteraction) {
+export async function autocomplete(interaction: AutocompleteInteraction) {
     const guildId = interaction.guildId;
     if (!guildId) return;
 
@@ -66,9 +65,9 @@ export const clanCommand: SlashCommandDefinition = {
     await interaction.respond(
       clans.map((c) => ({ name: c.name, value: c.name }))
     );
-  },
+  }
 
-  async execute(interaction: ChatInputCommandInteraction) {
+export async function execute(interaction: ChatInputCommandInteraction) {
     const guildId = interaction.guildId;
     if (!guildId) {
       await interaction.reply({
@@ -290,5 +289,6 @@ export const clanCommand: SlashCommandDefinition = {
       }
       return;
     }
-  },
-};
+}
+
+export const clanCommand = { data, autocomplete, execute } satisfies SlashCommandDefinition;

--- a/apps/bot/src/commands/community/clan.ts
+++ b/apps/bot/src/commands/community/clan.ts
@@ -1,0 +1,294 @@
+import {
+  ChatInputCommandInteraction,
+  AutocompleteInteraction,
+  SlashCommandBuilder,
+  PermissionFlagsBits,
+  EmbedBuilder,
+  MessageFlags,
+} from 'discord.js';
+import type { SlashCommandDefinition } from '../../commands.js';
+import prisma from '../../utils/db.js';
+import { runDistribution, runClear } from '../../services/community/clanService.js';
+import { E, rankEmoji } from '../../utils/emojis.js';
+import { COLORS_RAW } from '../../utils/embeds.js';
+
+export const clanCommand: SlashCommandDefinition = {
+  data: new SlashCommandBuilder()
+    .setName('clan')
+    .setDescription('🛡️ Gestion et classements des clans du serveur')
+    .addSubcommand((sub) =>
+      sub
+        .setName('list')
+        .setDescription('📋 Liste tous les clans configurés sur le serveur')
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('leaderboard')
+        .setDescription('🏆 Affiche le classement des clans pour la saison active')
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('info')
+        .setDescription('ℹ️ Affiche les informations et le classement des membres d\'un clan')
+        .addStringOption((opt) =>
+          opt
+            .setName('nom')
+            .setDescription('Le nom du clan')
+            .setRequired(true)
+            .setAutocomplete(true)
+        )
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('distribute')
+        .setDescription('🎲 (Admin) Répartit aléatoirement les membres sans clan')
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('clear')
+        .setDescription('🧹 (Admin) Retire tous les rôles de clan du serveur')
+    ) as any,
+
+  async autocomplete(interaction: AutocompleteInteraction) {
+    const guildId = interaction.guildId;
+    if (!guildId) return;
+
+    const focusedValue = interaction.options.getFocused();
+    const clans = await prisma.clan.findMany({
+      where: {
+        guildId,
+        name: { contains: focusedValue, mode: 'insensitive' },
+      },
+      take: 25,
+      select: { name: true },
+    });
+
+    await interaction.respond(
+      clans.map((c) => ({ name: c.name, value: c.name }))
+    );
+  },
+
+  async execute(interaction: ChatInputCommandInteraction) {
+    const guildId = interaction.guildId;
+    if (!guildId) {
+      await interaction.reply({
+        content: '❌ Cette commande doit être exécutée sur un serveur.',
+        flags: [MessageFlags.Ephemeral],
+      });
+      return;
+    }
+
+    const sub = interaction.options.getSubcommand();
+
+    // Charger la configuration générale des clans pour la guilde
+    const guildConfig = await prisma.guild.findUnique({
+      where: { id: guildId },
+      select: { clansEnabled: true, currentClanSeason: true },
+    });
+
+    if (!guildConfig?.clansEnabled) {
+      await interaction.reply({
+        content: '❌ Le module de clans est actuellement désactivé sur ce serveur.',
+        flags: [MessageFlags.Ephemeral],
+      });
+      return;
+    }
+
+    // ── SUBCOMMAND: list ──────────────────────────────────────────────────────
+    if (sub === 'list') {
+      await interaction.deferReply();
+
+      const clans = await prisma.clan.findMany({
+        where: { guildId },
+        orderBy: { name: 'asc' },
+      });
+
+      if (clans.length === 0) {
+        await interaction.editReply('Aucun clan n\'est configuré sur ce serveur.');
+        return;
+      }
+
+      const embed = new EmbedBuilder()
+        .setColor(COLORS_RAW.primary)
+        .setTitle(`🛡️ Clans de ${interaction.guild?.name}`)
+        .setDescription('Voici la liste des clans disponibles. Utilisez `/clan info <nom>` pour voir leurs détails.')
+        .setTimestamp();
+
+      for (const clan of clans) {
+        const role = interaction.guild?.roles.cache.get(clan.roleId);
+        const memberCount = role?.members.size ?? 0;
+        embed.addFields({
+          name: `• ${clan.name} (${memberCount} membres)`,
+          value: clan.description || '*Aucune description.*',
+          inline: false,
+        });
+      }
+
+      await interaction.editReply({ embeds: [embed] });
+      return;
+    }
+
+    // ── SUBCOMMAND: leaderboard ────────────────────────────────────────────────
+    if (sub === 'leaderboard') {
+      await interaction.deferReply();
+
+      const clans = await prisma.clan.findMany({ where: { guildId } });
+
+      if (clans.length === 0) {
+        await interaction.editReply('Aucun clan n\'est configuré sur ce serveur.');
+        return;
+      }
+
+      // Récupérer la somme des contributions pour la saison active
+      const contributions = await prisma.clanMemberContribution.groupBy({
+        by: ['clanId'],
+        where: {
+          guildId,
+          season: guildConfig.currentClanSeason,
+        },
+        _sum: { xp: true },
+      });
+
+      const contributionsMap = new Map(contributions.map((c) => [c.clanId, c._sum.xp ?? 0]));
+
+      // Assigner et trier
+      const rankedClans = clans
+        .map((clan) => {
+          const role = interaction.guild?.roles.cache.get(clan.roleId);
+          const memberCount = role?.members.size ?? 0;
+          const xp = contributionsMap.get(clan.id) ?? 0;
+          return { name: clan.name, memberCount, xp };
+        })
+        .sort((a, b) => b.xp - a.xp);
+
+      const embed = new EmbedBuilder()
+        .setColor(COLORS_RAW.warning)
+        .setTitle(`🏆 Classement des Clans — Saison ${guildConfig.currentClanSeason}`)
+        .setTimestamp();
+
+      let desc = '';
+      for (let i = 0; i < rankedClans.length; i++) {
+        const c = rankedClans[i];
+        desc += `\n${rankEmoji(i + 1)} **${c.name}**\n▸ Contribution : \`${c.xp.toLocaleString('fr-FR')} XP\` · Membres : \`${c.memberCount}\`\n`;
+      }
+
+      embed.setDescription(desc || '*Aucune contribution enregistrée pour le moment.*');
+      await interaction.editReply({ embeds: [embed] });
+      return;
+    }
+
+    // ── SUBCOMMAND: info ──────────────────────────────────────────────────────
+    if (sub === 'info') {
+      await interaction.deferReply();
+      const nom = interaction.options.getString('nom', true);
+
+      const clan = await prisma.clan.findFirst({
+        where: { guildId, name: { equals: nom, mode: 'insensitive' } },
+      });
+
+      if (!clan) {
+        await interaction.editReply(`❌ Le clan "${nom}" n'existe pas.`);
+        return;
+      }
+
+      const role = interaction.guild?.roles.cache.get(clan.roleId);
+      const memberCount = role?.members.size ?? 0;
+
+      // Calculer l'XP totale cumulée pour la saison active
+      const aggregate = await prisma.clanMemberContribution.aggregate({
+        where: {
+          guildId,
+          clanId: clan.id,
+          season: guildConfig.currentClanSeason,
+        },
+        _sum: { xp: true },
+      });
+      const totalXp = aggregate._sum.xp ?? 0;
+
+      // Top 10 contributeurs du clan pour la saison active
+      const topContributions = await prisma.clanMemberContribution.findMany({
+        where: {
+          guildId,
+          clanId: clan.id,
+          season: guildConfig.currentClanSeason,
+        },
+        orderBy: { xp: 'desc' },
+        take: 10,
+      });
+
+      const embed = new EmbedBuilder()
+        .setColor(role?.color ?? COLORS_RAW.primary)
+        .setTitle(`🛡️ Clan ${clan.name}`)
+        .setDescription(clan.description || '*Aucune description.*')
+        .addFields(
+          { name: 'Rôle Discord', value: role ? `<@&${role.id}>` : `ID: ${clan.roleId}`, inline: true },
+          { name: 'Membres actifs', value: `\`${memberCount}\``, inline: true },
+          { name: 'XP de Saison', value: `\`${totalXp.toLocaleString('fr-FR')} XP\``, inline: true }
+        )
+        .setTimestamp();
+
+      let contributorsList = '';
+      for (let i = 0; i < topContributions.length; i++) {
+        const contrib = topContributions[i];
+        const member = await interaction.guild?.members.fetch(contrib.userId).catch(() => null);
+        const name = member ? member.displayName : `Utilisateur ${contrib.userId}`;
+        contributorsList += `${rankEmoji(i + 1)} **${name}** : \`${contrib.xp.toLocaleString('fr-FR')} XP\`\n`;
+      }
+
+      embed.addFields({
+        name: '🏆 Top Contributeurs de Saison',
+        value: contributorsList || '*Aucune contribution pour le moment.*',
+        inline: false,
+      });
+
+      await interaction.editReply({ embeds: [embed] });
+      return;
+    }
+
+    // ── SUBCOMMAND: distribute (Admin Only) ───────────────────────────────────
+    if (sub === 'distribute') {
+      const isExecutorAdmin = interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild);
+      if (!isExecutorAdmin) {
+        await interaction.reply({
+          content: '❌ Vous devez disposer de la permission "Gérer le serveur" pour exécuter cette commande.',
+          flags: [MessageFlags.Ephemeral],
+        });
+        return;
+      }
+
+      await interaction.deferReply({ flags: [MessageFlags.Ephemeral] });
+
+      try {
+        const initiator = `${interaction.user.username} (${interaction.user.id})`;
+        const message = await runDistribution(guildId, interaction.client, initiator);
+        await interaction.editReply(message);
+      } catch (err: any) {
+        await interaction.editReply(`❌ Erreur : ${err.message}`);
+      }
+      return;
+    }
+
+    // ── SUBCOMMAND: clear (Admin Only) ────────────────────────────────────────
+    if (sub === 'clear') {
+      const isExecutorAdmin = interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild);
+      if (!isExecutorAdmin) {
+        await interaction.reply({
+          content: '❌ Vous devez disposer de la permission "Gérer le serveur" pour exécuter cette commande.',
+          flags: [MessageFlags.Ephemeral],
+        });
+        return;
+      }
+
+      await interaction.deferReply({ flags: [MessageFlags.Ephemeral] });
+
+      try {
+        const initiator = `${interaction.user.username} (${interaction.user.id})`;
+        const message = await runClear(guildId, interaction.client, initiator);
+        await interaction.editReply(message);
+      } catch (err: any) {
+        await interaction.editReply(`❌ Erreur : ${err.message}`);
+      }
+      return;
+    }
+  },
+};

--- a/apps/bot/src/events/clanEvents.ts
+++ b/apps/bot/src/events/clanEvents.ts
@@ -1,0 +1,98 @@
+import { Client, Events, EmbedBuilder, GuildMember } from 'discord.js';
+import prisma from '../utils/db.js';
+import { logger } from '../utils/logger.js';
+
+export function registerClanListener(client: Client) {
+  // 1. Sécurité de Clan Unique (guildMemberUpdate)
+  client.on(Events.GuildMemberUpdate, async (oldMember: GuildMember, newMember: GuildMember) => {
+    try {
+      const guildId = newMember.guild.id;
+
+      const config = await prisma.guild.findUnique({
+        where: { id: guildId },
+        select: { clansEnabled: true, clansUnique: true, logChannelId: true },
+      });
+
+      if (!config?.clansEnabled || !config?.clansUnique) return;
+
+      const clans = await prisma.clan.findMany({
+        where: { guildId },
+        select: { id: true, name: true, roleId: true },
+      });
+
+      if (clans.length === 0) return;
+
+      const clanRoleIds = clans.map((c) => c.roleId);
+
+      // Trouver quel rôle de clan a été ajouté dans newMember par rapport à oldMember
+      const addedRole = newMember.roles.cache.find(
+        (r) => clanRoleIds.includes(r.id) && !oldMember.roles.cache.has(r.id)
+      );
+
+      if (!addedRole) return;
+
+      // Lister les autres rôles de clans possédés par le membre
+      const otherClanRoles = newMember.roles.cache.filter(
+        (r) => clanRoleIds.includes(r.id) && r.id !== addedRole.id
+      );
+
+      if (otherClanRoles.size === 0) return;
+
+      // Il a plusieurs clans ! On retire les anciens rôles de clans
+      const rolesToRemove = [...otherClanRoles.keys()];
+      await newMember.roles.remove(rolesToRemove, 'Sécurité : un membre ne peut appartenir qu\'à un seul clan à la fois');
+
+      // Trouver les noms des clans impliqués
+      const addedClanName = clans.find((c) => c.roleId === addedRole.id)?.name ?? 'Inconnu';
+      const removedClansNames = clans
+        .filter((c) => rolesToRemove.includes(c.roleId))
+        .map((c) => c.name)
+        .join(', ');
+
+      logger.warn(
+        'ClansSecurity',
+        `Sécurité de clan unique déclenchée pour ${newMember.user.tag} : nouveaux rôles retirés [${removedClansNames}] au profit de [${addedClanName}]`
+      );
+
+      // Loguer dans le salon de modération/logs
+      if (config.logChannelId) {
+        const logChannel = newMember.guild.channels.cache.get(config.logChannelId);
+        if (logChannel?.isTextBased()) {
+          const embed = new EmbedBuilder()
+            .setColor(0x3a86c8)
+            .setTitle('Sécurité de Clan Unique | Automod')
+            .addFields(
+              { name: 'Membre', value: `<@${newMember.id}> \`${newMember.user.tag}\``, inline: false },
+              { name: 'Nouveau Clan Appliqué', value: `\`${addedClanName}\``, inline: true },
+              { name: 'Ancien(s) Clan(s) Retiré(s)', value: `\`${removedClansNames}\``, inline: true }
+            )
+            .setThumbnail(newMember.displayAvatarURL())
+            .setFooter({ text: 'Kotbo Clans Security' })
+            .setTimestamp();
+
+          await logChannel.send({ embeds: [embed], allowedMentions: { parse: [] } }).catch(() => null);
+        }
+      }
+
+      // Enregistrer dans le journal d'audit du dashboard
+      await prisma.dashboardAuditLog.create({
+        data: {
+          guildId,
+          channelId: config.logChannelId ?? null,
+          user: 'Automod Clans',
+          action: 'Correction automatique de clan',
+          context: newMember.guild.name,
+          module: 'Clans',
+          eventType: 'Sécurité',
+          details: `Double clan détecté pour ${newMember.user.tag}. Rôles de [${removedClansNames}] retirés pour conserver [${addedClanName}].`,
+          dateIso: new Date(),
+        },
+      }).catch(() => null);
+
+    } catch (error) {
+      logger.error('ClansSecurity', `Erreur lors de la vérification d'unicité de clan pour ${newMember.user.tag}:`, error);
+    }
+  });
+
+  logger.info('System', 'Écouteur d\'événements Clans enregistré.');
+}

--- a/apps/bot/src/events/crons.ts
+++ b/apps/bot/src/events/crons.ts
@@ -180,6 +180,11 @@ export async function registerCrons(client: Client): Promise<void> {
       const { checkAndProgressSeasons } = await import('../services/progression/seasonService.js');
       await checkAndProgressSeasons(client);
     },
+    'clan-season-check': async () => {
+      logger.debug('Cron', 'Vérification des saisons de clans...');
+      const { checkAndProgressClanSeasons } = await import('../services/community/clanService.js');
+      await checkAndProgressClanSeasons(client);
+    },
     'marketplace-expiration': async () => {
       logger.debug('Cron', 'Traitement des annonces marketplace expirées...');
       const { processExpiredListings } = await import('../services/economy/marketplaceService.js');
@@ -391,6 +396,14 @@ export async function registerCrons(client: Client): Promise<void> {
     await runCronJob('season-check', async () => {
       const { checkAndProgressSeasons } = await import('../services/progression/seasonService.js');
       await checkAndProgressSeasons(client);
+    }, 3000);
+  }, { timezone: 'Europe/Paris' });
+
+  // 🛡️ Clan Seasons: Vérification quotidienne à 0h05
+  cron.schedule('5 0 * * *', async () => {
+    await runCronJob('clan-season-check', async () => {
+      const { checkAndProgressClanSeasons } = await import('../services/community/clanService.js');
+      await checkAndProgressClanSeasons(client);
     }, 3000);
   }, { timezone: 'Europe/Paris' });
 

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -60,6 +60,7 @@ import { registerChannelLinkListener } from './events/channelLinkEvents.js';
 import { registerStaffServerListener } from './events/staffServerEvents.js';
 import { registerAbsenceMentionListener } from './events/absenceMentionEvents.js';
 import { registerPartnershipListener } from './services/features/partnershipService.js';
+import { registerClanListener } from './events/clanEvents.js';
 import { registerEventBusBridge } from './events/eventBusBridge.js';
 import { registerAnalyticsBusSubscribers } from './modules/analytics.module.js';
 import { registerLevelingBusSubscribers } from './modules/leveling.module.js';
@@ -341,6 +342,7 @@ client.once(Events.ClientReady, async (c) => {
   registerStaffServerListener(client);
   registerAbsenceMentionListener(client);
   registerPartnershipListener(client);
+  registerClanListener(client);
 
   // Enregistrer les cron jobs AVANT les opérations potentiellement bloquantes
   logger.info('System', 'Enregistrement des cron jobs...');

--- a/apps/bot/src/modules/welcomeGoodbye.module.ts
+++ b/apps/bot/src/modules/welcomeGoodbye.module.ts
@@ -21,6 +21,7 @@ import {
 } from '../services/features/welcomeGoodbyeService.js';
 import { handleWelcomeThread } from '../services/features/welcomeThreadService.js';
 import { checkMemberCountTriggers } from '../services/core/ctfTriggerService.js';
+import { syncMemberClanFromDcLink } from '../services/community/clanService.js';
 import { logger } from '../utils/logger.js';
 
 const MODULE_NAME = 'welcome-goodbye';
@@ -39,6 +40,7 @@ export function registerWelcomeGoodbyeBusSubscribers(client: Client): void {
 
     await applyJoinAutoRole(member);
     await applyTagAutoRole(member);
+    await syncMemberClanFromDcLink(payload.guildId, payload.userId, null);
     await handleGuildMemberAdd(member, client);
     await handleWelcomeThread(member, client);
     await checkMemberCountTriggers(guild, client);

--- a/apps/bot/src/services/community/clanService.ts
+++ b/apps/bot/src/services/community/clanService.ts
@@ -1,0 +1,167 @@
+import { Client } from 'discord.js';
+import prisma from '../../utils/db.js';
+import { logger } from '../../utils/logger.js';
+import { pushAudit } from '../../api/shared.js';
+
+export const clanTasks = new Map<string, { type: 'distribute' | 'clear'; processed: number; total: number }>();
+
+export async function runDistribution(guildId: string, client: Client, initiatorName: string): Promise<string> {
+  if (clanTasks.has(guildId)) {
+    throw new Error('Une opération de masse est déjà en cours sur ce serveur.');
+  }
+
+  const clans = await prisma.clan.findMany({ where: { guildId } });
+  if (clans.length === 0) {
+    throw new Error('Veuillez configurer au moins un clan avant de lancer la distribution.');
+  }
+
+  const discordGuild = client.guilds.cache.get(guildId) || await client.guilds.fetch(guildId).catch(() => null);
+  if (!discordGuild) {
+    throw new Error('Serveur introuvable sur Discord.');
+  }
+
+  // Récupérer tous les membres
+  const allMembers = await discordGuild.members.fetch().catch(() => null);
+  if (!allMembers) {
+    throw new Error('Impossible de récupérer la liste des membres Discord.');
+  }
+
+  const clanRoleIds = clans.map((c) => c.roleId);
+  
+  // Filtrer les humains qui n'ont pas encore de rôle de clan
+  const membersWithoutClan = allMembers.filter((member) => {
+    if (member.user.bot) return false;
+    return !member.roles.cache.some((r) => clanRoleIds.includes(r.id));
+  });
+
+  if (membersWithoutClan.size === 0) {
+    return 'Tous les membres ont déjà un clan.';
+  }
+
+  const targetList = [...membersWithoutClan.values()];
+  
+  // Démarrer la tâche asynchrone bridée
+  clanTasks.set(guildId, { type: 'distribute', processed: 0, total: targetList.length });
+
+  // Lancement asynchrone non-bloquant
+  (async () => {
+    logger.info('ClanService', `Lancement de la distribution aléatoire pour ${targetList.length} membres dans "${discordGuild.name}" par ${initiatorName}`);
+    
+    for (let i = 0; i < targetList.length; i++) {
+      const currentTask = clanTasks.get(guildId);
+      if (!currentTask || currentTask.type !== 'distribute') break;
+
+      const member = targetList[i];
+      const randomClan = clans[Math.floor(Math.random() * clans.length)];
+
+      try {
+        await member.roles.add(randomClan.roleId, 'Distribution globale et aléatoire des clans');
+      } catch (e) {
+        logger.warn('ClanService', `Impossible d'attribuer le clan à ${member.user.tag}:`, e);
+      }
+
+      clanTasks.set(guildId, {
+        type: 'distribute',
+        processed: i + 1,
+        total: targetList.length,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 450));
+    }
+
+    logger.info('ClanService', `Distribution aléatoire terminée pour "${discordGuild.name}"`);
+    clanTasks.delete(guildId);
+  })().catch((e) => logger.error('ClanService', 'Erreur critique dans le thread de distribution:', e));
+
+  await pushAudit(guildId, {
+    user: initiatorName,
+    action: 'Lancement distribution de clans',
+    context: discordGuild.name,
+    module: 'Clans',
+    eventType: 'Manuel',
+    details: `Distribution aléatoire lancée pour ${targetList.length} membres.`,
+    channelId: null,
+  }).catch(() => null);
+
+  return `La distribution aléatoire des clans à ${targetList.length} membres a commencé en arrière-plan. Cette opération s'effectue progressivement pour respecter les limites de requêtes de Discord et peut prendre plusieurs minutes. Vous pouvez suivre l'avancement sur le Dashboard.`;
+}
+
+export async function runClear(guildId: string, client: Client, initiatorName: string): Promise<string> {
+  if (clanTasks.has(guildId)) {
+    throw new Error('Une opération de masse est déjà en cours sur ce serveur.');
+  }
+
+  const clans = await prisma.clan.findMany({ where: { guildId } });
+  if (clans.length === 0) {
+    throw new Error('Aucun clan n\'est configuré sur ce serveur.');
+  }
+
+  const discordGuild = client.guilds.cache.get(guildId) || await client.guilds.fetch(guildId).catch(() => null);
+  if (!discordGuild) {
+    throw new Error('Serveur introuvable sur Discord.');
+  }
+
+  const clanRoleIds = clans.map((c) => c.roleId);
+
+  // Récupérer les membres
+  const allMembers = await discordGuild.members.fetch().catch(() => null);
+  if (!allMembers) {
+    throw new Error('Impossible de récupérer la liste des membres.');
+  }
+
+  // Filtrer les membres qui ont au moins un rôle de clan
+  const membersWithClan = allMembers.filter((member) => {
+    return member.roles.cache.some((r) => clanRoleIds.includes(r.id));
+  });
+
+  if (membersWithClan.size === 0) {
+    return 'Aucun membre ne possède de rôle de clan.';
+  }
+
+  const targetList = [...membersWithClan.values()];
+
+  // Démarrer la tâche
+  clanTasks.set(guildId, { type: 'clear', processed: 0, total: targetList.length });
+
+  // Lancement asynchrone
+  (async () => {
+    logger.info('ClanService', `Lancement du retrait de tous les clans pour ${targetList.length} membres dans "${discordGuild.name}" par ${initiatorName}`);
+
+    for (let i = 0; i < targetList.length; i++) {
+      const currentTask = clanTasks.get(guildId);
+      if (!currentTask || currentTask.type !== 'clear') break;
+
+      const member = targetList[i];
+      const rolesToRemove = member.roles.cache.filter((r) => clanRoleIds.includes(r.id)).map((r) => r.id);
+
+      try {
+        await member.roles.remove(rolesToRemove, 'Retrait global de tous les rôles de clan');
+      } catch (e) {
+        logger.warn('ClanService', `Impossible de retirer les clans de ${member.user.tag}:`, e);
+      }
+
+      clanTasks.set(guildId, {
+        type: 'clear',
+        processed: i + 1,
+        total: targetList.length,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 450));
+    }
+
+    logger.info('ClanService', `Retrait de tous les clans terminé pour "${discordGuild.name}"`);
+    clanTasks.delete(guildId);
+  })().catch((e) => logger.error('ClanService', 'Erreur critique dans le thread de retrait:', e));
+
+  await pushAudit(guildId, {
+    user: initiatorName,
+    action: 'Lancement retrait de clans',
+    context: discordGuild.name,
+    module: 'Clans',
+    eventType: 'Manuel',
+    details: `Retrait des clans lancé pour ${targetList.length} membres.`,
+    channelId: null,
+  }).catch(() => null);
+
+  return `Le retrait de tous les clans pour ${targetList.length} membres a commencé en arrière-plan. Cette opération s'effectue progressivement pour respecter les limites de requêtes de Discord et peut prendre plusieurs minutes. Vous pouvez suivre l'avancement sur le Dashboard.`;
+}

--- a/apps/bot/src/services/community/clanService.ts
+++ b/apps/bot/src/services/community/clanService.ts
@@ -1,7 +1,8 @@
-import { Client } from 'discord.js';
+import { Client, EmbedBuilder, ChannelType, CategoryChannel } from 'discord.js';
 import prisma from '../../utils/db.js';
 import { logger } from '../../utils/logger.js';
 import { pushAudit } from '../../api/shared.js';
+import { getClient } from '../../utils/client.js';
 
 export const clanTasks = new Map<string, { type: 'distribute' | 'clear'; processed: number; total: number }>();
 
@@ -164,4 +165,427 @@ export async function runClear(guildId: string, client: Client, initiatorName: s
   }).catch(() => null);
 
   return `Le retrait de tous les clans pour ${targetList.length} membres a commencé en arrière-plan. Cette opération s'effectue progressivement pour respecter les limites de requêtes de Discord et peut prendre plusieurs minutes. Vous pouvez suivre l'avancement sur le Dashboard.`;
+}
+
+/**
+ * Synchronise les clans pour les comptes reliés (doubles comptes).
+ * Si un utilisateur (ou les deux) possède déjà un clan, on harmonise.
+ */
+export async function syncMemberClanFromDcLink(
+  guildId: string,
+  userId: string,
+  otherUserId: string | null
+): Promise<void> {
+  try {
+    const client = getClient();
+    // 1. Vérifier si les clans sont activés
+    const guildSettings = await prisma.guild.findUnique({
+      where: { id: guildId },
+      select: { clansEnabled: true },
+    });
+    if (!guildSettings?.clansEnabled) return;
+
+    // 2. Si otherUserId n'est pas fourni, on cherche les liens validés pour userId
+    let u1 = userId;
+    let u2 = otherUserId;
+    if (!u2) {
+      const link = await prisma.linkedAccount.findFirst({
+        where: {
+          guildId,
+          status: 'VALIDATED',
+          OR: [
+            { user1Id: userId },
+            { user2Id: userId },
+          ],
+        },
+      });
+      if (!link) return;
+      u1 = link.user1Id;
+      u2 = link.user2Id;
+    }
+
+    // 3. Récupérer la guilde Discord
+    const discordGuild = client.guilds.cache.get(guildId) || await client.guilds.fetch(guildId).catch(() => null);
+    if (!discordGuild) return;
+
+    // 4. Récupérer les membres Discord
+    const member1 = discordGuild.members.cache.get(u1) || await discordGuild.members.fetch(u1).catch(() => null);
+    const member2 = discordGuild.members.cache.get(u2) || await discordGuild.members.fetch(u2).catch(() => null);
+
+    if (!member1 || !member2) return;
+
+    // 5. Récupérer les clans configurés
+    const clans = await prisma.clan.findMany({ where: { guildId } });
+    if (clans.length === 0) return;
+
+    // 6. Identifier le clan de chaque membre
+    const clan1 = clans.find(c => member1.roles.cache.has(c.roleId));
+    const clan2 = clans.find(c => member2.roles.cache.has(c.roleId));
+
+    // Si aucun des deux n'a de clan, rien à faire
+    if (!clan1 && !clan2) return;
+
+    let targetClan = clan1 || clan2;
+    if (!targetClan) return;
+
+    // Si les deux ont un clan différent, on choisit celui qui a le plus d'XP/niveau
+    if (clan1 && clan2 && clan1.id !== clan2.id) {
+      const [lvl1, lvl2] = await Promise.all([
+        prisma.memberLevel.findUnique({ where: { guildId_userId: { guildId, userId: u1 } } }),
+        prisma.memberLevel.findUnique({ where: { guildId_userId: { guildId, userId: u2 } } }),
+      ]);
+      const xp1 = lvl1?.xp ?? 0;
+      const xp2 = lvl2?.xp ?? 0;
+
+      if (xp1 >= xp2) {
+        targetClan = clan1;
+        logger.info('ClanService', `Synchro DC : Alignement de ${member2.user.tag} vers le clan de ${member1.user.tag} ("${clan1.name}" avec ${xp1} XP vs ${xp2} XP)`);
+        
+        // Retirer le rôle du clan 2 à member2 et ajouter le rôle du clan 1
+        await member2.roles.remove(clan2.roleId, `Double compte aligné sur ${member1.user.tag} (synchro auto)`).catch(() => null);
+        await member2.roles.add(clan1.roleId, `Double compte aligné sur ${member1.user.tag} (synchro auto)`).catch(() => null);
+
+        // Migrer les contributions de member2 du clan2 vers clan1
+        await migrateContributions(guildId, u2, clan2.id, clan1.id);
+      } else {
+        targetClan = clan2;
+        logger.info('ClanService', `Synchro DC : Alignement de ${member1.user.tag} vers le clan de ${member2.user.tag} ("${clan2.name}" avec ${xp2} XP vs ${xp1} XP)`);
+        
+        // Retirer le rôle du clan 1 à member1 et ajouter le rôle du clan 2
+        await member1.roles.remove(clan1.roleId, `Double compte aligné sur ${member2.user.tag} (synchro auto)`).catch(() => null);
+        await member1.roles.add(clan2.roleId, `Double compte aligné sur ${member2.user.tag} (synchro auto)`).catch(() => null);
+
+        // Migrer les contributions de member1 du clan1 vers clan2
+        await migrateContributions(guildId, u1, clan1.id, clan2.id);
+      }
+    } else {
+      // Attribuer le clan à celui qui ne l'a pas
+      if (!clan1 && targetClan) {
+        logger.info('ClanService', `Synchro DC : Attribution du clan "${targetClan.name}" à ${member1.user.tag} (lié à ${member2.user.tag})`);
+        await member1.roles.add(targetClan.roleId, `Double compte de ${member2.user.tag} (synchro auto)`).catch(() => null);
+      }
+      if (!clan2 && targetClan) {
+        logger.info('ClanService', `Synchro DC : Attribution du clan "${targetClan.name}" à ${member2.user.tag} (lié à ${member1.user.tag})`);
+        await member2.roles.add(targetClan.roleId, `Double compte de ${member1.user.tag} (synchro auto)`).catch(() => null);
+      }
+    }
+  } catch (err) {
+    logger.error('ClanService', `Erreur synchro clan DC pour ${userId}:`, err);
+  }
+}
+
+/**
+ * Migre les contributions d'un utilisateur d'un clan vers un autre,
+ * en fusionnant l'XP s'il existe déjà une contribution pour la même saison.
+ */
+async function migrateContributions(
+  guildId: string,
+  userId: string,
+  sourceClanId: string,
+  targetClanId: string
+): Promise<void> {
+  try {
+    const sourceContribs = await prisma.clanMemberContribution.findMany({
+      where: { guildId, clanId: sourceClanId, userId },
+    });
+
+    for (const contrib of sourceContribs) {
+      const targetContrib = await prisma.clanMemberContribution.findUnique({
+        where: {
+          guildId_clanId_userId_season: {
+            guildId,
+            clanId: targetClanId,
+            userId,
+            season: contrib.season,
+          },
+        },
+      });
+
+      if (targetContrib) {
+        // Fusionner l'XP
+        await prisma.clanMemberContribution.update({
+          where: { id: targetContrib.id },
+          data: { xp: targetContrib.xp + contrib.xp },
+        });
+        // Supprimer l'ancienne contribution source
+        await prisma.clanMemberContribution.delete({
+          where: { id: contrib.id },
+        });
+      } else {
+        // Simplement changer le clanId
+        await prisma.clanMemberContribution.update({
+          where: { id: contrib.id },
+          data: { clanId: targetClanId },
+        });
+      }
+    }
+    logger.info('ClanService', `Contributions de l'utilisateur ${userId} migrées avec succès de ${sourceClanId} vers ${targetClanId}`);
+  } catch (err) {
+    logger.error('ClanService', `Erreur lors de la migration des contributions pour ${userId} de ${sourceClanId} vers ${targetClanId}:`, err);
+  }
+}
+
+/**
+ * Gère le sacre et l'attribution des bonus de fin de saison.
+ */
+export async function handleEndSeason(
+  guildId: string,
+  client: Client,
+  initiatorName: string,
+  currentSeason: number,
+  nextSeason: number
+): Promise<void> {
+  try {
+    const guildSettings = await prisma.guild.findUnique({
+      where: { id: guildId },
+      select: {
+        clanAnnouncementChannelId: true,
+        clanRewardGiveaway: true,
+        clanRewardXpBoost: true,
+        clanRewardXpBoostRate: true,
+        clanRewardLeaderRole: true,
+      },
+    });
+
+    if (!guildSettings) return;
+
+    // 1. Récupérer les clans
+    const clans = await prisma.clan.findMany({ where: { guildId } });
+    if (clans.length === 0) return;
+
+    // 2. Calculer les totaux d'XP par clan pour la saison
+    let winningClan = null;
+    let maxClanXp = -1;
+
+    const clansWithXp = await Promise.all(
+      clans.map(async (clan) => {
+        const aggregate = await prisma.clanMemberContribution.aggregate({
+          where: { guildId, clanId: clan.id, season: currentSeason },
+          _sum: { xp: true },
+        });
+        const totalXp = aggregate._sum.xp ?? 0;
+        return { clan, totalXp };
+      })
+    );
+
+    for (const item of clansWithXp) {
+      if (item.totalXp > maxClanXp && item.totalXp > 0) {
+        maxClanXp = item.totalXp;
+        winningClan = item.clan;
+      }
+    }
+
+    // Récupérer le serveur Discord
+    const discordGuild = client.guilds.cache.get(guildId) || await client.guilds.fetch(guildId).catch(() => null);
+    if (!discordGuild) return;
+
+    // Nettoyer les anciens rôles de chefs de clan de tous les clans
+    if (guildSettings.clanRewardLeaderRole) {
+      for (const clan of clans) {
+        if (!clan.leaderRoleId) continue;
+        try {
+          const role = discordGuild.roles.cache.get(clan.leaderRoleId)
+            || await discordGuild.roles.fetch(clan.leaderRoleId).catch(() => null);
+          if (role) {
+            const membersWithRole = Array.from(role.members.values());
+            for (const m of membersWithRole) {
+              await m.roles.remove(clan.leaderRoleId, `Clôture de la Saison ${currentSeason} - Réinitialisation des chefs`).catch(() => null);
+            }
+          }
+        } catch (err) {
+          logger.warn('ClanService', `Erreur lors du nettoyage du rôle de chef ${clan.leaderRoleId}:`, err);
+        }
+      }
+    }
+
+    let leaderUserId: string | null = null;
+    let leaderXp = 0;
+
+    // 3. Traiter le vainqueur s'il y en a un
+    if (winningClan) {
+      // Enregistrer le vainqueur
+      await prisma.guild.update({
+        where: { id: guildId },
+        data: { lastWinningClanId: winningClan.id },
+      });
+
+      // Trouver le chef de coalition (meilleur contributeur) du clan gagnant
+      const topContributor = await prisma.clanMemberContribution.findFirst({
+        where: { guildId, clanId: winningClan.id, season: currentSeason },
+        orderBy: { xp: 'desc' },
+      });
+
+      if (topContributor && topContributor.xp > 0) {
+        leaderUserId = topContributor.userId;
+        leaderXp = topContributor.xp;
+
+        // Attribuer le rôle de chef si configuré et activé
+        if (guildSettings.clanRewardLeaderRole && winningClan.leaderRoleId) {
+          const member = discordGuild.members.cache.get(leaderUserId) 
+            || await discordGuild.members.fetch(leaderUserId).catch(() => null);
+          if (member) {
+            await member.roles.add(winningClan.leaderRoleId, `Sacre du Chef de Coalition - Fin de la Saison ${currentSeason}`).catch((err) => {
+              logger.warn('ClanService', `Impossible d'attribuer le rôle de chef de clan à ${member.user.tag}:`, err);
+            });
+          }
+        }
+      }
+    }
+
+    // 4. Renommage des catégories QG de clan (avec gestion d'erreur robuste)
+    for (const clan of clans) {
+      if (!clan.generalChannelId) continue;
+      
+      const channel = discordGuild.channels.cache.get(clan.generalChannelId)
+        || await discordGuild.channels.fetch(clan.generalChannelId).catch(() => null);
+        
+      if (channel && channel.parent && channel.parent.type === ChannelType.GuildCategory) {
+        const category = channel.parent as CategoryChannel;
+        const isWinner = winningClan && clan.id === winningClan.id;
+        
+        let targetName = category.name.split('[')[0].trim(); // Retirer les anciennes balises
+        
+        if (isWinner) {
+          const activeRewards: string[] = [];
+          if (guildSettings.clanRewardXpBoost) {
+            activeRewards.push(`+${Math.round((guildSettings.clanRewardXpBoostRate - 1) * 100)}% XP`);
+          }
+          if (guildSettings.clanRewardGiveaway) {
+            activeRewards.push('GIVEAWAY BOOST');
+          }
+          
+          if (activeRewards.length > 0) {
+            targetName = `${targetName} [🏆 ${activeRewards.join(' + ')}]`;
+          }
+        }
+        
+        if (category.name !== targetName) {
+          logger.info('ClanService', `Renommage du QG du clan "${clan.name}" en "${targetName}"`);
+          await category.setName(targetName, `Mise à jour QG - Fin de la Saison ${currentSeason}`).catch((err) => {
+            logger.warn('ClanService', `Permission insuffisante pour renommer la catégorie ${category.name}:`, err);
+          });
+        }
+      }
+    }
+
+    // 5. Envoyer l'annonce globale de fin de saison
+    if (guildSettings.clanAnnouncementChannelId) {
+      const announcementChannel = discordGuild.channels.cache.get(guildSettings.clanAnnouncementChannelId)
+        || await discordGuild.channels.fetch(guildSettings.clanAnnouncementChannelId).catch(() => null);
+        
+      if (announcementChannel && announcementChannel.isTextBased()) {
+        const globalEmbed = new EmbedBuilder()
+          .setTitle(`🏁 Fin de la Saison de Clans ${currentSeason} !`)
+          .setColor(0xF59E0B) // Amber
+          .setTimestamp();
+
+        if (winningClan) {
+          let winnerText = `Le clan **${winningClan.name}** remporte la victoire pour cette saison avec un total de **${maxClanXp.toLocaleString('fr-FR')} XP** ! 🎉\n\n`;
+          winnerText += `Ses membres bénéficient d'avantages exclusifs pour la **Saison ${nextSeason}** :\n`;
+          if (guildSettings.clanRewardXpBoost) {
+            winnerText += `- **Boost d'XP** : +${Math.round((guildSettings.clanRewardXpBoostRate - 1) * 100)}% d'XP sur tout le serveur !\n`;
+          }
+          if (guildSettings.clanRewardGiveaway) {
+            winnerText += `- **Giveaways** : Plus de chances de remporter les tirages au sort !\n`;
+          }
+          
+          if (leaderUserId) {
+            winnerText += `\nFélicitations à <@${leaderUserId}>, couronné **Chef de Coalition** du clan avec une contribution record de **${leaderXp.toLocaleString('fr-FR')} XP** ! 👑`;
+          }
+
+          globalEmbed.setDescription(winnerText);
+        } else {
+          globalEmbed.setDescription(`La saison de clans ${currentSeason} se termine. Aucun clan n'a accumulé d'XP cette saison.`);
+        }
+
+        await announcementChannel.send({ embeds: [globalEmbed] }).catch((err) => {
+          logger.warn('ClanService', 'Impossible d\'envoyer l\'annonce globale de fin de saison:', err);
+        });
+      }
+    }
+
+    // 6. Envoyer l'annonce interne dans le QG du clan vainqueur
+    if (winningClan && winningClan.generalChannelId) {
+      const qgChannel = discordGuild.channels.cache.get(winningClan.generalChannelId)
+        || await discordGuild.channels.fetch(winningClan.generalChannelId).catch(() => null);
+        
+      if (qgChannel && qgChannel.isTextBased()) {
+        const localEmbed = new EmbedBuilder()
+          .setTitle(`🏆 Victoire du Clan ${winningClan.name} !`)
+          .setDescription(
+            `Félicitations à tous les membres ! Grâce à votre investissement, notre clan remporte la **Saison ${currentSeason}** ! 🎉\n\n` +
+            `Nos bonus sont maintenant actifs dans toute notre catégorie QG. ` +
+            (leaderUserId ? `Un salut spécial à notre **Chef de Coalition** <@${leaderUserId}> pour son score impressionnant de **${leaderXp.toLocaleString('fr-FR')} XP** ! 👑` : '')
+          )
+          .setColor(0x10B981) // Green
+          .setTimestamp();
+
+        await qgChannel.send({ embeds: [localEmbed] }).catch((err) => {
+          logger.warn('ClanService', `Impossible d'envoyer l'annonce locale de victoire dans le QG de ${winningClan.name}:`, err);
+        });
+      }
+    }
+  } catch (err) {
+    logger.error('ClanService', `Erreur critique lors de la fin de saison de clans pour le serveur ${guildId}:`, err);
+  }
+}
+
+/**
+ * Vérifie si la saison de clans active a atteint sa date de fin et procède
+ * au reset et à l'application des récompenses.
+ */
+export async function checkAndProgressClanSeasons(client: Client): Promise<void> {
+  try {
+    const now = new Date();
+
+    // Trouver tous les serveurs avec les clans activés et une date de fin de saison dépassée
+    const guildsToReset = await prisma.guild.findMany({
+      where: {
+        clansEnabled: true,
+        clanSeasonEndsAt: {
+          not: null,
+          lte: now,
+        },
+      },
+      select: {
+        id: true,
+        currentClanSeason: true,
+        clanSeasonStartsAt: true,
+        clanSeasonEndsAt: true,
+      },
+    });
+
+    for (const guild of guildsToReset) {
+      logger.info('ClanService', `Déclenchement automatique de la fin de saison de clans pour le serveur ${guild.id}`);
+
+      const nextSeason = guild.currentClanSeason + 1;
+
+      // Déterminer la nouvelle plage de dates si la saison précédente avait une durée planifiée
+      let nextStartsAt: Date | null = null;
+      let nextEndsAt: Date | null = null;
+
+      if (guild.clanSeasonStartsAt && guild.clanSeasonEndsAt) {
+        const durationMs = guild.clanSeasonEndsAt.getTime() - guild.clanSeasonStartsAt.getTime();
+        nextStartsAt = now;
+        nextEndsAt = new Date(now.getTime() + durationMs);
+      }
+
+      // 1. Décerner les bonus, renommer les QG et publier les annonces
+      await handleEndSeason(guild.id, client, 'Système (Planifié)', guild.currentClanSeason, nextSeason);
+
+      // 2. Mettre à jour la saison et les dates en BDD
+      await prisma.guild.update({
+        where: { id: guild.id },
+        data: {
+          currentClanSeason: nextSeason,
+          clanSeasonStartsAt: nextStartsAt,
+          clanSeasonEndsAt: nextEndsAt,
+        },
+      });
+
+      logger.info('ClanService', `Saison de clans réinitialisée automatiquement. Nouvelle saison: ${nextSeason} (Fin: ${nextEndsAt})`);
+    }
+  } catch (err) {
+    logger.error('ClanService', 'Erreur lors de la vérification planifiée des saisons de clans:', err);
+  }
 }

--- a/apps/bot/src/services/features/giveawayService.ts
+++ b/apps/bot/src/services/features/giveawayService.ts
@@ -214,19 +214,8 @@ export async function endGiveaway(client: Client, giveawayId: string) {
   const channel = discordGuild.channels.cache.get(giveaway.channelId);
   if (!channel?.isTextBased()) return;
 
-  // Tirer les gagnants
-  const participants = giveaway.participants;
-  const winners: string[] = [];
-  const count = Math.min(giveaway.winnerCount, participants.length);
-
-  if (count > 0) {
-    const pool = [...participants];
-    for (let i = 0; i < count; i++) {
-      const randIndex = Math.floor(Math.random() * pool.length);
-      winners.push(pool[randIndex]);
-      pool.splice(randIndex, 1);
-    }
-  }
+  // Tirer les gagnants avec pondération de clan
+  const winners = await drawWinnersWeighted(giveaway.guildId, giveaway.participants, giveaway.winnerCount, channel);
 
   // Mettre à jour le message d'origine
   if (giveaway.messageId) {
@@ -333,7 +322,8 @@ export async function rerollGiveaway(client: Client, giveawayId: string) {
     return;
   }
 
-  const newWinner = candidates[Math.floor(Math.random() * candidates.length)];
+  const newWinners = await drawWinnersWeighted(giveaway.guildId, candidates, 1, channel);
+  const newWinner = newWinners[0];
 
   if (giveaway.needValidation) {
     // Si validation requise, on met à jour en tant que gagnant en attente
@@ -605,4 +595,85 @@ export async function checkExpiredGiveaways(client: Client) {
   } catch (err) {
     logger.error('GiveawayService', 'Erreur lors de la vérification des giveaways expirés :', err);
   }
+}
+
+/**
+ * Choisit `count` gagnants parmi les candidats en appliquant le bonus de chances
+ * du clan gagnant de la saison de clans active.
+ */
+async function drawWinnersWeighted(
+  guildId: string,
+  candidates: string[],
+  count: number,
+  channel: any
+): Promise<string[]> {
+  if (candidates.length === 0 || count <= 0) return [];
+
+  // Récupérer les paramètres de bonus du clan vainqueur
+  let winningRoleId: string | null = null;
+  try {
+    const guildSettings = await prisma.guild.findUnique({
+      where: { id: guildId },
+      select: { clanRewardGiveaway: true, lastWinningClanId: true },
+    });
+    if (guildSettings?.clanRewardGiveaway && guildSettings.lastWinningClanId) {
+      const winningClan = await prisma.clan.findUnique({
+        where: { id: guildSettings.lastWinningClanId },
+        select: { roleId: true },
+      });
+      if (winningClan) {
+        winningRoleId = winningClan.roleId;
+      }
+    }
+  } catch (err) {
+    logger.error('GiveawayService', 'Erreur lors de la récupération du bonus de giveaway de clan:', err);
+  }
+
+  const winners: string[] = [];
+  const pool = [...candidates];
+  const discordGuild = channel.guild;
+
+  // Si pas de bonus actif, tirage uniforme standard
+  if (!winningRoleId || !discordGuild) {
+    const actualCount = Math.min(count, pool.length);
+    for (let i = 0; i < actualCount; i++) {
+      const randIndex = Math.floor(Math.random() * pool.length);
+      winners.push(pool[randIndex]);
+      pool.splice(randIndex, 1);
+    }
+    return winners;
+  }
+
+  // Tirage pondéré
+  const actualCount = Math.min(count, pool.length);
+  for (let i = 0; i < actualCount; i++) {
+    // Calculer les poids de chaque candidat restant
+    const weights: number[] = [];
+    let totalWeight = 0;
+
+    for (const userId of pool) {
+      const member = discordGuild.members.cache.get(userId);
+      // Poids de 2 si le membre est dans le clan vainqueur (a le rôle), sinon 1
+      const weight = (member && member.roles.cache.has(winningRoleId)) ? 2 : 1;
+      weights.push(weight);
+      totalWeight += weight;
+    }
+
+    // Sélection aléatoire pondérée
+    let randomVal = Math.random() * totalWeight;
+    let selectedIndex = 0;
+
+    for (let j = 0; j < pool.length; j++) {
+      randomVal -= weights[j];
+      if (randomVal <= 0) {
+        selectedIndex = j;
+        break;
+      }
+    }
+
+    winners.push(pool[selectedIndex]);
+    pool.splice(selectedIndex, 1);
+  }
+
+  return winners;
 }

--- a/apps/bot/src/services/moderation/altAccountService.ts
+++ b/apps/bot/src/services/moderation/altAccountService.ts
@@ -4,6 +4,7 @@ import { logger } from '../../utils/logger.js';
 import { type Client  } from 'discord.js';
 import * as sanctionService from './sanctionService.js';
 import { createNotification } from '../staff/staffLeadershipService.js';
+import { syncMemberClanFromDcLink } from '../community/clanService.js';
 
 /**
  * Service pour la gestion des comptes liés (Main/Alt)
@@ -105,11 +106,12 @@ export async function linkAccounts(params: {
     }
   });
 
-  // Notifier les deux utilisateurs (uniquement si validé)
+  // Notifier les deux utilisateurs (uniquement si validé) et synchroniser leurs clans
   if (status === LinkedAccountStatus.VALIDATED) {
     await Promise.all([
       createNotification(guildId, idA, '🔗 Comptes liés', `Votre compte a été officiellement lié à <@${idB}>.`, 'SUCCESS', '/profile'),
-      createNotification(guildId, idB, '🔗 Comptes liés', `Votre compte a été officiellement lié à <@${idA}>.`, 'SUCCESS', '/profile')
+      createNotification(guildId, idB, '🔗 Comptes liés', `Votre compte a été officiellement lié à <@${idA}>.`, 'SUCCESS', '/profile'),
+      syncMemberClanFromDcLink(guildId, idA, idB)
     ].map(p => p.catch(() => null)));
   }
 

--- a/apps/bot/src/services/progression/levelingService.ts
+++ b/apps/bot/src/services/progression/levelingService.ts
@@ -148,6 +148,57 @@ export async function addXp(guildId: string, userId: string, amount: number, cli
     },
   });
 
+  // Incrémenter la contribution de clan si activé
+  try {
+    const guildConfig = await prisma.guild.findUnique({
+      where: { id: guildId },
+      select: { clansEnabled: true, currentClanSeason: true }
+    });
+    if (guildConfig?.clansEnabled) {
+      const clans = await prisma.clan.findMany({
+        where: { guildId },
+        select: { id: true, roleId: true }
+      });
+      if (clans.length > 0) {
+        const discordGuild = client.guilds.cache.get(guildId) || await client.guilds.fetch(guildId).catch(() => null);
+        if (discordGuild) {
+          const member = await discordGuild.members.fetch(userId).catch(() => null);
+          if (member) {
+            const clanRoleIds = clans.map(c => c.roleId);
+            const memberClanRole = member.roles.cache.find(r => clanRoleIds.includes(r.id));
+            if (memberClanRole) {
+              const clan = clans.find(c => c.roleId === memberClanRole.id);
+              if (clan) {
+                await prisma.clanMemberContribution.upsert({
+                  where: {
+                    guildId_clanId_userId_season: {
+                      guildId,
+                      clanId: clan.id,
+                      userId,
+                      season: guildConfig.currentClanSeason
+                    }
+                  },
+                  update: {
+                    xp: { increment: amount }
+                  },
+                  create: {
+                    guildId,
+                    clanId: clan.id,
+                    userId,
+                    season: guildConfig.currentClanSeason,
+                    xp: amount
+                  }
+                });
+              }
+            }
+          }
+        }
+      }
+    }
+  } catch (err) {
+    logger.error('LevelingService', `Erreur de traitement des clans lors de l'ajout d'XP pour ${userId}:`, err);
+  }
+
   const previousLevel = memberLevel.level;
   // Le niveau est toujours recalculé depuis l'XP totale : ça gère les montées
   // de niveau et auto-répare les lignes dont le niveau était incohérent.

--- a/apps/bot/src/services/progression/levelingService.ts
+++ b/apps/bot/src/services/progression/levelingService.ts
@@ -152,9 +152,9 @@ export async function addXp(guildId: string, userId: string, amount: number, cli
   try {
     const guildConfig = await prisma.guild.findUnique({
       where: { id: guildId },
-      select: { clansEnabled: true, currentClanSeason: true }
+      select: { clansEnabled: true, currentClanSeason: true, clanXpFromActivity: true }
     });
-    if (guildConfig?.clansEnabled) {
+    if (guildConfig?.clansEnabled && guildConfig?.clanXpFromActivity) {
       const clans = await prisma.clan.findMany({
         where: { guildId },
         select: { id: true, roleId: true }
@@ -232,6 +232,52 @@ async function processLevelUp(guildId: string, userId: string, newLevel: number,
 
     const member = await discordGuild.members.fetch(userId).catch(() => null);
     if (!member) return;
+
+    // 0. Attribution des points de clan pour la montée de niveau si activé
+    try {
+      const guildConfig = await prisma.guild.findUnique({
+        where: { id: guildId },
+        select: { clansEnabled: true, currentClanSeason: true, clanXpFromLevelUp: true, clanXpPerLevelUp: true }
+      });
+      if (guildConfig?.clansEnabled && guildConfig?.clanXpFromLevelUp && guildConfig?.clanXpPerLevelUp > 0) {
+        const clans = await prisma.clan.findMany({
+          where: { guildId },
+          select: { id: true, roleId: true }
+        });
+        if (clans.length > 0) {
+          const clanRoleIds = clans.map(c => c.roleId);
+          const memberClanRole = member.roles.cache.find(r => clanRoleIds.includes(r.id));
+          if (memberClanRole) {
+            const clan = clans.find(c => c.roleId === memberClanRole.id);
+            if (clan) {
+              await prisma.clanMemberContribution.upsert({
+                where: {
+                  guildId_clanId_userId_season: {
+                    guildId,
+                    clanId: clan.id,
+                    userId,
+                    season: guildConfig.currentClanSeason
+                  }
+                },
+                update: {
+                  xp: { increment: guildConfig.clanXpPerLevelUp }
+                },
+                create: {
+                  guildId,
+                  clanId: clan.id,
+                  userId,
+                  season: guildConfig.currentClanSeason,
+                  xp: guildConfig.clanXpPerLevelUp
+                }
+              });
+              logger.info('LevelingService', `Points de clan (${guildConfig.clanXpPerLevelUp} XP) attribués à ${member.user.tag} pour son passage au niveau ${newLevel} dans le clan "${clan.id}"`);
+            }
+          }
+        }
+      }
+    } catch (clanErr) {
+      logger.error('LevelingService', `Erreur lors de l'attribution des points de clan pour le level up de ${userId}:`, clanErr);
+    }
 
     // 1. Attribution des rôles de récompense
     const rewards = await prisma.levelRoleReward.findMany({

--- a/apps/bot/src/services/progression/levelingService.ts
+++ b/apps/bot/src/services/progression/levelingService.ts
@@ -148,56 +148,7 @@ export async function addXp(guildId: string, userId: string, amount: number, cli
     },
   });
 
-  // Incrémenter la contribution de clan si activé
-  try {
-    const guildConfig = await prisma.guild.findUnique({
-      where: { id: guildId },
-      select: { clansEnabled: true, currentClanSeason: true, clanXpFromActivity: true }
-    });
-    if (guildConfig?.clansEnabled && guildConfig?.clanXpFromActivity) {
-      const clans = await prisma.clan.findMany({
-        where: { guildId },
-        select: { id: true, roleId: true }
-      });
-      if (clans.length > 0) {
-        const discordGuild = client.guilds.cache.get(guildId) || await client.guilds.fetch(guildId).catch(() => null);
-        if (discordGuild) {
-          const member = await discordGuild.members.fetch(userId).catch(() => null);
-          if (member) {
-            const clanRoleIds = clans.map(c => c.roleId);
-            const memberClanRole = member.roles.cache.find(r => clanRoleIds.includes(r.id));
-            if (memberClanRole) {
-              const clan = clans.find(c => c.roleId === memberClanRole.id);
-              if (clan) {
-                await prisma.clanMemberContribution.upsert({
-                  where: {
-                    guildId_clanId_userId_season: {
-                      guildId,
-                      clanId: clan.id,
-                      userId,
-                      season: guildConfig.currentClanSeason
-                    }
-                  },
-                  update: {
-                    xp: { increment: amount }
-                  },
-                  create: {
-                    guildId,
-                    clanId: clan.id,
-                    userId,
-                    season: guildConfig.currentClanSeason,
-                    xp: amount
-                  }
-                });
-              }
-            }
-          }
-        }
-      }
-    }
-  } catch (err) {
-    logger.error('LevelingService', `Erreur de traitement des clans lors de l'ajout d'XP pour ${userId}:`, err);
-  }
+
 
   const previousLevel = memberLevel.level;
   // Le niveau est toujours recalculé depuis l'XP totale : ça gère les montées

--- a/apps/bot/src/services/progression/levelingService.ts
+++ b/apps/bot/src/services/progression/levelingService.ts
@@ -134,16 +134,49 @@ export async function handleTextXp(guildId: string, userId: string, client: Clie
  * Ajoute de l'XP brute à un utilisateur et gère le passage de niveau
  */
 export async function addXp(guildId: string, userId: string, amount: number, client: Client, channelId?: string) {
+  if (amount <= 0) return;
+
+  let finalAmount = amount;
+  try {
+    const guildSettings = await prisma.guild.findUnique({
+      where: { id: guildId },
+      select: {
+        clanRewardXpBoost: true,
+        clanRewardXpBoostRate: true,
+        lastWinningClanId: true,
+      },
+    });
+
+    if (guildSettings?.clanRewardXpBoost && guildSettings.lastWinningClanId) {
+      const winningClan = await prisma.clan.findUnique({
+        where: { id: guildSettings.lastWinningClanId },
+        select: { roleId: true },
+      });
+
+      if (winningClan) {
+        const discordGuild = client.guilds.cache.get(guildId) || await client.guilds.fetch(guildId).catch(() => null);
+        if (discordGuild) {
+          const member = discordGuild.members.cache.get(userId) || await discordGuild.members.fetch(userId).catch(() => null);
+          if (member && member.roles.cache.has(winningClan.roleId)) {
+            finalAmount = Math.round(amount * guildSettings.clanRewardXpBoostRate);
+          }
+        }
+      }
+    }
+  } catch (err) {
+    logger.error('LevelingService', `Erreur lors de l'application du multiplicateur d'XP de clan pour ${userId}:`, err);
+  }
+
   const memberLevel = await prisma.memberLevel.upsert({
     where: { guildId_userId: { guildId, userId } },
     update: {
-      xp: { increment: amount },
+      xp: { increment: finalAmount },
       lastXpGain: new Date(),
     },
     create: {
       guildId,
       userId,
-      xp: amount,
+      xp: finalAmount,
       level: 0,
     },
   });

--- a/apps/bot/src/tests/unit/clanService.test.ts
+++ b/apps/bot/src/tests/unit/clanService.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test, mock, beforeEach } from 'bun:test';
+import path from 'node:path';
+
+// Mock the database dependency
+const mockDb = {
+  guild: {
+    findUnique: mock(() => Promise.resolve({ clansEnabled: true })),
+  },
+  linkedAccount: {
+    findFirst: mock(() => Promise.resolve(null)),
+  },
+  clan: {
+    findMany: mock(() => Promise.resolve([])),
+  },
+  memberLevel: {
+    findUnique: mock(() => Promise.resolve(null)),
+  },
+  clanMemberContribution: {
+    findMany: mock(() => Promise.resolve([])),
+    findUnique: mock(() => Promise.resolve(null)),
+    update: mock(() => Promise.resolve({})),
+    delete: mock(() => Promise.resolve({})),
+  },
+};
+
+const dbPath = path.resolve(import.meta.dir, '../../utils/db.ts');
+const dbJsPath = path.resolve(import.meta.dir, '../../utils/db.js');
+
+mock.module(dbPath, () => ({
+  default: mockDb,
+  prisma: mockDb,
+}));
+
+mock.module(dbJsPath, () => ({
+  default: mockDb,
+  prisma: mockDb,
+}));
+
+// Mock Discord Client & getClient helper
+const mockDiscordMember1 = {
+  user: { tag: 'User1#0001' },
+  roles: {
+    cache: {
+      has: mock((roleId: string) => roleId === 'role-clan-1'),
+    },
+    add: mock(() => Promise.resolve({})),
+    remove: mock(() => Promise.resolve({})),
+  },
+};
+
+const mockDiscordMember2 = {
+  user: { tag: 'User2#0002' },
+  roles: {
+    cache: {
+      has: mock((roleId: string) => roleId === 'role-clan-2'),
+    },
+    add: mock(() => Promise.resolve({})),
+    remove: mock(() => Promise.resolve({})),
+  },
+};
+
+const mockDiscordGuild = {
+  members: {
+    cache: {
+      get: mock((userId: string) => {
+        if (userId === 'user-1') return mockDiscordMember1;
+        if (userId === 'user-2') return mockDiscordMember2;
+        return null;
+      }),
+    },
+    fetch: mock((userId: string) => {
+      if (userId === 'user-1') return Promise.resolve(mockDiscordMember1);
+      if (userId === 'user-2') return Promise.resolve(mockDiscordMember2);
+      return Promise.resolve(null);
+    }),
+  },
+};
+
+const mockClient = {
+  guilds: {
+    cache: {
+      get: mock(() => mockDiscordGuild),
+    },
+    fetch: mock(() => Promise.resolve(mockDiscordGuild)),
+  },
+};
+
+const clientPath = path.resolve(import.meta.dir, '../../utils/client.ts');
+const clientJsPath = path.resolve(import.meta.dir, '../../utils/client.js');
+
+mock.module(clientPath, () => ({
+  getClient: () => mockClient,
+}));
+
+mock.module(clientJsPath, () => ({
+  getClient: () => mockClient,
+}));
+
+// Now import the service we want to test
+import { syncMemberClanFromDcLink } from '../../services/community/clanService.js';
+
+describe('clan service DC sync tests', () => {
+  beforeEach(() => {
+    mockDb.guild.findUnique.mockClear();
+    mockDb.linkedAccount.findFirst.mockClear();
+    mockDb.clan.findMany.mockClear();
+    mockDb.memberLevel.findUnique.mockClear();
+    mockDb.clanMemberContribution.findMany.mockClear();
+    mockDb.clanMemberContribution.findUnique.mockClear();
+    mockDb.clanMemberContribution.update.mockClear();
+    mockDb.clanMemberContribution.delete.mockClear();
+
+    mockDiscordMember1.roles.add.mockClear();
+    mockDiscordMember1.roles.remove.mockClear();
+    mockDiscordMember2.roles.add.mockClear();
+    mockDiscordMember2.roles.remove.mockClear();
+
+    // Reset default mock behaviors
+    mockDb.guild.findUnique.mockResolvedValue({ clansEnabled: true });
+    mockDb.clan.findMany.mockResolvedValue([
+      { id: 'clan-1', name: 'Clan One', roleId: 'role-clan-1' },
+      { id: 'clan-2', name: 'Clan Two', roleId: 'role-clan-2' },
+    ]);
+  });
+
+  test('should return early if clans are not enabled', async () => {
+    mockDb.guild.findUnique.mockResolvedValue({ clansEnabled: false });
+
+    await syncMemberClanFromDcLink('guild-123', 'user-1', 'user-2');
+
+    expect(mockDb.clan.findMany).not.toHaveBeenCalled();
+  });
+
+  test('should assign clan to member who does not have one', async () => {
+    // Member 1 has clan-1, Member 2 has no clan
+    mockDiscordMember1.roles.cache.has.mockImplementation((roleId) => roleId === 'role-clan-1');
+    mockDiscordMember2.roles.cache.has.mockImplementation(() => false);
+
+    await syncMemberClanFromDcLink('guild-123', 'user-1', 'user-2');
+
+    expect(mockDiscordMember2.roles.add).toHaveBeenCalledWith('role-clan-1', expect.any(String));
+    expect(mockDiscordMember1.roles.add).not.toHaveBeenCalled();
+  });
+
+  test('should align double accounts with different clans to the one with highest MemberLevel XP', async () => {
+    // Member 1 has clan-1, Member 2 has clan-2
+    mockDiscordMember1.roles.cache.has.mockImplementation((roleId) => roleId === 'role-clan-1');
+    mockDiscordMember2.roles.cache.has.mockImplementation((roleId) => roleId === 'role-clan-2');
+
+    // Member 1 has 500 XP, Member 2 has 100 XP
+    mockDb.memberLevel.findUnique.mockImplementation(async (options: any) => {
+      if (options.where.guildId_userId.userId === 'user-1') return { xp: 500 };
+      if (options.where.guildId_userId.userId === 'user-2') return { xp: 100 };
+      return null;
+    });
+
+    // Mock contributions migration: Member 2 has a contribution in clan-2 for season 1
+    mockDb.clanMemberContribution.findMany.mockResolvedValue([
+      { id: 'contrib-alt', guildId: 'guild-123', clanId: 'clan-2', userId: 'user-2', xp: 50, season: 1 },
+    ]);
+    // Member 2 already has a contribution in target clan-1 (to test fusion)
+    mockDb.clanMemberContribution.findUnique.mockResolvedValue({
+      id: 'contrib-main', guildId: 'guild-123', clanId: 'clan-1', userId: 'user-2', xp: 100, season: 1
+    });
+
+    await syncMemberClanFromDcLink('guild-123', 'user-1', 'user-2');
+
+    // Member 2 should be moved to clan-1 (role-clan-1)
+    expect(mockDiscordMember2.roles.remove).toHaveBeenCalledWith('role-clan-2', expect.any(String));
+    expect(mockDiscordMember2.roles.add).toHaveBeenCalledWith('role-clan-1', expect.any(String));
+
+    // Contributions should be fused
+    expect(mockDb.clanMemberContribution.update).toHaveBeenCalledWith({
+      where: { id: 'contrib-main' },
+      data: { xp: 150 },
+    });
+    expect(mockDb.clanMemberContribution.delete).toHaveBeenCalledWith({
+      where: { id: 'contrib-alt' },
+    });
+  });
+});

--- a/apps/dashboard/src/App.svelte
+++ b/apps/dashboard/src/App.svelte
@@ -101,6 +101,8 @@
   import MCPSettings from "./pages/MCPSettings.svelte";
   import FunSettings from "./pages/FunSettings.svelte";
   import CustomBot from "./pages/CustomBot.svelte";
+  import Clans from "./pages/Clans.svelte";
+  import LevelingClanPublic from "./pages/LevelingClanPublic.svelte";
   import Verify from "./pages/Verify.svelte";
   import ChannelHealth from "./pages/ChannelHealth.svelte";
   import ChannelLinks from "./pages/ChannelLinks.svelte";
@@ -120,6 +122,7 @@
   const isPublicPage = $derived(
     /^\/\d{17,19}\/news\/?$/.test($router.path) ||
       /^\/\d{17,19}\/leveling\/classement\/?$/.test($router.path) ||
+      /^\/\d{17,19}\/leveling\/clan\/?$/.test($router.path) ||
       ($router.path.startsWith("/profile/") && !authStore.isAuthenticated) ||
       $router.path.startsWith("/transcripts/") ||
       $router.path.startsWith("/sanction-evidence/") ||
@@ -460,6 +463,9 @@
       </Route>
       <Route path="/:serverId/leveling/classement" let:meta>
         <LevelingPublic serverId={meta.params.serverId} />
+      </Route>
+      <Route path="/:serverId/leveling/clan" let:meta>
+        <LevelingClanPublic serverId={meta.params.serverId} />
       </Route>
       <Route path="/profile/:userId" let:meta>
         <PublicProfile userId={meta.params.userId} />
@@ -895,6 +901,9 @@
             </Route>
             <Route path="/fun">
               <FunSettings />
+            </Route>
+            <Route path="/clans">
+              <Clans />
             </Route>
 
             <Route path="/double-accounts/*">

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -3135,3 +3135,113 @@ export async function updateMessageLogConfig(
     errorContext: 'API Error (Message Config):',
   });
 }
+
+// ─────────────────────────────────────────────────────────────
+// Clans
+// ─────────────────────────────────────────────────────────────
+
+export interface ClanEntry {
+  id: string;
+  name: string;
+  description: string | null;
+  roleId: string;
+  memberCount: number;
+  totalXp: number;
+}
+
+export interface ClansDataResult {
+  clansEnabled: boolean;
+  clansUnique: boolean;
+  currentClanSeason: number;
+  clans: ClanEntry[];
+  taskInProgress: { type: 'distribute' | 'clear'; processed: number; total: number } | null;
+}
+
+export async function fetchClansData(guildId = authStore.selectedGuildId): Promise<ClansDataResult | null> {
+  return dashboardRequest('/clans', {
+    method: 'GET',
+    guildId,
+    errorContext: 'API Error (Fetch Clans):',
+    silent: true,
+  });
+}
+
+export async function updateClanSettings(
+  payload: { clansEnabled?: boolean; clansUnique?: boolean },
+  guildId = authStore.selectedGuildId,
+): Promise<{ clansEnabled: boolean; clansUnique: boolean } | null> {
+  return dashboardRequest('/clans', {
+    method: 'PATCH',
+    payload,
+    guildId,
+    errorContext: 'API Error (Update Clans Settings):',
+  });
+}
+
+export async function createClan(
+  payload: { name: string; description?: string; roleId: string },
+  guildId = authStore.selectedGuildId,
+): Promise<{ clan: ClanEntry } | null> {
+  return dashboardRequest('/clans', {
+    method: 'POST',
+    payload,
+    guildId,
+    errorContext: 'API Error (Create Clan):',
+  });
+}
+
+export async function updateClan(
+  id: string,
+  payload: { name: string; description?: string; roleId: string },
+  guildId = authStore.selectedGuildId,
+): Promise<{ clan: ClanEntry } | null> {
+  return dashboardRequest(`/clans/${id}`, {
+    method: 'PUT',
+    payload,
+    guildId,
+    errorContext: 'API Error (Update Clan):',
+  });
+}
+
+export async function deleteClan(id: string, guildId = authStore.selectedGuildId): Promise<boolean> {
+  return dashboardMutation(`/clans/${id}`, {
+    method: 'DELETE',
+    guildId,
+    errorContext: 'API Error (Delete Clan):',
+  });
+}
+
+export async function distributeClans(guildId = authStore.selectedGuildId): Promise<{ message: string } | null> {
+  return dashboardRequest('/clans/distribute', {
+    method: 'POST',
+    guildId,
+    errorContext: 'API Error (Distribute Clans):',
+  });
+}
+
+export async function clearClans(guildId = authStore.selectedGuildId): Promise<{ message: string } | null> {
+  return dashboardRequest('/clans/clear', {
+    method: 'POST',
+    guildId,
+    errorContext: 'API Error (Clear Clans):',
+  });
+}
+
+export async function resetClanSeason(guildId = authStore.selectedGuildId): Promise<{ currentClanSeason: number } | null> {
+  return dashboardRequest('/clans/reset-season', {
+    method: 'POST',
+    guildId,
+    errorContext: 'API Error (Reset Clan Season):',
+  });
+}
+
+export async function fetchPublicClans(guildId: string): Promise<any | null> {
+  try {
+    const response = await fetch(`${API_BASE_URL}/api/public/guilds/${guildId}/clans`);
+    if (!response.ok) return null;
+    return await response.json();
+  } catch (err) {
+    console.error('API Error (Fetch Public Clans):', err);
+    return null;
+  }
+}

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -3153,7 +3153,6 @@ export interface ClansDataResult {
   clansEnabled: boolean;
   clansUnique: boolean;
   currentClanSeason: number;
-  clanXpFromActivity: boolean;
   clanXpFromLevelUp: boolean;
   clanXpPerLevelUp: number;
   clans: ClanEntry[];
@@ -3173,7 +3172,6 @@ export async function updateClanSettings(
   payload: {
     clansEnabled?: boolean;
     clansUnique?: boolean;
-    clanXpFromActivity?: boolean;
     clanXpFromLevelUp?: boolean;
     clanXpPerLevelUp?: number;
   },
@@ -3181,7 +3179,6 @@ export async function updateClanSettings(
 ): Promise<{
   clansEnabled: boolean;
   clansUnique: boolean;
-  clanXpFromActivity: boolean;
   clanXpFromLevelUp: boolean;
   clanXpPerLevelUp: number;
 } | null> {

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -3145,6 +3145,8 @@ export interface ClanEntry {
   name: string;
   description: string | null;
   roleId: string;
+  generalChannelId: string | null;
+  leaderRoleId: string | null;
   memberCount: number;
   totalXp: number;
 }
@@ -3155,6 +3157,14 @@ export interface ClansDataResult {
   currentClanSeason: number;
   clanXpFromLevelUp: boolean;
   clanXpPerLevelUp: number;
+  clanAnnouncementChannelId: string | null;
+  clanRewardGiveaway: boolean;
+  clanRewardXpBoost: boolean;
+  clanRewardXpBoostRate: number;
+  clanRewardLeaderRole: boolean;
+  lastWinningClanId: string | null;
+  clanSeasonStartsAt: string | null;
+  clanSeasonEndsAt: string | null;
   clans: ClanEntry[];
   taskInProgress: { type: 'distribute' | 'clear'; processed: number; total: number } | null;
 }
@@ -3174,6 +3184,13 @@ export async function updateClanSettings(
     clansUnique?: boolean;
     clanXpFromLevelUp?: boolean;
     clanXpPerLevelUp?: number;
+    clanAnnouncementChannelId?: string | null;
+    clanRewardGiveaway?: boolean;
+    clanRewardLeaderRole?: boolean;
+    clanRewardXpBoost?: boolean;
+    clanRewardXpBoostRate?: number;
+    clanSeasonStartsAt?: string | null;
+    clanSeasonEndsAt?: string | null;
   },
   guildId = authStore.selectedGuildId,
 ): Promise<{
@@ -3181,6 +3198,13 @@ export async function updateClanSettings(
   clansUnique: boolean;
   clanXpFromLevelUp: boolean;
   clanXpPerLevelUp: number;
+  clanAnnouncementChannelId: string | null;
+  clanRewardGiveaway: boolean;
+  clanRewardLeaderRole: boolean;
+  clanRewardXpBoost: boolean;
+  clanRewardXpBoostRate: number;
+  clanSeasonStartsAt: string | null;
+  clanSeasonEndsAt: string | null;
 } | null> {
   return dashboardRequest('/clans', {
     method: 'PATCH',
@@ -3191,7 +3215,13 @@ export async function updateClanSettings(
 }
 
 export async function createClan(
-  payload: { name: string; description?: string; roleId: string },
+  payload: {
+    name: string;
+    description?: string;
+    roleId: string;
+    generalChannelId?: string | null;
+    leaderRoleId?: string | null;
+  },
   guildId = authStore.selectedGuildId,
 ): Promise<{ clan: ClanEntry } | null> {
   return dashboardRequest('/clans', {
@@ -3204,7 +3234,13 @@ export async function createClan(
 
 export async function updateClan(
   id: string,
-  payload: { name: string; description?: string; roleId: string },
+  payload: {
+    name: string;
+    description?: string;
+    roleId: string;
+    generalChannelId?: string | null;
+    leaderRoleId?: string | null;
+  },
   guildId = authStore.selectedGuildId,
 ): Promise<{ clan: ClanEntry } | null> {
   return dashboardRequest(`/clans/${id}`, {
@@ -3244,6 +3280,18 @@ export async function resetClanSeason(guildId = authStore.selectedGuildId): Prom
     method: 'POST',
     guildId,
     errorContext: 'API Error (Reset Clan Season):',
+  });
+}
+
+export async function addClanPoints(
+  payload: { clanId: string; userId?: string | null; amount: number },
+  guildId = authStore.selectedGuildId
+): Promise<{ success: boolean; contribution?: any } | null> {
+  return dashboardRequest('/clans/points', {
+    method: 'POST',
+    guildId,
+    body: JSON.stringify(payload),
+    errorContext: 'API Error (Add Clan Points):',
   });
 }
 

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -3153,6 +3153,9 @@ export interface ClansDataResult {
   clansEnabled: boolean;
   clansUnique: boolean;
   currentClanSeason: number;
+  clanXpFromActivity: boolean;
+  clanXpFromLevelUp: boolean;
+  clanXpPerLevelUp: number;
   clans: ClanEntry[];
   taskInProgress: { type: 'distribute' | 'clear'; processed: number; total: number } | null;
 }
@@ -3167,9 +3170,21 @@ export async function fetchClansData(guildId = authStore.selectedGuildId): Promi
 }
 
 export async function updateClanSettings(
-  payload: { clansEnabled?: boolean; clansUnique?: boolean },
+  payload: {
+    clansEnabled?: boolean;
+    clansUnique?: boolean;
+    clanXpFromActivity?: boolean;
+    clanXpFromLevelUp?: boolean;
+    clanXpPerLevelUp?: number;
+  },
   guildId = authStore.selectedGuildId,
-): Promise<{ clansEnabled: boolean; clansUnique: boolean } | null> {
+): Promise<{
+  clansEnabled: boolean;
+  clansUnique: boolean;
+  clanXpFromActivity: boolean;
+  clanXpFromLevelUp: boolean;
+  clanXpPerLevelUp: number;
+} | null> {
   return dashboardRequest('/clans', {
     method: 'PATCH',
     payload,

--- a/apps/dashboard/src/lib/components/Sidebar.svelte
+++ b/apps/dashboard/src/lib/components/Sidebar.svelte
@@ -131,7 +131,7 @@
   const navGroups = $derived.by((): NavGroup[] => {
     const general    = { key: 'general',    label: 'Général',       items: visibleGeneral    };
     const moderation = { key: 'moderation', label: 'Modération',     items: visibleModeration };
-    const leveling   = { key: 'leveling',   label: "Système d'XP",  items: visibleLeveling   };
+    const leveling   = { key: 'leveling',   label: "Système d'XP & Clans", items: visibleLeveling   };
     const economy    = { key: 'economy',    label: 'Économie & RPG',items: visibleEconomy    };
     const community  = { key: 'community',  label: 'Communauté',     items: visibleCommunity  };
     const staff      = { key: 'staff',      label: 'Staff',          items: visibleStaff      };

--- a/apps/dashboard/src/lib/config/pages.ts
+++ b/apps/dashboard/src/lib/config/pages.ts
@@ -48,6 +48,7 @@ export const levelingItems: PageConfig[] = [
   { name: "Leveling & XP",       icon: "trophy",        href: "/leveling",         featureKey: "leveling", beta: false, wip: false },
   { name: "Saisons",             icon: "flag",          href: "/seasons",          featureKey: "leveling", beta: true, wip: false },
   { name: "Réputation",          icon: "star",          href: "/reputation",       featureKey: "leveling", beta: true, wip: false },
+  { name: "Clans",               icon: "shield",        href: "/clans",            featureKey: "leveling", beta: true, wip: false },
 ];
 
 export const economyItems: PageConfig[] = [
@@ -67,7 +68,6 @@ export const communityItems: PageConfig[] = [
   { name: "Actualités & RSS",    icon: "rss",           href: "/news",             featureKey: "news", beta: false, wip: false },
   { name: "Salons Fun",          icon: "smile",         href: "/fun",              featureKey: "fun",  beta: true, wip: false },
   { name: "Réseaux sociaux",     icon: "share-2",       href: "/social-networks",  featureKey: "social_networks", beta: true, wip: false },
-  { name: "Clans",               icon: "shield",        href: "/clans",            featureKey: "welcome_goodbye", beta: true, wip: false },
 ];
 
 export const staffItems: PageConfig[] = [

--- a/apps/dashboard/src/lib/config/pages.ts
+++ b/apps/dashboard/src/lib/config/pages.ts
@@ -67,6 +67,7 @@ export const communityItems: PageConfig[] = [
   { name: "Actualités & RSS",    icon: "rss",           href: "/news",             featureKey: "news", beta: false, wip: false },
   { name: "Salons Fun",          icon: "smile",         href: "/fun",              featureKey: "fun",  beta: true, wip: false },
   { name: "Réseaux sociaux",     icon: "share-2",       href: "/social-networks",  featureKey: "social_networks", beta: true, wip: false },
+  { name: "Clans",               icon: "shield",        href: "/clans",            featureKey: "welcome_goodbye", beta: true, wip: false },
 ];
 
 export const staffItems: PageConfig[] = [

--- a/apps/dashboard/src/pages/Clans.svelte
+++ b/apps/dashboard/src/pages/Clans.svelte
@@ -33,12 +33,18 @@
   let clansEnabled = $state(false);
   let clansUnique = $state(true);
   let currentClanSeason = $state(1);
+  let clanXpFromActivity = $state(true);
+  let clanXpFromLevelUp = $state(false);
+  let clanXpPerLevelUp = $state(50);
   let clans = $state<ClanEntry[]>([]);
   let taskInProgress = $state<ClansDataResult['taskInProgress']>(null);
 
   // Saved states (for dirty checking)
   let savedClansEnabled = $state(false);
   let savedClansUnique = $state(true);
+  let savedClanXpFromActivity = $state(true);
+  let savedClanXpFromLevelUp = $state(false);
+  let savedClanXpPerLevelUp = $state(50);
 
   // Form states
   let formName = $state('');
@@ -59,7 +65,12 @@
 
   // Sync state changes with the unsaved changes bar
   $effect(() => {
-    const dirty = clansEnabled !== savedClansEnabled || clansUnique !== savedClansUnique;
+    const dirty = clansEnabled !== savedClansEnabled 
+      || clansUnique !== savedClansUnique
+      || clanXpFromActivity !== savedClanXpFromActivity
+      || clanXpFromLevelUp !== savedClanXpFromLevelUp
+      || clanXpPerLevelUp !== savedClanXpPerLevelUp;
+
     if (dirty && canManageSettings) {
       untrack(() => {
         unsavedChanges.register({
@@ -68,6 +79,9 @@
           onReset: () => {
             clansEnabled = savedClansEnabled;
             clansUnique = savedClansUnique;
+            clanXpFromActivity = savedClanXpFromActivity;
+            clanXpFromLevelUp = savedClanXpFromLevelUp;
+            clanXpPerLevelUp = savedClanXpPerLevelUp;
           }
         });
       });
@@ -110,12 +124,18 @@
         clansEnabled = res.clansEnabled;
         clansUnique = res.clansUnique;
         currentClanSeason = res.currentClanSeason;
+        clanXpFromActivity = res.clanXpFromActivity;
+        clanXpFromLevelUp = res.clanXpFromLevelUp;
+        clanXpPerLevelUp = res.clanXpPerLevelUp;
         clans = res.clans;
         taskInProgress = res.taskInProgress;
 
         if (!silent) {
           savedClansEnabled = res.clansEnabled;
           savedClansUnique = res.clansUnique;
+          savedClanXpFromActivity = res.clanXpFromActivity;
+          savedClanXpFromLevelUp = res.clanXpFromLevelUp;
+          savedClanXpPerLevelUp = res.clanXpPerLevelUp;
         }
       }
     } catch (err) {
@@ -134,11 +154,20 @@
     if (!canManageSettings) return false;
     let success = false;
     await actionState.run(async () => {
-      const res = await updateClanSettings({ clansEnabled, clansUnique });
+      const res = await updateClanSettings({
+        clansEnabled,
+        clansUnique,
+        clanXpFromActivity,
+        clanXpFromLevelUp,
+        clanXpPerLevelUp
+      });
       if (!res) throw new Error('Erreur de sauvegarde');
       
       savedClansEnabled = res.clansEnabled;
       savedClansUnique = res.clansUnique;
+      savedClanXpFromActivity = res.clanXpFromActivity;
+      savedClanXpFromLevelUp = res.clanXpFromLevelUp;
+      savedClanXpPerLevelUp = res.clanXpPerLevelUp;
       success = true;
       return true;
     }, { successMessage: 'Paramètres des clans sauvegardés avec succès !' });
@@ -283,21 +312,60 @@
         <section class="bg-surface-container-low/40 border border-outline-variant/30 p-6 rounded-xl space-y-6">
           <h3 class="text-lg font-semibold border-b border-outline-variant/15 pb-2">⚙️ Configuration</h3>
           
-          <div class="space-y-4">
-            <div class="flex items-center justify-between">
-              <div>
-                <span class="text-sm font-medium text-on-surface">Activer les clans</span>
-                <p class="text-xs text-on-surface-variant/70">Active les commandes slash /clan et la sécurité.</p>
+          <div class="space-y-4 divide-y divide-outline-variant/10">
+            <div class="space-y-4 pb-4">
+              <div class="flex items-center justify-between">
+                <div>
+                  <span class="text-sm font-medium text-on-surface">Activer les clans</span>
+                  <p class="text-xs text-on-surface-variant/70">Active les commandes slash /clan et la sécurité.</p>
+                </div>
+                <ToggleSwitch bind:checked={clansEnabled} disabled={!canManageSettings} />
               </div>
-              <ToggleSwitch bind:checked={clansEnabled} disabled={!canManageSettings} />
+
+              <div class="flex items-center justify-between">
+                <div>
+                  <span class="text-sm font-medium text-on-surface">Clan Unique</span>
+                  <p class="text-xs text-on-surface-variant/70">Force un seul rôle de clan par membre Discord.</p>
+                </div>
+                <ToggleSwitch bind:checked={clansUnique} disabled={!canManageSettings} />
+              </div>
             </div>
 
-            <div class="flex items-center justify-between">
-              <div>
-                <span class="text-sm font-medium text-on-surface">Clan Unique</span>
-                <p class="text-xs text-on-surface-variant/70">Force un seul rôle de clan par membre Discord.</p>
+            <div class="space-y-4 pt-4">
+              <h4 class="text-xs font-bold text-on-surface-variant/80 uppercase tracking-wider">⚡ Sources de points</h4>
+              
+              <div class="flex items-center justify-between">
+                <div>
+                  <span class="text-sm font-medium text-on-surface">Activité (écrit / vocal)</span>
+                  <p class="text-xs text-on-surface-variant/70">Gagne des points de clan via l'XP de chat/vocal.</p>
+                </div>
+                <ToggleSwitch bind:checked={clanXpFromActivity} disabled={!canManageSettings} />
               </div>
-              <ToggleSwitch bind:checked={clansUnique} disabled={!canManageSettings} />
+
+              <div class="flex items-center justify-between">
+                <div>
+                  <span class="text-sm font-medium text-on-surface">Passage de niveau</span>
+                  <p class="text-xs text-on-surface-variant/70">Points bonus offerts lors d'un level up sur le serveur.</p>
+                </div>
+                <ToggleSwitch bind:checked={clanXpFromLevelUp} disabled={!canManageSettings} />
+              </div>
+
+              {#if clanXpFromLevelUp}
+                <div class="space-y-1.5 pl-4 animate-in slide-in-from-top-2 duration-200">
+                  <label for="clan-xp-levelup-amount" class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest">Points attribués par niveau</label>
+                  <div class="flex items-center gap-2">
+                    <input
+                      id="clan-xp-levelup-amount"
+                      type="number"
+                      bind:value={clanXpPerLevelUp}
+                      min="0"
+                      class="w-24 bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-2.5 py-1.5 text-xs text-on-surface focus:outline-none focus:ring-1 focus:ring-primary/40 font-bold"
+                      disabled={!canManageSettings}
+                    />
+                    <span class="text-xs text-on-surface-variant/60 font-semibold">XP / niveau</span>
+                  </div>
+                </div>
+              {/if}
             </div>
           </div>
         </section>

--- a/apps/dashboard/src/pages/Clans.svelte
+++ b/apps/dashboard/src/pages/Clans.svelte
@@ -33,7 +33,6 @@
   let clansEnabled = $state(false);
   let clansUnique = $state(true);
   let currentClanSeason = $state(1);
-  let clanXpFromActivity = $state(true);
   let clanXpFromLevelUp = $state(false);
   let clanXpPerLevelUp = $state(50);
   let clans = $state<ClanEntry[]>([]);
@@ -42,7 +41,6 @@
   // Saved states (for dirty checking)
   let savedClansEnabled = $state(false);
   let savedClansUnique = $state(true);
-  let savedClanXpFromActivity = $state(true);
   let savedClanXpFromLevelUp = $state(false);
   let savedClanXpPerLevelUp = $state(50);
 
@@ -67,7 +65,6 @@
   $effect(() => {
     const dirty = clansEnabled !== savedClansEnabled 
       || clansUnique !== savedClansUnique
-      || clanXpFromActivity !== savedClanXpFromActivity
       || clanXpFromLevelUp !== savedClanXpFromLevelUp
       || clanXpPerLevelUp !== savedClanXpPerLevelUp;
 
@@ -79,7 +76,6 @@
           onReset: () => {
             clansEnabled = savedClansEnabled;
             clansUnique = savedClansUnique;
-            clanXpFromActivity = savedClanXpFromActivity;
             clanXpFromLevelUp = savedClanXpFromLevelUp;
             clanXpPerLevelUp = savedClanXpPerLevelUp;
           }
@@ -124,7 +120,6 @@
         clansEnabled = res.clansEnabled;
         clansUnique = res.clansUnique;
         currentClanSeason = res.currentClanSeason;
-        clanXpFromActivity = res.clanXpFromActivity;
         clanXpFromLevelUp = res.clanXpFromLevelUp;
         clanXpPerLevelUp = res.clanXpPerLevelUp;
         clans = res.clans;
@@ -133,7 +128,6 @@
         if (!silent) {
           savedClansEnabled = res.clansEnabled;
           savedClansUnique = res.clansUnique;
-          savedClanXpFromActivity = res.clanXpFromActivity;
           savedClanXpFromLevelUp = res.clanXpFromLevelUp;
           savedClanXpPerLevelUp = res.clanXpPerLevelUp;
         }
@@ -157,7 +151,6 @@
       const res = await updateClanSettings({
         clansEnabled,
         clansUnique,
-        clanXpFromActivity,
         clanXpFromLevelUp,
         clanXpPerLevelUp
       });
@@ -165,7 +158,6 @@
       
       savedClansEnabled = res.clansEnabled;
       savedClansUnique = res.clansUnique;
-      savedClanXpFromActivity = res.clanXpFromActivity;
       savedClanXpFromLevelUp = res.clanXpFromLevelUp;
       savedClanXpPerLevelUp = res.clanXpPerLevelUp;
       success = true;
@@ -333,14 +325,6 @@
 
             <div class="space-y-4 pt-4">
               <h4 class="text-xs font-bold text-on-surface-variant/80 uppercase tracking-wider">⚡ Sources de points</h4>
-              
-              <div class="flex items-center justify-between">
-                <div>
-                  <span class="text-sm font-medium text-on-surface">Activité (écrit / vocal)</span>
-                  <p class="text-xs text-on-surface-variant/70">Gagne des points de clan via l'XP de chat/vocal.</p>
-                </div>
-                <ToggleSwitch bind:checked={clanXpFromActivity} disabled={!canManageSettings} />
-              </div>
 
               <div class="flex items-center justify-between">
                 <div>

--- a/apps/dashboard/src/pages/Clans.svelte
+++ b/apps/dashboard/src/pages/Clans.svelte
@@ -20,6 +20,7 @@
     distributeClans,
     clearClans,
     resetClanSeason,
+    addClanPoints,
     type ClanEntry,
     type ClansDataResult
   } from '../lib/api';
@@ -35,19 +36,77 @@
   let currentClanSeason = $state(1);
   let clanXpFromLevelUp = $state(false);
   let clanXpPerLevelUp = $state(50);
+  let clanAnnouncementChannelId = $state<string | null>(null);
+  let clanRewardGiveaway = $state(false);
+  let clanRewardLeaderRole = $state(false);
+  let clanRewardXpBoost = $state(false); // needed for handleSaveSettings update
+  let clanRewardXpBoostRate = $state(1.2); // needed for handleSaveSettings update
   let clans = $state<ClanEntry[]>([]);
   let taskInProgress = $state<ClansDataResult['taskInProgress']>(null);
+
+  // Season dates states
+  let clanSeasonStartsAt = $state<string | null>(null);
+  let clanSeasonEndsAt = $state<string | null>(null);
+  let formSeasonStartsAt = $state('');
+  let formSeasonEndsAt = $state('');
 
   // Saved states (for dirty checking)
   let savedClansEnabled = $state(false);
   let savedClansUnique = $state(true);
   let savedClanXpFromLevelUp = $state(false);
   let savedClanXpPerLevelUp = $state(50);
+  let savedClanAnnouncementChannelId = $state<string | null>(null);
+  let savedClanRewardGiveaway = $state(false);
+  let savedClanRewardLeaderRole = $state(false);
+  let savedClanSeasonStartsAt = $state<string | null>(null);
+  let savedClanSeasonEndsAt = $state<string | null>(null);
+
+  // Tab routing
+  let activeTab = $state<'clans' | 'seasons' | 'points'>('clans');
 
   // Form states
   let formName = $state('');
   let formDescription = $state('');
   let formRoleId = $state('');
+  let formGeneralChannelId = $state('');
+  let formLeaderRoleId = $state('');
+
+  let availableChannels = $state<any[]>([]);
+
+  // Points Management tab states & handlers
+  let selectedClanIdForPoints = $state('');
+  let manualPointsAmountClan = $state(100);
+  let selectedClanIdForMemberPoints = $state('');
+  let manualPointsMemberUserId = $state('');
+  let manualPointsAmountMember = $state(100);
+
+  async function handleAddClanPoints() {
+    if (!canManageSettings || !selectedClanIdForPoints || !manualPointsAmountClan) return;
+    await actionState.run(async () => {
+      const res = await addClanPoints({
+        clanId: selectedClanIdForPoints,
+        amount: manualPointsAmountClan,
+      });
+      if (!res) throw new Error('Erreur lors de l\'ajout de points au clan.');
+      await refreshData(true);
+      manualPointsAmountClan = 100;
+    }, { successMessage: 'Points ajustés avec succès !' });
+  }
+
+  async function handleAddMemberPoints() {
+    if (!canManageSettings || !selectedClanIdForMemberPoints || !manualPointsMemberUserId || !manualPointsAmountMember) return;
+    await actionState.run(async () => {
+      const res = await addClanPoints({
+        clanId: selectedClanIdForMemberPoints,
+        userId: manualPointsMemberUserId,
+        amount: manualPointsAmountMember,
+      });
+      if (!res) throw new Error('Erreur lors de l\'ajout de points au membre.');
+      await refreshData(true);
+      manualPointsMemberUserId = '';
+      manualPointsAmountMember = 100;
+    }, { successMessage: 'Points du membre ajustés avec succès !' });
+  }
 
   // Confirmation state for reset/clear/distribute
   let confirmInput = $state('');
@@ -61,12 +120,25 @@
 
   const availableRoles = $derived(dashboardStore.state.discordRoles || []);
 
+  const formatLocal = (dateStr: string | null) => {
+    if (!dateStr) return '';
+    const d = new Date(dateStr);
+    if (Number.isNaN(d.getTime())) return '';
+    const tzOffset = d.getTimezoneOffset() * 60000;
+    return new Date(d.getTime() - tzOffset).toISOString().slice(0, 16);
+  };
+
   // Sync state changes with the unsaved changes bar
   $effect(() => {
     const dirty = clansEnabled !== savedClansEnabled 
       || clansUnique !== savedClansUnique
       || clanXpFromLevelUp !== savedClanXpFromLevelUp
-      || clanXpPerLevelUp !== savedClanXpPerLevelUp;
+      || clanXpPerLevelUp !== savedClanXpPerLevelUp
+      || clanAnnouncementChannelId !== savedClanAnnouncementChannelId
+      || clanRewardGiveaway !== savedClanRewardGiveaway
+      || clanRewardLeaderRole !== savedClanRewardLeaderRole
+      || formSeasonStartsAt !== formatLocal(savedClanSeasonStartsAt)
+      || formSeasonEndsAt !== formatLocal(savedClanSeasonEndsAt);
 
     if (dirty && canManageSettings) {
       untrack(() => {
@@ -78,6 +150,11 @@
             clansUnique = savedClansUnique;
             clanXpFromLevelUp = savedClanXpFromLevelUp;
             clanXpPerLevelUp = savedClanXpPerLevelUp;
+            clanAnnouncementChannelId = savedClanAnnouncementChannelId;
+            clanRewardGiveaway = savedClanRewardGiveaway;
+            clanRewardLeaderRole = savedClanRewardLeaderRole;
+            formSeasonStartsAt = formatLocal(savedClanSeasonStartsAt);
+            formSeasonEndsAt = formatLocal(savedClanSeasonEndsAt);
           }
         });
       });
@@ -112,6 +189,30 @@
     }
   });
 
+  // Countdown helper
+  let timeRemaining = $state('');
+  $effect(() => {
+    if (clanSeasonEndsAt) {
+      const target = new Date(clanSeasonEndsAt).getTime();
+      const update = () => {
+        const diff = target - Date.now();
+        if (diff <= 0) {
+          timeRemaining = 'Saison terminée (clôture imminente par le Bot)';
+          return;
+        }
+        const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+        const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+        const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+        timeRemaining = `Se termine dans ${days}j ${hours}h ${minutes}m`;
+      };
+      update();
+      const interval = setInterval(update, 60000);
+      return () => clearInterval(interval);
+    } else {
+      timeRemaining = 'Non planifiée (durée indéterminée)';
+    }
+  });
+
   async function refreshData(silent = false) {
     if (!silent) loading = true;
     try {
@@ -122,14 +223,30 @@
         currentClanSeason = res.currentClanSeason;
         clanXpFromLevelUp = res.clanXpFromLevelUp;
         clanXpPerLevelUp = res.clanXpPerLevelUp;
+        clanAnnouncementChannelId = res.clanAnnouncementChannelId;
+        clanRewardGiveaway = res.clanRewardGiveaway;
+        clanRewardLeaderRole = res.clanRewardLeaderRole;
+        clanRewardXpBoost = res.clanRewardXpBoost;
+        clanRewardXpBoostRate = res.clanRewardXpBoostRate;
+        clanSeasonStartsAt = res.clanSeasonStartsAt;
+        clanSeasonEndsAt = res.clanSeasonEndsAt;
         clans = res.clans;
         taskInProgress = res.taskInProgress;
+
+        // Formater les dates pour l'input type datetime-local (YYYY-MM-DDTHH:MM)
+        formSeasonStartsAt = formatLocal(res.clanSeasonStartsAt);
+        formSeasonEndsAt = formatLocal(res.clanSeasonEndsAt);
 
         if (!silent) {
           savedClansEnabled = res.clansEnabled;
           savedClansUnique = res.clansUnique;
           savedClanXpFromLevelUp = res.clanXpFromLevelUp;
           savedClanXpPerLevelUp = res.clanXpPerLevelUp;
+          savedClanAnnouncementChannelId = res.clanAnnouncementChannelId;
+          savedClanRewardGiveaway = res.clanRewardGiveaway;
+          savedClanRewardLeaderRole = res.clanRewardLeaderRole;
+          savedClanSeasonStartsAt = res.clanSeasonStartsAt;
+          savedClanSeasonEndsAt = res.clanSeasonEndsAt;
         }
       }
     } catch (err) {
@@ -142,7 +259,14 @@
   onMount(async () => {
     await dashboardStore.refresh();
     await refreshData();
+    const channelsData = await fetchDiscordChannels().catch(() => null);
+    if (channelsData) {
+      availableChannels = channelsData.textChannels || [];
+    }
   });
+
+  // Dynamically import channels fetch
+  import { fetchDiscordChannels } from '../lib/api';
 
   async function handleSaveSettings(): Promise<boolean> {
     if (!canManageSettings) return false;
@@ -152,7 +276,14 @@
         clansEnabled,
         clansUnique,
         clanXpFromLevelUp,
-        clanXpPerLevelUp
+        clanXpPerLevelUp,
+        clanAnnouncementChannelId: clanAnnouncementChannelId || null,
+        clanRewardGiveaway,
+        clanRewardLeaderRole,
+        clanRewardXpBoost,
+        clanRewardXpBoostRate,
+        clanSeasonStartsAt: formSeasonStartsAt ? new Date(formSeasonStartsAt).toISOString() : null,
+        clanSeasonEndsAt: formSeasonEndsAt ? new Date(formSeasonEndsAt).toISOString() : null
       });
       if (!res) throw new Error('Erreur de sauvegarde');
       
@@ -160,6 +291,11 @@
       savedClansUnique = res.clansUnique;
       savedClanXpFromLevelUp = res.clanXpFromLevelUp;
       savedClanXpPerLevelUp = res.clanXpPerLevelUp;
+      savedClanAnnouncementChannelId = res.clanAnnouncementChannelId;
+      savedClanRewardGiveaway = res.clanRewardGiveaway;
+      savedClanRewardLeaderRole = res.clanRewardLeaderRole;
+      savedClanSeasonStartsAt = res.clanSeasonStartsAt;
+      savedClanSeasonEndsAt = res.clanSeasonEndsAt;
       success = true;
       return true;
     }, { successMessage: 'Paramètres des clans sauvegardés avec succès !' });
@@ -171,6 +307,8 @@
     formName = '';
     formDescription = '';
     formRoleId = '';
+    formGeneralChannelId = '';
+    formLeaderRoleId = '';
     actionState.clearFeedback();
     showModal = true;
   }
@@ -180,6 +318,8 @@
     formName = clan.name;
     formDescription = clan.description || '';
     formRoleId = clan.roleId;
+    formGeneralChannelId = clan.generalChannelId || '';
+    formLeaderRoleId = clan.leaderRoleId || '';
     actionState.clearFeedback();
     showModal = true;
   }
@@ -188,20 +328,20 @@
     if (!canManageSettings || !formName || !formRoleId) return;
 
     await actionState.run(async () => {
+      const payload = {
+        name: formName,
+        description: formDescription || undefined,
+        roleId: formRoleId,
+        generalChannelId: formGeneralChannelId || null,
+        leaderRoleId: formLeaderRoleId || null
+      };
+
       if (editingClan) {
-        const res = await updateClan(editingClan.id, {
-          name: formName,
-          description: formDescription || undefined,
-          roleId: formRoleId
-        });
+        const res = await updateClan(editingClan.id, payload);
         if (!res) throw new Error('Erreur lors de la modification');
         clans = clans.map(c => c.id === editingClan!.id ? res.clan : c);
       } else {
-        const res = await createClan({
-          name: formName,
-          description: formDescription || undefined,
-          roleId: formRoleId
-        });
+        const res = await createClan(payload);
         if (!res) throw new Error('Erreur lors de la création');
         clans = [...clans, res.clan];
       }
@@ -288,6 +428,28 @@
 >
   <InlineFeedback state={actionState} />
 
+  <!-- Navigation par Onglets -->
+  <div class="flex border-b border-outline-variant/15 mb-6">
+    <button
+      class="px-5 py-3 text-sm font-semibold border-b-2 transition-all cursor-pointer {activeTab === 'clans' ? 'border-primary text-primary font-bold bg-primary/5 rounded-t-lg' : 'border-transparent text-on-surface-variant/70 hover:text-on-surface hover:bg-surface-container-low/30'}"
+      onclick={() => activeTab = 'clans'}
+    >
+      🛡️ Clans & Rôles
+    </button>
+    <button
+      class="px-5 py-3 text-sm font-semibold border-b-2 transition-all cursor-pointer {activeTab === 'seasons' ? 'border-primary text-primary font-bold bg-primary/5 rounded-t-lg' : 'border-transparent text-on-surface-variant/70 hover:text-on-surface hover:bg-surface-container-low/30'}"
+      onclick={() => activeTab = 'seasons'}
+    >
+      📅 Gestion des Saisons
+    </button>
+    <button
+      class="px-5 py-3 text-sm font-semibold border-b-2 transition-all cursor-pointer {activeTab === 'points' ? 'border-primary text-primary font-bold bg-primary/5 rounded-t-lg' : 'border-transparent text-on-surface-variant/70 hover:text-on-surface hover:bg-surface-container-low/30'}"
+      onclick={() => activeTab = 'points'}
+    >
+      ⚡ Gestion des Points
+    </button>
+  </div>
+
   {#if loading}
     <div class="space-y-6">
       <Skeleton height="80px" />
@@ -297,6 +459,7 @@
       <LoadingHint context="clans" />
     </div>
   {:else}
+    {#if activeTab === 'clans'}
     <div class="grid grid-cols-1 xl:grid-cols-3 gap-8">
       
       <!-- Left side: General Settings -->
@@ -304,52 +467,58 @@
         <section class="bg-surface-container-low/40 border border-outline-variant/30 p-6 rounded-xl space-y-6">
           <h3 class="text-lg font-semibold border-b border-outline-variant/15 pb-2">⚙️ Configuration</h3>
           
-          <div class="space-y-4 divide-y divide-outline-variant/10">
-            <div class="space-y-4 pb-4">
-              <div class="flex items-center justify-between">
-                <div>
-                  <span class="text-sm font-medium text-on-surface">Activer les clans</span>
-                  <p class="text-xs text-on-surface-variant/70">Active les commandes slash /clan et la sécurité.</p>
-                </div>
-                <ToggleSwitch bind:checked={clansEnabled} disabled={!canManageSettings} />
+          <div class="space-y-4">
+            <div class="flex items-center justify-between">
+              <div>
+                <span class="text-sm font-medium text-on-surface">Activer les clans</span>
+                <p class="text-xs text-on-surface-variant/70">Active les commandes slash /clan et la sécurité.</p>
               </div>
-
-              <div class="flex items-center justify-between">
-                <div>
-                  <span class="text-sm font-medium text-on-surface">Clan Unique</span>
-                  <p class="text-xs text-on-surface-variant/70">Force un seul rôle de clan par membre Discord.</p>
-                </div>
-                <ToggleSwitch bind:checked={clansUnique} disabled={!canManageSettings} />
-              </div>
+              <ToggleSwitch bind:checked={clansEnabled} disabled={!canManageSettings} />
             </div>
 
-            <div class="space-y-4 pt-4">
-              <h4 class="text-xs font-bold text-on-surface-variant/80 uppercase tracking-wider">⚡ Sources de points</h4>
+            <div class="flex items-center justify-between pt-4 border-t border-outline-variant/10">
+              <div>
+                <span class="text-sm font-medium text-on-surface">Clan Unique</span>
+                <p class="text-xs text-on-surface-variant/70">Force un seul rôle de clan par membre Discord.</p>
+              </div>
+              <ToggleSwitch bind:checked={clansUnique} disabled={!canManageSettings} />
+            </div>
+          </div>
+        </section>
+ 
+        <!-- Season Rewards / Advantages -->
+        <section class="bg-surface-container-low/40 border border-outline-variant/30 p-6 rounded-xl space-y-6">
+          <h3 class="text-lg font-semibold border-b border-outline-variant/15 pb-2">🏆 Récompenses de fin de saison</h3>
+          
+          <div class="space-y-4">
+            <div class="space-y-1.5">
+              <label for="clan-announcement-channel" class="text-[10px] font-bold text-on-surface-variant/60 ml-1 uppercase tracking-widest">Salon d'Annonces de Saison</label>
+              <SearchableSelect
+                id="clan-announcement-channel"
+                bind:value={clanAnnouncementChannelId}
+                options={[{ id: '', name: 'Aucun (Désactivé)' }, ...availableChannels.map(c => ({ id: c.id, name: `#${c.name}` }))]}
+                placeholder="Sélectionner le salon"
+                disabled={!canManageSettings}
+              />
+              <p class="text-[10px] text-on-surface-variant/60 mt-1">Salon où est publiée l'annonce du vainqueur à la fin de la saison.</p>
+            </div>
+
+            <div class="space-y-4 pt-2 border-t border-outline-variant/10">
+              <div class="flex items-center justify-between">
+                <div>
+                  <span class="text-sm font-medium text-on-surface">Boost de Giveaways</span>
+                  <p class="text-xs text-on-surface-variant/70">Augmente les chances du clan gagnant dans les giveaways.</p>
+                </div>
+                <ToggleSwitch bind:checked={clanRewardGiveaway} disabled={!canManageSettings} />
+              </div>
 
               <div class="flex items-center justify-between">
                 <div>
-                  <span class="text-sm font-medium text-on-surface">Passage de niveau</span>
-                  <p class="text-xs text-on-surface-variant/70">Points bonus offerts lors d'un level up sur le serveur.</p>
+                  <span class="text-sm font-medium text-on-surface">Rôle de Chef de Clan</span>
+                  <p class="text-xs text-on-surface-variant/70">Attribue le rôle de chef configuré sur le clan au meilleur contributeur.</p>
                 </div>
-                <ToggleSwitch bind:checked={clanXpFromLevelUp} disabled={!canManageSettings} />
+                <ToggleSwitch bind:checked={clanRewardLeaderRole} disabled={!canManageSettings} />
               </div>
-
-              {#if clanXpFromLevelUp}
-                <div class="space-y-1.5 pl-4 animate-in slide-in-from-top-2 duration-200">
-                  <label for="clan-xp-levelup-amount" class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest">Points attribués par niveau</label>
-                  <div class="flex items-center gap-2">
-                    <input
-                      id="clan-xp-levelup-amount"
-                      type="number"
-                      bind:value={clanXpPerLevelUp}
-                      min="0"
-                      class="w-24 bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-2.5 py-1.5 text-xs text-on-surface focus:outline-none focus:ring-1 focus:ring-primary/40 font-bold"
-                      disabled={!canManageSettings}
-                    />
-                    <span class="text-xs text-on-surface-variant/60 font-semibold">XP / niveau</span>
-                  </div>
-                </div>
-              {/if}
             </div>
           </div>
         </section>
@@ -444,6 +613,8 @@
                   <tr class="border-b border-outline-variant/10 text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-wider">
                     <th class="pb-3">Clan</th>
                     <th class="pb-3">Rôle Discord</th>
+                    <th class="pb-3">Général de clan</th>
+                    <th class="pb-3">Rôle du Chef</th>
                     <th class="pb-3 text-center">Membres</th>
                     <th class="pb-3 text-right">XP Cumulée</th>
                     {#if canManageSettings}
@@ -464,6 +635,24 @@
                         <span class="px-2 py-1 bg-surface-container-high rounded text-xs text-on-surface-variant">
                           {availableRoles.find(r => r.id === clan.roleId)?.name || `ID: ${clan.roleId}`}
                         </span>
+                      </td>
+                      <td class="py-4">
+                        {#if clan.generalChannelId}
+                          <span class="text-xs text-on-surface-variant">
+                            #{availableChannels.find(ch => ch.id === clan.generalChannelId)?.name || `ID: ${clan.generalChannelId}`}
+                          </span>
+                        {:else}
+                          <span class="text-xs text-on-surface-variant/40 italic">Aucun</span>
+                        {/if}
+                      </td>
+                      <td class="py-4">
+                        {#if clan.leaderRoleId}
+                          <span class="px-2 py-1 bg-primary/10 rounded text-xs text-primary font-medium">
+                            {availableRoles.find(r => r.id === clan.leaderRoleId)?.name || `ID: ${clan.leaderRoleId}`}
+                          </span>
+                        {:else}
+                          <span class="text-xs text-on-surface-variant/40 italic">Aucun</span>
+                        {/if}
                       </td>
                       <td class="py-4 text-center font-medium text-xs text-on-surface">
                         {clan.memberCount}
@@ -498,7 +687,238 @@
         </section>
       </div>
 
-    </div>
+    {:else if activeTab === 'seasons'}
+      <div class="grid grid-cols-1 xl:grid-cols-3 gap-8">
+        
+        <!-- Left Column: Current Season Status Card -->
+        <div class="xl:col-span-1 space-y-6">
+          <section class="bg-surface-container-low/40 border border-outline-variant/30 p-6 rounded-xl space-y-6">
+            <div class="flex items-center justify-between border-b border-outline-variant/15 pb-3">
+              <h3 class="text-lg font-semibold flex items-center gap-2">
+                <Papicon icon="calendar" size={16} class="text-primary" />
+                Saison Actuelle
+              </h3>
+              <span class="px-3 py-1 bg-amber-500/10 text-amber-500 text-xs font-bold rounded-full">Saison {currentClanSeason}</span>
+            </div>
+
+            <div class="space-y-4">
+              <div class="p-4 bg-surface-container-high/20 rounded-xl border border-outline-variant/10 space-y-3">
+                <span class="text-xs font-bold text-on-surface-variant/60 uppercase tracking-widest block">Temps Restant</span>
+                <div class="flex items-center gap-2">
+                  <span class="text-xl font-extrabold text-on-surface">{timeRemaining}</span>
+                </div>
+                {#if clanSeasonStartsAt && clanSeasonEndsAt}
+                  <p class="text-[10px] text-on-surface-variant/50 leading-relaxed">
+                    Début : {new Date(clanSeasonStartsAt).toLocaleDateString('fr-FR', { day: 'numeric', month: 'long', hour: '2-digit', minute: '2-digit' })}
+                    <br />
+                    Fin : {new Date(clanSeasonEndsAt).toLocaleDateString('fr-FR', { day: 'numeric', month: 'long', hour: '2-digit', minute: '2-digit' })}
+                  </p>
+                {/if}
+              </div>
+
+              <p class="text-xs text-on-surface-variant/70 leading-relaxed">
+                La clôture de la saison calcule automatiquement le clan vainqueur, attribue les avantages, renomme le QG et réinitialise l'XP de clan active de tous les membres à 0.
+              </p>
+
+              {#if canManageSettings}
+                <button
+                  type="button"
+                  onclick={() => openConfirmation('reset')}
+                  class="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-amber-500 hover:bg-amber-600 text-white font-semibold text-xs rounded-lg transition-colors cursor-pointer"
+                >
+                  <Papicon icon="Refresh" size={14} /> Clôturer manuellement la Saison
+                </button>
+              {/if}
+            </div>
+          </section>
+        </div>
+
+        <!-- Right Column: Schedule / Planning Form -->
+        <div class="xl:col-span-2 space-y-6">
+          <section class="bg-surface-container-low/40 border border-outline-variant/30 p-6 rounded-xl space-y-6">
+            <h3 class="text-lg font-semibold border-b border-outline-variant/15 pb-2 flex items-center gap-2">
+              <Papicon icon="flag" size={16} class="text-secondary" />
+              Planifier la saison de clans
+            </h3>
+
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
+              <div class="space-y-2">
+                <label for="clanSeasonStartsAtInput" class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest block ml-1">Date & Heure de Début</label>
+                <input
+                  id="clanSeasonStartsAtInput"
+                  type="datetime-local"
+                  bind:value={formSeasonStartsAt}
+                  class="w-full bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-4 py-2.5 text-sm text-on-surface focus:outline-none focus:ring-2 focus:ring-primary/30 transition-all font-medium"
+                  disabled={!canManageSettings}
+                />
+              </div>
+
+              <div class="space-y-2">
+                <label for="clanSeasonEndsAtInput" class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest block ml-1">Date & Heure de Fin</label>
+                <input
+                  id="clanSeasonEndsAtInput"
+                  type="datetime-local"
+                  bind:value={formSeasonEndsAt}
+                  class="w-full bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-4 py-2.5 text-sm text-on-surface focus:outline-none focus:ring-2 focus:ring-primary/30 transition-all font-medium"
+                  disabled={!canManageSettings}
+                />
+              </div>
+            </div>
+
+            <div class="p-4 bg-primary/5 border border-primary/20 rounded-xl text-xs text-primary leading-relaxed space-y-1">
+              <p class="font-bold">💡 Fonctionnement Automatique</p>
+              <p>Lorsque la date de fin est dépassée, le Bot lancera automatiquement le traitement de fin de saison. Si une date de début et de fin étaient configurées, le système calculera automatiquement l'intervalle et programmera la saison suivante pour la même durée.</p>
+            </div>
+          </section>
+        </div>
+
+      </div>
+
+    {:else if activeTab === 'points'}
+      <div class="grid grid-cols-1 xl:grid-cols-3 gap-8">
+        
+        <!-- Left Column: Points Configuration (Module Toggle) -->
+        <div class="xl:col-span-1 space-y-6">
+          <section class="bg-surface-container-low/40 border border-outline-variant/30 p-6 rounded-xl space-y-6">
+            <h3 class="text-lg font-semibold border-b border-outline-variant/15 pb-2 flex items-center gap-2">
+              <Papicon icon="Settings" size={16} class="text-primary" />
+              Configuration des Points
+            </h3>
+
+            <div class="space-y-4">
+              <div class="flex items-center justify-between">
+                <div>
+                  <span class="text-sm font-medium text-on-surface">Gain par passage de niveau</span>
+                  <p class="text-xs text-on-surface-variant/70">Points bonus offerts lors d'un level up sur le serveur.</p>
+                </div>
+                <ToggleSwitch bind:checked={clanXpFromLevelUp} disabled={!canManageSettings} />
+              </div>
+
+              {#if clanXpFromLevelUp}
+                <div class="space-y-1.5 pt-2 border-t border-outline-variant/10 animate-in slide-in-from-top-2 duration-200">
+                  <label for="clan-xp-levelup-amount" class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest block ml-1">Points attribués par niveau</label>
+                  <div class="flex items-center gap-2">
+                    <input
+                      id="clan-xp-levelup-amount"
+                      type="number"
+                      bind:value={clanXpPerLevelUp}
+                      min="0"
+                      class="w-full bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-4 py-2.5 text-sm text-on-surface focus:outline-none focus:ring-2 focus:ring-primary/30 transition-all font-bold"
+                      disabled={!canManageSettings}
+                    />
+                    <span class="text-xs text-on-surface-variant/60 font-semibold shrink-0">XP / niveau</span>
+                  </div>
+                </div>
+              {/if}
+            </div>
+          </section>
+        </div>
+
+        <!-- Right Column: Manual Points Adjustments -->
+        <div class="xl:col-span-2 grid grid-cols-1 sm:grid-cols-2 gap-6 items-start">
+          
+          <!-- Card 1: Add points to a Clan -->
+          <section class="bg-surface-container-low/40 border border-outline-variant/30 p-6 rounded-xl space-y-6">
+            <h3 class="text-lg font-semibold border-b border-outline-variant/15 pb-2 flex items-center gap-2">
+              <Papicon icon="Shield" size={16} class="text-amber-500" />
+              Points de Clan (Global)
+            </h3>
+
+            <div class="space-y-4">
+              <div class="space-y-1.5">
+                <label for="manual-points-clan-select" class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest block ml-1">Sélectionner le Clan</label>
+                <SearchableSelect
+                  id="manual-points-clan-select"
+                  bind:value={selectedClanIdForPoints}
+                  options={clans.map(c => ({ id: c.id, name: c.name }))}
+                  placeholder="Choisir un clan"
+                  disabled={!canManageSettings}
+                />
+              </div>
+
+              <div class="space-y-1.5">
+                <label for="manual-points-clan-amount" class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest block ml-1">Montant d'XP à ajouter (ou retirer)</label>
+                <input
+                  id="manual-points-clan-amount"
+                  type="number"
+                  bind:value={manualPointsAmountClan}
+                  class="w-full bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-4 py-2.5 text-sm text-on-surface focus:outline-none focus:ring-2 focus:ring-primary/30 transition-all font-bold"
+                  disabled={!canManageSettings}
+                />
+              </div>
+
+              {#if canManageSettings}
+                <button
+                  type="button"
+                  onclick={handleAddClanPoints}
+                  class="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-primary hover:bg-primary/80 text-white font-semibold text-xs rounded-lg transition-colors cursor-pointer"
+                  disabled={!selectedClanIdForPoints}
+                >
+                  ⚡ Ajuster les points du Clan
+                </button>
+              {/if}
+            </div>
+          </section>
+
+          <!-- Card 2: Add points to a Member -->
+          <section class="bg-surface-container-low/40 border border-outline-variant/30 p-6 rounded-xl space-y-6">
+            <h3 class="text-lg font-semibold border-b border-outline-variant/15 pb-2 flex items-center gap-2">
+              <Papicon icon="user" size={16} class="text-secondary" />
+              Points d'un Membre
+            </h3>
+
+            <div class="space-y-4">
+              <div class="space-y-1.5">
+                <label for="manual-points-member-clan-select" class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest block ml-1">Sélectionner son Clan</label>
+                <SearchableSelect
+                  id="manual-points-member-clan-select"
+                  bind:value={selectedClanIdForMemberPoints}
+                  options={clans.map(c => ({ id: c.id, name: c.name }))}
+                  placeholder="Choisir un clan"
+                  disabled={!canManageSettings}
+                />
+              </div>
+
+              <div class="space-y-1.5">
+                <label for="manual-points-member-user-id" class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest block ml-1">ID Discord du Membre</label>
+                <input
+                  id="manual-points-member-user-id"
+                  type="text"
+                  placeholder="Ex: 123456789012345678"
+                  bind:value={manualPointsMemberUserId}
+                  class="w-full bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-4 py-2.5 text-sm text-on-surface focus:outline-none focus:ring-2 focus:ring-primary/30 transition-all font-medium"
+                  disabled={!canManageSettings}
+                />
+              </div>
+
+              <div class="space-y-1.5">
+                <label for="manual-points-member-amount" class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest block ml-1">Montant d'XP à ajouter (ou retirer)</label>
+                <input
+                  id="manual-points-member-amount"
+                  type="number"
+                  bind:value={manualPointsAmountMember}
+                  class="w-full bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-4 py-2.5 text-sm text-on-surface focus:outline-none focus:ring-2 focus:ring-primary/30 transition-all font-bold"
+                  disabled={!canManageSettings}
+                />
+              </div>
+
+              {#if canManageSettings}
+                <button
+                  type="button"
+                  onclick={handleAddMemberPoints}
+                  class="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-secondary hover:bg-secondary/80 text-white font-semibold text-xs rounded-lg transition-colors cursor-pointer"
+                  disabled={!selectedClanIdForMemberPoints || !manualPointsMemberUserId}
+                >
+                  ⚡ Ajuster les points du Membre
+                </button>
+              {/if}
+            </div>
+          </section>
+
+        </div>
+
+      </div>
+    {/if}
   {/if}
 </ModulePage>
 
@@ -551,6 +971,28 @@
             bind:value={formRoleId}
             options={availableRoles.map(r => ({ id: r.id, name: r.name }))}
             placeholder="Choisir le rôle Discord"
+            disabled={!canManageSettings}
+          />
+        </div>
+
+        <div class="space-y-1.5">
+          <label for="clan-channel" class="text-[10px] font-bold text-on-surface-variant/60 ml-1 uppercase tracking-widest">Général de clan (QG)</label>
+          <SearchableSelect
+            id="clan-channel"
+            bind:value={formGeneralChannelId}
+            options={[{ id: '', name: 'Aucun (Désactivé)' }, ...availableChannels.map(c => ({ id: c.id, name: `#${c.name}` }))]}
+            placeholder="Choisir le salon général"
+            disabled={!canManageSettings}
+          />
+        </div>
+
+        <div class="space-y-1.5">
+          <label for="clan-leader-role" class="text-[10px] font-bold text-on-surface-variant/60 ml-1 uppercase tracking-widest">Rôle du Chef de Clan</label>
+          <SearchableSelect
+            id="clan-leader-role"
+            bind:value={formLeaderRoleId}
+            options={[{ id: '', name: 'Aucun (Désactivé)' }, ...availableRoles.map(r => ({ id: r.id, name: `@${r.name}` }))]}
+            placeholder="Choisir le rôle du chef"
             disabled={!canManageSettings}
           />
         </div>

--- a/apps/dashboard/src/pages/Clans.svelte
+++ b/apps/dashboard/src/pages/Clans.svelte
@@ -1,0 +1,589 @@
+<script lang="ts">
+  import { onMount, onDestroy, untrack } from 'svelte';
+  import { fade, scale } from 'svelte/transition';
+  import { dashboardStore } from '../lib/stores/dashboard.svelte';
+  import { createAsyncActionState } from '../lib/asyncAction.svelte';
+  import { unsavedChanges } from '../lib/stores/unsavedChanges.svelte';
+  import Papicon from '../lib/components/Papicon.svelte';
+  import InlineFeedback from '../lib/components/InlineFeedback.svelte';
+  import SearchableSelect from '../lib/components/SearchableSelect.svelte';
+  import Skeleton from '../lib/components/Skeleton.svelte';
+  import LoadingHint from '../lib/components/LoadingHint.svelte';
+  import ModulePage from '../lib/components/ModulePage.svelte';
+  import ToggleSwitch from '../lib/components/ToggleSwitch.svelte';
+  import {
+    fetchClansData,
+    updateClanSettings,
+    createClan,
+    updateClan,
+    deleteClan,
+    distributeClans,
+    clearClans,
+    resetClanSeason,
+    type ClanEntry,
+    type ClansDataResult
+  } from '../lib/api';
+
+  const actionState = createAsyncActionState();
+  let loading = $state(false);
+  let showModal = $state(false);
+  let editingClan = $state<ClanEntry | null>(null);
+
+  // States
+  let clansEnabled = $state(false);
+  let clansUnique = $state(true);
+  let currentClanSeason = $state(1);
+  let clans = $state<ClanEntry[]>([]);
+  let taskInProgress = $state<ClansDataResult['taskInProgress']>(null);
+
+  // Saved states (for dirty checking)
+  let savedClansEnabled = $state(false);
+  let savedClansUnique = $state(true);
+
+  // Form states
+  let formName = $state('');
+  let formDescription = $state('');
+  let formRoleId = $state('');
+
+  // Confirmation state for reset/clear/distribute
+  let confirmInput = $state('');
+  let confirmActionType = $state<'clear' | 'reset' | 'distribute' | null>(null);
+  let showConfirmModal = $state(false);
+
+  const canManageSettings = $derived(
+    !!dashboardStore.state.featureAccess?.welcome_goodbye?.canConfigure
+      || !!dashboardStore.state.access?.canManageSettings
+  );
+
+  const availableRoles = $derived(dashboardStore.state.discordRoles || []);
+
+  // Sync state changes with the unsaved changes bar
+  $effect(() => {
+    const dirty = clansEnabled !== savedClansEnabled || clansUnique !== savedClansUnique;
+    if (dirty && canManageSettings) {
+      untrack(() => {
+        unsavedChanges.register({
+          label: 'Configuration des Clans',
+          onSave: () => handleSaveSettings(),
+          onReset: () => {
+            clansEnabled = savedClansEnabled;
+            clansUnique = savedClansUnique;
+          }
+        });
+      });
+    } else if (!dirty) {
+      untrack(() => {
+        if (unsavedChanges.isDirty && unsavedChanges.pageLabel === 'Configuration des Clans') {
+          unsavedChanges.clear();
+        }
+      });
+    }
+  });
+
+  // Polling mechanism while a background operation is active
+  let pollInterval: ReturnType<typeof setInterval> | null = null;
+  $effect(() => {
+    if (taskInProgress && !pollInterval) {
+      pollInterval = setInterval(() => {
+        void refreshData(true);
+      }, 2000);
+    } else if (!taskInProgress && pollInterval) {
+      clearInterval(pollInterval);
+      pollInterval = null;
+    }
+  });
+
+  onDestroy(() => {
+    if (unsavedChanges.pageLabel === 'Configuration des Clans') {
+      unsavedChanges.clear();
+    }
+    if (pollInterval) {
+      clearInterval(pollInterval);
+    }
+  });
+
+  async function refreshData(silent = false) {
+    if (!silent) loading = true;
+    try {
+      const res = await fetchClansData();
+      if (res) {
+        clansEnabled = res.clansEnabled;
+        clansUnique = res.clansUnique;
+        currentClanSeason = res.currentClanSeason;
+        clans = res.clans;
+        taskInProgress = res.taskInProgress;
+
+        if (!silent) {
+          savedClansEnabled = res.clansEnabled;
+          savedClansUnique = res.clansUnique;
+        }
+      }
+    } catch (err) {
+      console.error(err);
+    } finally {
+      if (!silent) loading = false;
+    }
+  }
+
+  onMount(async () => {
+    await dashboardStore.refresh();
+    await refreshData();
+  });
+
+  async function handleSaveSettings(): Promise<boolean> {
+    if (!canManageSettings) return false;
+    let success = false;
+    await actionState.run(async () => {
+      const res = await updateClanSettings({ clansEnabled, clansUnique });
+      if (!res) throw new Error('Erreur de sauvegarde');
+      
+      savedClansEnabled = res.clansEnabled;
+      savedClansUnique = res.clansUnique;
+      success = true;
+      return true;
+    }, { successMessage: 'Paramètres des clans sauvegardés avec succès !' });
+    return success;
+  }
+
+  function openCreateModal() {
+    editingClan = null;
+    formName = '';
+    formDescription = '';
+    formRoleId = '';
+    actionState.clearFeedback();
+    showModal = true;
+  }
+
+  function openEditModal(clan: ClanEntry) {
+    editingClan = clan;
+    formName = clan.name;
+    formDescription = clan.description || '';
+    formRoleId = clan.roleId;
+    actionState.clearFeedback();
+    showModal = true;
+  }
+
+  async function handleSaveClan() {
+    if (!canManageSettings || !formName || !formRoleId) return;
+
+    await actionState.run(async () => {
+      if (editingClan) {
+        const res = await updateClan(editingClan.id, {
+          name: formName,
+          description: formDescription || undefined,
+          roleId: formRoleId
+        });
+        if (!res) throw new Error('Erreur lors de la modification');
+        clans = clans.map(c => c.id === editingClan!.id ? res.clan : c);
+      } else {
+        const res = await createClan({
+          name: formName,
+          description: formDescription || undefined,
+          roleId: formRoleId
+        });
+        if (!res) throw new Error('Erreur lors de la création');
+        clans = [...clans, res.clan];
+      }
+      showModal = false;
+      await refreshData(true);
+      return true;
+    }, { successMessage: editingClan ? 'Clan modifié avec succès !' : 'Clan créé avec succès !' });
+  }
+
+  async function handleDeleteClan(clan: ClanEntry) {
+    if (!canManageSettings) return;
+    if (!confirm(`Voulez-vous vraiment supprimer le clan "${clan.name}" ?`)) return;
+
+    await actionState.run(async () => {
+      const success = await deleteClan(clan.id);
+      if (!success) throw new Error('Erreur de suppression');
+      clans = clans.filter(c => c.id !== clan.id);
+      return true;
+    }, { successMessage: 'Clan supprimé.' });
+  }
+
+  function openConfirmation(type: 'clear' | 'reset' | 'distribute') {
+    confirmActionType = type;
+    confirmInput = '';
+    showConfirmModal = true;
+  }
+
+  async function handleConfirmAction() {
+    if (!canManageSettings || !confirmActionType) return;
+
+    const expected = confirmActionType === 'clear' 
+      ? 'RETIRER' 
+      : confirmActionType === 'reset' 
+      ? 'RESET' 
+      : 'DISTRIBUER';
+
+    if (confirmInput.toUpperCase() !== expected) {
+      alert('Veuillez saisir le mot de confirmation correct.');
+      return;
+    }
+
+    showConfirmModal = false;
+
+    await actionState.run(async () => {
+      if (confirmActionType === 'clear') {
+        const res = await clearClans();
+        if (!res) throw new Error('Erreur lors du retrait');
+        await refreshData(true);
+      } else if (confirmActionType === 'reset') {
+        const res = await resetClanSeason();
+        if (!res) throw new Error('Erreur lors du reset');
+        currentClanSeason = res.currentClanSeason;
+        await refreshData(true);
+      } else if (confirmActionType === 'distribute') {
+        const res = await distributeClans();
+        if (!res) throw new Error('Erreur lors du lancement');
+        await refreshData(true);
+      }
+      return true;
+    }, {
+      successMessage: confirmActionType === 'clear'
+        ? 'Retrait de tous les rôles démarré en arrière-plan.'
+        : confirmActionType === 'reset'
+        ? 'Nouvelle saison de clans démarrée !'
+        : 'Distribution aléatoire lancée en arrière-plan.'
+    });
+  }
+
+  function handleDistribute() {
+    if (!canManageSettings) return;
+    if (clans.length === 0) {
+      alert('Veuillez configurer au moins un clan avant de lancer la distribution.');
+      return;
+    }
+    openConfirmation('distribute');
+  }
+</script>
+
+<ModulePage
+  title="Clans"
+  description="Divisez votre communauté en clans basés sur des rôles Discord et suivez la compétition."
+  icon="Shield"
+  featureKey="welcome_goodbye"
+>
+  <InlineFeedback state={actionState} />
+
+  {#if loading}
+    <div class="space-y-6">
+      <Skeleton height="80px" />
+      <Skeleton height="300px" />
+    </div>
+    <div class="flex justify-center mt-4">
+      <LoadingHint context="clans" />
+    </div>
+  {:else}
+    <div class="grid grid-cols-1 xl:grid-cols-3 gap-8">
+      
+      <!-- Left side: General Settings -->
+      <div class="xl:col-span-1 space-y-6">
+        <section class="bg-surface-container-low/40 border border-outline-variant/30 p-6 rounded-xl space-y-6">
+          <h3 class="text-lg font-semibold border-b border-outline-variant/15 pb-2">⚙️ Configuration</h3>
+          
+          <div class="space-y-4">
+            <div class="flex items-center justify-between">
+              <div>
+                <span class="text-sm font-medium text-on-surface">Activer les clans</span>
+                <p class="text-xs text-on-surface-variant/70">Active les commandes slash /clan et la sécurité.</p>
+              </div>
+              <ToggleSwitch bind:checked={clansEnabled} disabled={!canManageSettings} />
+            </div>
+
+            <div class="flex items-center justify-between">
+              <div>
+                <span class="text-sm font-medium text-on-surface">Clan Unique</span>
+                <p class="text-xs text-on-surface-variant/70">Force un seul rôle de clan par membre Discord.</p>
+              </div>
+              <ToggleSwitch bind:checked={clansUnique} disabled={!canManageSettings} />
+            </div>
+          </div>
+        </section>
+
+        <!-- Seasons control -->
+        <section class="bg-surface-container-low/40 border border-outline-variant/30 p-6 rounded-xl space-y-6">
+          <div class="flex items-center justify-between border-b border-outline-variant/15 pb-2">
+            <h3 class="text-lg font-semibold">📅 Saison Actuelle</h3>
+            <span class="px-3 py-1 bg-amber-500/10 text-amber-500 text-xs font-bold rounded-full">Saison {currentClanSeason}</span>
+          </div>
+
+          <div class="space-y-4">
+            <p class="text-xs text-on-surface-variant/70">
+              Passer à la saison suivante réinitialise l'XP active de tous les clans à 0. L'historique des contributions des anciennes saisons reste conservé en base de données.
+            </p>
+            {#if canManageSettings}
+              <button
+                onclick={() => openConfirmation('reset')}
+                class="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-amber-500 hover:bg-amber-600 text-white font-semibold text-xs rounded-lg transition-colors cursor-pointer"
+              >
+                <Papicon icon="Refresh" size={14} /> Réinitialiser la Saison (Reset)
+              </button>
+            {/if}
+          </div>
+        </section>
+
+        <!-- Bulk Task Progress Bar -->
+        {#if taskInProgress}
+          <section class="bg-primary/5 border border-primary/20 p-6 rounded-xl space-y-4 animate-pulse">
+            <h3 class="text-sm font-bold text-primary uppercase tracking-wider flex items-center gap-2">
+              <svg class="animate-spin h-4 w-4 text-primary" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+              </svg>
+              Tâche en arrière-plan active
+            </h3>
+            
+            <div class="space-y-2">
+              <div class="flex justify-between text-xs font-medium text-on-surface-variant">
+                <span>{taskInProgress.type === 'distribute' ? 'Distribution aléatoire' : 'Retrait des rôles'}</span>
+                <span>{taskInProgress.processed} / {taskInProgress.total}</span>
+              </div>
+              <div class="w-full bg-surface-container-high rounded-full h-2">
+                <div class="bg-primary h-2 rounded-full transition-all duration-300" style="width: {taskInProgress.total > 0 ? (taskInProgress.processed / taskInProgress.total) * 100 : 0}%"></div>
+              </div>
+            </div>
+          </section>
+        {/if}
+      </div>
+
+      <!-- Right side: Clans List & Leaderboard -->
+      <div class="xl:col-span-2 space-y-6">
+        <section class="bg-surface-container-low/40 border border-outline-variant/30 p-6 rounded-xl space-y-6">
+          <div class="flex items-center justify-between border-b border-outline-variant/15 pb-3">
+            <h3 class="text-lg font-semibold">🛡️ Clans Configurés</h3>
+            <div class="flex gap-2">
+              {#if canManageSettings}
+                <button
+                  onclick={() => openConfirmation('clear')}
+                  class="flex items-center gap-1.5 px-3 py-1.5 border border-rose-500/30 hover:bg-rose-500/10 text-rose-500 font-bold text-xs rounded-lg transition-colors cursor-pointer"
+                  title="Retirer tous les rôles de clan du serveur"
+                >
+                  <Papicon icon="Trash" size={12} /> Retirer à tous
+                </button>
+                <button
+                  onclick={handleDistribute}
+                  class="flex items-center gap-1.5 px-3 py-1.5 bg-secondary/15 hover:bg-secondary/25 text-secondary font-bold text-xs rounded-lg transition-colors cursor-pointer"
+                  title="Distribuer aléatoirement les membres sans clan"
+                >
+                  <Papicon icon="Users" size={12} /> Distribuer
+                </button>
+                <button
+                  onclick={openCreateModal}
+                  class="flex items-center gap-1.5 px-3 py-1.5 bg-primary text-on-primary font-bold text-xs rounded-lg hover:opacity-90 transition-opacity cursor-pointer"
+                >
+                  <Papicon icon="Add" size={12} /> Nouveau clan
+                </button>
+              {/if}
+            </div>
+          </div>
+
+          {#if clans.length === 0}
+            <div class="flex flex-col items-center justify-center py-12 text-center">
+              <p class="text-sm text-on-surface-variant/60 font-medium">Aucun clan n'a été créé.</p>
+              <p class="text-xs text-on-surface-variant/40">Cliquez sur « Nouveau clan » pour commencer la configuration.</p>
+            </div>
+          {:else}
+            <!-- Clans table -->
+            <div class="overflow-x-auto">
+              <table class="w-full text-left border-collapse">
+                <thead>
+                  <tr class="border-b border-outline-variant/10 text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-wider">
+                    <th class="pb-3">Clan</th>
+                    <th class="pb-3">Rôle Discord</th>
+                    <th class="pb-3 text-center">Membres</th>
+                    <th class="pb-3 text-right">XP Cumulée</th>
+                    {#if canManageSettings}
+                      <th class="pb-3 text-right">Actions</th>
+                    {/if}
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-outline-variant/10">
+                  {#each clans as clan}
+                    <tr class="hover:bg-surface-container-low/20 transition-colors">
+                      <td class="py-4">
+                        <span class="font-bold text-sm text-on-surface">{clan.name}</span>
+                        {#if clan.description}
+                          <p class="text-xs text-on-surface-variant/70 max-w-[200px] truncate">{clan.description}</p>
+                        {/if}
+                      </td>
+                      <td class="py-4">
+                        <span class="px-2 py-1 bg-surface-container-high rounded text-xs text-on-surface-variant">
+                          {availableRoles.find(r => r.id === clan.roleId)?.name || `ID: ${clan.roleId}`}
+                        </span>
+                      </td>
+                      <td class="py-4 text-center font-medium text-xs text-on-surface">
+                        {clan.memberCount}
+                      </td>
+                      <td class="py-4 text-right font-bold text-xs text-amber-500">
+                        {clan.totalXp.toLocaleString('fr-FR')} XP
+                      </td>
+                      {#if canManageSettings}
+                        <td class="py-4 text-right space-x-2">
+                          <button
+                            onclick={() => openEditModal(clan)}
+                            class="p-1.5 hover:bg-surface-container-high rounded-lg text-on-surface-variant transition-colors cursor-pointer inline-flex"
+                            title="Modifier"
+                          >
+                            <Papicon icon="Edit" size={14} />
+                          </button>
+                          <button
+                            onclick={() => handleDeleteClan(clan)}
+                            class="p-1.5 hover:bg-rose-500/10 text-rose-500 rounded-lg transition-colors cursor-pointer inline-flex"
+                            title="Supprimer"
+                          >
+                            <Papicon icon="Trash" size={14} />
+                          </button>
+                        </td>
+                      {/if}
+                    </tr>
+                  {/each}
+                </tbody>
+              </table>
+            </div>
+          {/if}
+        </section>
+      </div>
+
+    </div>
+  {/if}
+</ModulePage>
+
+<!-- Modal: Créer / Éditer un Clan -->
+{#if showModal}
+  <div class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4" transition:fade={{ duration: 150 }}>
+    <div class="bg-surface-container-low/95 border border-outline-variant/20 max-w-lg w-full rounded-xl p-6 space-y-6 shadow-lg relative" transition:scale={{ start: 0.97, duration: 150 }}>
+      
+      <button
+        onclick={() => showModal = false}
+        class="absolute top-6 right-6 p-2 rounded-full bg-surface-container-high/40 hover:bg-rose-500/15 hover:text-rose-500 text-on-surface-variant transition-colors cursor-pointer"
+      >
+        <Papicon icon="Cross" size={18} />
+      </button>
+
+      <div>
+        <h3 class="text-xl font-semibold">{editingClan ? 'Modifier le clan' : 'Créer un clan'}</h3>
+        <p class="text-xs text-on-surface-variant/80">Liez un rôle Discord et configurez les détails de votre clan.</p>
+      </div>
+
+      <form onsubmit={(e) => { e.preventDefault(); handleSaveClan(); }} class="space-y-4">
+        <div class="space-y-1.5">
+          <label for="clan-name" class="text-[10px] font-bold text-on-surface-variant/60 ml-1 uppercase tracking-widest">Nom du Clan</label>
+          <input
+            id="clan-name"
+            type="text"
+            bind:value={formName}
+            placeholder="Ex: Griffondor, Guerriers, etc."
+            class="w-full bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-primary/30 transition-all text-on-surface focus:outline-none"
+            required
+            disabled={!canManageSettings}
+          />
+        </div>
+
+        <div class="space-y-1.5">
+          <label for="clan-desc" class="text-[10px] font-bold text-on-surface-variant/60 ml-1 uppercase tracking-widest">Description</label>
+          <textarea
+            id="clan-desc"
+            bind:value={formDescription}
+            placeholder="Description du clan, son histoire ou sa devise..."
+            class="w-full bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-primary/30 transition-all text-on-surface focus:outline-none h-20"
+            disabled={!canManageSettings}
+          ></textarea>
+        </div>
+
+        <div class="space-y-1.5">
+          <label for="clan-role" class="text-[10px] font-bold text-on-surface-variant/60 ml-1 uppercase tracking-widest">Rôle Discord Associé</label>
+          <SearchableSelect
+            id="clan-role"
+            bind:value={formRoleId}
+            options={availableRoles.map(r => ({ id: r.id, name: r.name }))}
+            placeholder="Choisir le rôle Discord"
+            disabled={!canManageSettings}
+          />
+        </div>
+
+        <div class="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onclick={() => showModal = false}
+            class="px-4 py-2 border border-outline-variant/30 hover:bg-surface-container-high/60 text-on-surface text-xs font-semibold rounded-lg transition-colors cursor-pointer"
+          >
+            Annuler
+          </button>
+          <button
+            type="submit"
+            class="px-4 py-2 bg-primary text-on-primary text-xs font-semibold rounded-lg hover:opacity-90 transition-opacity cursor-pointer"
+          >
+            Enregistrer
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+{/if}
+
+<!-- Modal: Confirmation de Double Validation (Reset / Clear) -->
+{#if showConfirmModal}
+  <div class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4" transition:fade={{ duration: 150 }}>
+    <div class="bg-surface-container-low border border-outline-variant/20 max-w-md w-full rounded-xl p-6 space-y-6 shadow-lg relative" transition:scale={{ start: 0.97, duration: 150 }}>
+      
+      <button
+        onclick={() => showConfirmModal = false}
+        class="absolute top-6 right-6 p-2 rounded-full bg-surface-container-high/40 hover:bg-rose-500/15 hover:text-rose-500 text-on-surface-variant transition-colors cursor-pointer"
+      >
+        <Papicon icon="Cross" size={18} />
+      </button>
+
+      <div>
+        <h3 class="text-lg font-semibold text-rose-500 flex items-center gap-2">
+          <Papicon icon="AlertTriangle" size={20} />
+          Validation requise
+        </h3>
+        <p class="text-xs text-on-surface-variant/80 mt-1">
+          {#if confirmActionType === 'clear'}
+            Vous vous apprêtez à <strong>retirer tous les rôles de clan</strong> de tous les membres du serveur. Cette action s'exécute progressivement en arrière-plan.
+          {:else}
+            {#if confirmActionType === 'reset'}
+              Vous vous apprêtez à <strong>clore la saison active</strong> de clans et à passer à la suivante. Les scores d'XP des clans repartiront à 0.
+            {:else if confirmActionType === 'distribute'}
+              Vous vous apprêtez à <strong>distribuer aléatoirement un clan</strong> à tous les membres sans clan. Cette action s'exécute progressivement en arrière-plan.
+            {/if}
+          {/if}
+        </p>
+      </div>
+
+      <div class="space-y-4">
+        <div class="space-y-1.5">
+          <label for="confirm-word" class="text-[10px] font-bold text-on-surface-variant/60 ml-1 uppercase tracking-widest">
+            Saisissez <strong>{confirmActionType === 'clear' ? 'RETIRER' : confirmActionType === 'reset' ? 'RESET' : 'DISTRIBUER'}</strong> pour confirmer
+          </label>
+          <input
+            id="confirm-word"
+            type="text"
+            bind:value={confirmInput}
+            placeholder={confirmActionType === 'clear' ? 'RETIRER' : confirmActionType === 'reset' ? 'RESET' : 'DISTRIBUER'}
+            class="w-full bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-primary/30 transition-all text-on-surface focus:outline-none font-bold uppercase tracking-wider"
+          />
+        </div>
+
+        <div class="flex justify-end gap-2">
+          <button
+            type="button"
+            onclick={() => showConfirmModal = false}
+            class="px-4 py-2 border border-outline-variant/30 hover:bg-surface-container-high/60 text-on-surface text-xs font-semibold rounded-lg transition-colors cursor-pointer"
+          >
+            Annuler
+          </button>
+          <button
+            type="button"
+            onclick={handleConfirmAction}
+            class="px-4 py-2 bg-rose-500 text-white text-xs font-semibold rounded-lg hover:bg-rose-600 transition-colors cursor-pointer"
+          >
+            Confirmer
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/apps/dashboard/src/pages/Leveling.svelte
+++ b/apps/dashboard/src/pages/Leveling.svelte
@@ -17,7 +17,9 @@
     updateLevelingConfig, 
     addLevelingReward, 
     deleteLevelingReward,
-    importLevelingData
+    importLevelingData,
+    fetchClansData,
+    updateClanSettings
   } from '../lib/api';
 
   const saveAction = createAsyncActionState();
@@ -76,8 +78,22 @@
     xpMultipliers: {} as Record<string, number>
   })));
 
+  // Clan states for boost configuration
+  let clansEnabled = $state(false);
+  let clanRewardXpBoost = $state(false);
+  let clanRewardXpBoostRate = $state(1.2);
+  let lastWinningClanId = $state<string | null>(null);
+  let clans = $state<any[]>([]);
+
+  // Saved versions for dirty checking
+  let savedClanRewardXpBoost = $state(false);
+  let savedClanRewardXpBoostRate = $state(1.2);
+
   $effect(() => {
-    const dirty = JSON.stringify(config) !== JSON.stringify(savedConfig);
+    const dirty = JSON.stringify(config) !== JSON.stringify(savedConfig)
+      || clanRewardXpBoost !== savedClanRewardXpBoost
+      || clanRewardXpBoostRate !== savedClanRewardXpBoostRate;
+
     if (dirty && canManageSettings) {
       untrack(() => {
         unsavedChanges.register({
@@ -85,6 +101,8 @@
           onSave: () => handleSaveConfig(),
           onReset: () => {
             config = JSON.parse(JSON.stringify(savedConfig));
+            clanRewardXpBoost = savedClanRewardXpBoost;
+            clanRewardXpBoostRate = savedClanRewardXpBoostRate;
           }
         });
       });
@@ -154,6 +172,19 @@
         rewards = res.rewards || [];
         levels = res.levels || [];
       }
+
+      // Récupérer les paramètres de clan pour le boost d'XP de saison
+      const clansRes = await fetchClansData().catch(() => null);
+      if (clansRes) {
+        clansEnabled = clansRes.clansEnabled;
+        clanRewardXpBoost = clansRes.clanRewardXpBoost;
+        clanRewardXpBoostRate = clansRes.clanRewardXpBoostRate;
+        lastWinningClanId = clansRes.lastWinningClanId;
+        clans = clansRes.clans;
+
+        savedClanRewardXpBoost = clansRes.clanRewardXpBoost;
+        savedClanRewardXpBoostRate = clansRes.clanRewardXpBoostRate;
+      }
     } catch (err) {
       console.error(err);
     } finally {
@@ -165,10 +196,25 @@
     if (!canManageSettings) return false;
     let success = false;
     await saveAction.run(async () => {
+      // 1. Enregistrer la configuration du leveling
       const res = await updateLevelingConfig(config);
       if (!res) throw new Error('Erreur de sauvegarde');
       config = res.config;
       savedConfig = JSON.parse(JSON.stringify(res.config));
+
+      // 2. Enregistrer la configuration du boost d'XP de clan si modifiée
+      if (clanRewardXpBoost !== savedClanRewardXpBoost || clanRewardXpBoostRate !== savedClanRewardXpBoostRate) {
+        const clanRes = await updateClanSettings({
+          clanRewardXpBoost,
+          clanRewardXpBoostRate,
+        });
+        if (!clanRes) throw new Error('Erreur de sauvegarde des paramètres de clan');
+        clanRewardXpBoost = clanRes.clanRewardXpBoost;
+        clanRewardXpBoostRate = clanRes.clanRewardXpBoostRate;
+        savedClanRewardXpBoost = clanRes.clanRewardXpBoost;
+        savedClanRewardXpBoostRate = clanRes.clanRewardXpBoostRate;
+      }
+
       success = true;
       return true;
     }, { successMessage: 'Configuration XP enregistrée.' });
@@ -666,6 +712,72 @@
           </div>
 
           <!-- Save button removed since global bottom bar handles saving -->
+        </section>
+
+        <!-- Boost de Saison de Clan -->
+        <section class="bg-surface-container-low/30 border border-outline-variant/10 p-8 rounded-xl space-y-6">
+          <h3 class="text-xl font-semibold flex items-center gap-3">
+            <Papicon icon="Award" size={20} class="text-amber-500" />
+            Boost de Saison de Clan
+          </h3>
+
+          {#if !clansEnabled}
+            <div class="p-6 bg-surface-container-high/20 rounded-xl border border-outline-variant/10 flex flex-col items-center justify-center text-center space-y-3">
+              <span class="text-3xl">🔒</span>
+              <div>
+                <h4 class="text-sm font-semibold text-on-surface">Les clans ne sont pas activés</h4>
+                <p class="text-xs text-on-surface-variant/70 max-w-md mt-1">
+                  Les clans ne sont pas activés sur ce serveur. Activez-les dans l'onglet Clans pour configurer ce boost.
+                </p>
+              </div>
+            </div>
+          {:else}
+            <div class="space-y-4">
+              <div class="flex items-center justify-between">
+                <div>
+                  <span class="text-sm font-medium text-on-surface">Activer le Boost d'XP automatique</span>
+                  <p class="text-xs text-on-surface-variant/70">
+                    Attribue automatiquement un boost d'XP aux membres du clan gagnant de la dernière saison.
+                  </p>
+                </div>
+                <ToggleSwitch bind:checked={clanRewardXpBoost} disabled={!canManageSettings} />
+              </div>
+
+              {#if clanRewardXpBoost}
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-6 pt-4 border-t border-outline-variant/10 animate-in slide-in-from-top-2 duration-200">
+                  <div class="space-y-1.5">
+                    <span class="text-[10px] font-bold text-on-surface-variant/60 ml-2 uppercase tracking-widest">Rôle Discord Cible (Automatique)</span>
+                    <div class="px-4 py-3 bg-primary/10 rounded-lg text-sm text-primary font-semibold border border-primary/20 flex items-center gap-2">
+                      <span>👑</span>
+                      {#if lastWinningClanId}
+                        {@const winningClan = clans.find(c => c.id === lastWinningClanId)}
+                        {@const targetRole = availableRoles.find(r => r.id === winningClan?.roleId)}
+                        <span>
+                          {winningClan ? `${winningClan.name} (@${targetRole?.name || 'Rôle Inconnu'})` : 'Clan Gagnant'}
+                        </span>
+                      {:else}
+                        <span class="italic text-primary/70">En attente de la fin de la première saison</span>
+                      {/if}
+                    </div>
+                  </div>
+
+                  <div class="space-y-1.5">
+                    <label for="clanXpBoostRate" class="text-[10px] font-bold text-on-surface-variant/60 ml-2 uppercase tracking-widest">Multiplicateur d'XP (ex: 1.2 = +20%)</label>
+                    <input 
+                      id="clanXpBoostRate"
+                      type="number" 
+                      step="0.05"
+                      min="1.0"
+                      max="10"
+                      bind:value={clanRewardXpBoostRate} 
+                      class="w-full bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-4 py-3 text-sm focus:ring-2 focus:ring-primary/30 transition-all text-on-surface focus:outline-none font-bold"
+                      disabled={!canManageSettings}
+                    />
+                  </div>
+                </div>
+              {/if}
+            </div>
+          {/if}
         </section>
       </div>
 

--- a/apps/dashboard/src/pages/LevelingClanPublic.svelte
+++ b/apps/dashboard/src/pages/LevelingClanPublic.svelte
@@ -1,0 +1,295 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import Papicon from '../lib/components/Papicon.svelte';
+  import Skeleton from '../lib/components/Skeleton.svelte';
+  import { fetchPublicClans } from '../lib/api';
+
+  interface Props {
+    serverId: string;
+  }
+  const { serverId }: Props = $props();
+
+  let loading = $state(true);
+  let errorMsg = $state<string | null>(null);
+  let guildName = $state('Kotbo Server');
+  let guildIcon = $state<string | null>(null);
+  let enabled = $state(false);
+  let currentClanSeason = $state(1);
+  
+  interface Participant {
+    userId: string;
+    xp: number;
+    displayName: string;
+    avatarUrl: string | null;
+  }
+
+  interface ClanData {
+    id: string;
+    name: string;
+    description: string | null;
+    roleId: string;
+    roleColor: string | null;
+    totalXp: number;
+    memberCount: number;
+    topParticipants: Participant[];
+  }
+
+  let clans = $state<ClanData[]>([]);
+  let searchQuery = $state('');
+
+  onMount(async () => {
+    try {
+      const res = await fetchPublicClans(serverId);
+      if (res) {
+        enabled = res.enabled ?? false;
+        guildName = res.guildName ?? 'Kotbo Server';
+        guildIcon = res.guildIcon ?? null;
+        currentClanSeason = res.currentClanSeason ?? 1;
+        clans = res.clans || [];
+      }
+    } catch (err: any) {
+      console.error(err);
+      errorMsg = err.message || 'Erreur lors du chargement des données des clans.';
+    } finally {
+      loading = false;
+    }
+  });
+
+  // Filter participants in each clan based on search query
+  function getFilteredParticipants(clan: ClanData): Participant[] {
+    if (!searchQuery) return clan.topParticipants;
+    const q = searchQuery.toLowerCase().normalize('NFD').replace(/\p{Diacritic}/gu, '');
+    return clan.topParticipants.filter(p => {
+      const name = p.displayName.toLowerCase().normalize('NFD').replace(/\p{Diacritic}/gu, '');
+      return name.includes(q) || p.userId.includes(searchQuery);
+    });
+  }
+
+  function formatXp(xp: number): string {
+    if (xp >= 1_000_000) return `${(xp / 1_000_000).toFixed(1)}M`;
+    if (xp >= 1_000) return `${(xp / 1_000).toFixed(1)}k`;
+    return xp.toLocaleString();
+  }
+
+  function getRankBadgeColor(rank: number) {
+    if (rank === 1) return 'bg-amber-500/10 text-amber-500 border border-amber-500/20';
+    if (rank === 2) return 'bg-slate-400/10 text-slate-400 border border-slate-400/20';
+    if (rank === 3) return 'bg-amber-700/10 text-amber-700 border border-amber-700/20';
+    return 'bg-slate-100 dark:bg-slate-800 text-slate-500';
+  }
+</script>
+
+<svelte:head>
+  <title>Classement des Clans — {guildName}</title>
+  <meta name="description" content="Classement compétitif et scores des clans de {guildName} sur Discord." />
+</svelte:head>
+
+<div class="min-h-screen whiteboard-container relative overflow-x-hidden selection:bg-yellow-100 dark:selection:bg-slate-850 py-12 px-4 sm:px-6 z-10">
+  
+  <div class="relative z-10 w-full max-w-6xl mx-auto space-y-10 animate-in fade-in duration-300">
+
+    <!-- ─── En-tête style Feuille Index épuré ─── -->
+    <header class="relative flex flex-col sm:flex-row sm:items-center justify-between gap-4 bg-white dark:bg-[#111a2e] border border-slate-200 dark:border-slate-800 p-5 rounded-lg shadow-sm overflow-hidden group">
+      <div class="tape-accent"></div>
+
+      <div class="flex items-center gap-4">
+        {#if guildIcon}
+          <div class="relative shrink-0">
+            <img src={guildIcon} alt="{guildName} Logo" class="w-11 h-11 rounded-lg object-cover border border-slate-200 dark:border-slate-800" />
+          </div>
+        {:else}
+          <div class="relative w-11 h-11 bg-slate-50 dark:bg-[#0c1322] border border-slate-200 dark:border-slate-800 rounded-lg flex items-center justify-center font-bold text-sm text-slate-800 dark:text-slate-100 shrink-0">
+            <span>{guildName.slice(0, 2).toUpperCase()}</span>
+          </div>
+        {/if}
+
+        <div class="relative">
+          <h1 class="text-lg font-extrabold tracking-tight text-slate-800 dark:text-slate-100">
+            {guildName}
+          </h1>
+          <div class="flex items-center gap-1.5 text-slate-500 dark:text-slate-400 font-semibold text-xs uppercase tracking-wider">
+            <span class="text-amber-500"><Papicon icon="Shield" size={14} /></span>
+            <span>Guerre des Clans — Saison {currentClanSeason}</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Badge "Live" -->
+      <div class="flex items-center gap-2 self-start sm:self-auto px-3 py-1.5 rounded-full border border-emerald-500/20 dark:border-emerald-500/10 bg-emerald-500/5 text-emerald-600 dark:text-emerald-400 text-xs font-bold">
+        <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-ping"></span>
+        <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 absolute"></span>
+        <span class="ml-2.5 uppercase tracking-wider text-[10px]">Temps Réel</span>
+      </div>
+    </header>
+
+    {#if loading}
+      <!-- Loading Skeletons -->
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+        <Skeleton height="500px" radius="1.25rem" />
+        <Skeleton height="500px" radius="1.25rem" />
+      </div>
+    {:else if errorMsg}
+      <!-- Error Message -->
+      <div class="bg-white dark:bg-[#111a2e] border border-red-200 dark:border-red-950 p-12 rounded-lg text-center space-y-4 shadow-sm">
+        <div class="w-12 h-12 bg-red-50 dark:bg-red-950/35 rounded-full flex items-center justify-center text-red-500 dark:text-red-400 mx-auto">
+          <Papicon icon="AlertTriangle" size={20} />
+        </div>
+        <div class="space-y-1.5">
+          <p class="text-slate-800 dark:text-slate-100 font-extrabold text-lg">Une erreur est survenue</p>
+          <p class="text-slate-505 dark:text-slate-400 text-sm max-w-md mx-auto">{errorMsg}</p>
+        </div>
+      </div>
+    {:else if !enabled || clans.length === 0}
+      <!-- Module disabled -->
+      <div class="bg-white dark:bg-[#111a2e] border border-slate-200 dark:border-slate-800 p-16 rounded-lg text-center flex flex-col items-center space-y-4 shadow-sm">
+        <div class="w-14 h-14 rounded-full bg-slate-50 dark:bg-[#0c1322] flex items-center justify-center text-slate-400">
+          <Papicon icon="Lock" size={24} />
+        </div>
+        <div class="space-y-1.5 max-w-sm">
+          <h2 class="text-xl font-bold text-slate-800 dark:text-slate-100">Classement Inactif</h2>
+          <p class="text-slate-500 dark:text-slate-400 text-sm leading-relaxed">
+            Le module de Clans n'est pas activé sur ce serveur ou aucun clan n'a été configuré par l'administration.
+          </p>
+        </div>
+      </div>
+    {:else}
+      <!-- ─── Search Bar ─── -->
+      <div class="relative max-w-md mx-auto group">
+        <span class="absolute inset-y-0 left-4 flex items-center text-slate-400 group-focus-within:text-slate-500 transition-colors">
+          <Papicon icon="Search" size={16} />
+        </span>
+        <input
+          type="text"
+          bind:value={searchQuery}
+          placeholder="Rechercher un participant par pseudo..."
+          class="w-full pl-11 pr-4 py-3 bg-white dark:bg-[#111a2e] border border-slate-200 dark:border-slate-800 rounded-lg text-sm text-slate-800 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-500/20 focus:border-amber-500/50 shadow-sm transition-all"
+        />
+      </div>
+
+      <!-- ─── Side-by-side Clans Column Grid ─── -->
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 items-start relative z-10">
+        
+        {#each clans as clan}
+          {@const pList = getFilteredParticipants(clan)}
+          
+          <div
+            class="clean-card bg-white dark:bg-[#111a2e] border-t-4 border-slate-200 dark:border-slate-800 rounded-2xl shadow-sm transition-transform hover:-translate-y-0.5 duration-300 overflow-hidden"
+            style="border-top-color: {clan.roleColor || '#e2e8f0'};"
+          >
+            <!-- Clan Header -->
+            <div class="p-6 border-b border-slate-100 dark:border-slate-800 space-y-4">
+              <div class="flex items-center justify-between">
+                <h2 class="text-xl font-extrabold text-slate-800 dark:text-slate-100 flex items-center gap-2">
+                  <span class="inline-block w-3.5 h-3.5 rounded-full" style="background-color: {clan.roleColor || '#e2e8f0'};"></span>
+                  {clan.name}
+                </h2>
+                
+                <span class="px-3 py-1 bg-slate-50 dark:bg-[#0c1322] border border-slate-200/50 dark:border-slate-800 rounded-full text-[10px] font-bold text-slate-500 uppercase tracking-wider">
+                  {clan.memberCount} membres
+                </span>
+              </div>
+
+              {#if clan.description}
+                <p class="text-xs text-slate-500 dark:text-slate-400 leading-relaxed italic">
+                  « {clan.description} »
+                </p>
+              {/if}
+
+              <!-- Score Card -->
+              <div class="flex items-center justify-between p-3.5 rounded-xl bg-slate-50/50 dark:bg-[#0c1322]/50 border border-slate-200/10">
+                <span class="text-[10px] font-bold text-slate-400 uppercase tracking-widest">XP de Saison</span>
+                <span class="text-lg font-black text-amber-500 tracking-tight">
+                  {clan.totalXp.toLocaleString('fr-FR')} XP
+                </span>
+              </div>
+            </div>
+
+            <!-- Participants list -->
+            <div class="p-4">
+              {#if pList.length === 0}
+                <div class="py-12 text-center text-xs text-slate-400 dark:text-slate-500 italic">
+                  Aucun membre trouvé ou aucun point marqué.
+                </div>
+              {:else}
+                <div class="space-y-1.5">
+                  {#each pList as p, index}
+                    <div class="flex items-center justify-between p-2.5 hover:bg-slate-50/50 dark:hover:bg-slate-800/20 rounded-xl transition-all duration-200 group/item">
+                      <div class="flex items-center gap-3 min-w-0">
+                        
+                        <!-- Rank Badge -->
+                        <span class="w-6 h-6 rounded-md flex items-center justify-center text-xs font-black shrink-0 {getRankBadgeColor(index + 1)}">
+                          {index + 1}
+                        </span>
+
+                        <!-- User avatar -->
+                        {#if p.avatarUrl}
+                          <img src={p.avatarUrl} alt={p.displayName} class="w-8 h-8 rounded-full border border-slate-200/50 dark:border-slate-800" />
+                        {:else}
+                          <div class="w-8 h-8 rounded-full bg-slate-100 dark:bg-slate-800 flex items-center justify-center text-xs font-bold text-slate-500 uppercase shrink-0">
+                            {p.displayName.slice(0, 2)}
+                          </div>
+                        {/if}
+
+                        <span class="text-sm font-bold text-slate-700 dark:text-slate-350 truncate max-w-[160px] sm:max-w-xs group-hover/item:text-slate-900 dark:group-hover/item:text-slate-100 transition-colors">
+                          {p.displayName}
+                        </span>
+                      </div>
+
+                      <span class="text-xs font-extrabold text-amber-500 tracking-tight shrink-0 pl-2">
+                        {p.xp.toLocaleString('fr-FR')} XP
+                      </span>
+                    </div>
+                  {/each}
+                </div>
+              {/if}
+            </div>
+
+          </div>
+        {/each}
+
+      </div>
+    {/if}
+
+  </div>
+</div>
+
+<style>
+  /* Accents de style Feuille Index */
+  .whiteboard-container {
+    background-color: #f8fafc;
+    background-image: 
+      radial-gradient(#cbd5e1 0.75px, transparent 0.75px), 
+      radial-gradient(#cbd5e1 0.75px, #f8fafc 0.75px);
+    background-size: 30px 30px;
+    background-position: 0 0, 15px 15px;
+  }
+  
+  :global(.dark) .whiteboard-container {
+    background-color: #070d19;
+    background-image: 
+      radial-gradient(#1e293b 0.75px, transparent 0.75px), 
+      radial-gradient(#1e293b 0.75px, #070d19 0.75px);
+    background-size: 30px 30px;
+    background-position: 0 0, 15px 15px;
+  }
+
+  .tape-accent {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 4px;
+    background: linear-gradient(90deg, #f59e0b 0%, #10b981 50%, #3b82f6 100%);
+    opacity: 0.85;
+  }
+
+  .clean-card {
+    background-color: #ffffff;
+    border: 1px solid #e2e8f0;
+  }
+  
+  :global(.dark) .clean-card {
+    background-color: #0e1626;
+    border: 1px solid #1e293b;
+  }
+</style>

--- a/packages/database/prisma/clans.prisma
+++ b/packages/database/prisma/clans.prisma
@@ -1,0 +1,36 @@
+// ============================================================================
+// CLANS & CONTRIBUTIONS SCHEMA
+// ============================================================================
+
+model Clan {
+  id          String   @id @default(cuid())
+  guildId     String
+  name        String
+  description String?
+  roleId      String   @unique // ID du rôle Discord unique associé
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  guild Guild @relation(fields: [guildId], references: [id], onDelete: Cascade)
+  contributions ClanMemberContribution[]
+
+  @@unique([guildId, name])
+  @@map("clans")
+}
+
+model ClanMemberContribution {
+  id        String   @id @default(cuid())
+  guildId   String
+  clanId    String
+  userId    String
+  xp        Int      @default(0) // Points accumulés dans ce clan pour cette saison
+  season    Int      @default(1) // Numéro de la saison
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  guild Guild @relation(fields: [guildId], references: [id], onDelete: Cascade)
+  clan  Clan  @relation(fields: [clanId], references: [id], onDelete: Cascade)
+
+  @@unique([guildId, clanId, userId, season])
+  @@map("clan_member_contributions")
+}

--- a/packages/database/prisma/clans.prisma
+++ b/packages/database/prisma/clans.prisma
@@ -11,6 +11,9 @@ model Clan {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
+  generalChannelId String?
+  leaderRoleId     String?
+
   guild Guild @relation(fields: [guildId], references: [id], onDelete: Cascade)
   contributions ClanMemberContribution[]
 

--- a/packages/database/prisma/guild.prisma
+++ b/packages/database/prisma/guild.prisma
@@ -111,6 +111,9 @@ model Guild {
   clansEnabled      Boolean @default(false)
   clansUnique       Boolean @default(true)
   currentClanSeason Int     @default(1)
+  clanXpFromActivity Boolean @default(true)
+  clanXpFromLevelUp  Boolean @default(false)
+  clanXpPerLevelUp   Int     @default(50)
 
   clans                 Clan[]
   clanMemberContributions ClanMemberContribution[]

--- a/packages/database/prisma/guild.prisma
+++ b/packages/database/prisma/guild.prisma
@@ -111,8 +111,16 @@ model Guild {
   clansEnabled      Boolean @default(false)
   clansUnique       Boolean @default(true)
   currentClanSeason Int     @default(1)
+  clanSeasonStartsAt DateTime?
+  clanSeasonEndsAt   DateTime?
   clanXpFromLevelUp  Boolean @default(false)
   clanXpPerLevelUp   Int     @default(50)
+  lastWinningClanId  String?
+  clanAnnouncementChannelId String?
+  clanRewardGiveaway Boolean @default(false)
+  clanRewardXpBoost  Boolean @default(false)
+  clanRewardXpBoostRate Float @default(1.2)
+  clanRewardLeaderRole Boolean @default(false)
 
   clans                 Clan[]
   clanMemberContributions ClanMemberContribution[]

--- a/packages/database/prisma/guild.prisma
+++ b/packages/database/prisma/guild.prisma
@@ -111,7 +111,6 @@ model Guild {
   clansEnabled      Boolean @default(false)
   clansUnique       Boolean @default(true)
   currentClanSeason Int     @default(1)
-  clanXpFromActivity Boolean @default(true)
   clanXpFromLevelUp  Boolean @default(false)
   clanXpPerLevelUp   Int     @default(50)
 

--- a/packages/database/prisma/guild.prisma
+++ b/packages/database/prisma/guild.prisma
@@ -108,6 +108,12 @@ model Guild {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  clansEnabled      Boolean @default(false)
+  clansUnique       Boolean @default(true)
+  currentClanSeason Int     @default(1)
+
+  clans                 Clan[]
+  clanMemberContributions ClanMemberContribution[]
   memberLevels MemberLevel[]
   levelRoleRewards LevelRoleReward[]
   levelConfig LevelConfig?

--- a/packages/database/prisma/migrations/20260713164100_add_clan_system/migration.sql
+++ b/packages/database/prisma/migrations/20260713164100_add_clan_system/migration.sql
@@ -1,0 +1,49 @@
+-- AlterTable
+ALTER TABLE "guilds" ADD COLUMN     "clansEnabled" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "clansUnique" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "currentClanSeason" INTEGER NOT NULL DEFAULT 1;
+
+-- CreateTable
+CREATE TABLE "clans" (
+    "id" TEXT NOT NULL,
+    "guildId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "roleId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "clans_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "clan_member_contributions" (
+    "id" TEXT NOT NULL,
+    "guildId" TEXT NOT NULL,
+    "clanId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "xp" INTEGER NOT NULL DEFAULT 0,
+    "season" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "clan_member_contributions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "clans_roleId_key" ON "clans"("roleId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "clans_guildId_name_key" ON "clans"("guildId", "name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "clan_member_contributions_guildId_clanId_userId_season_key" ON "clan_member_contributions"("guildId", "clanId", "userId", "season");
+
+-- AddForeignKey
+ALTER TABLE "clans" ADD CONSTRAINT "clans_guildId_fkey" FOREIGN KEY ("guildId") REFERENCES "guilds"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "clan_member_contributions" ADD CONSTRAINT "clan_member_contributions_guildId_fkey" FOREIGN KEY ("guildId") REFERENCES "guilds"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "clan_member_contributions" ADD CONSTRAINT "clan_member_contributions_clanId_fkey" FOREIGN KEY ("clanId") REFERENCES "clans"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/migrations/20260713165900_add_clan_xp_settings/migration.sql
+++ b/packages/database/prisma/migrations/20260713165900_add_clan_xp_settings/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "guilds" ADD COLUMN     "clanXpFromActivity" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "clanXpFromLevelUp" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "clanXpPerLevelUp" INTEGER NOT NULL DEFAULT 50;

--- a/packages/database/prisma/migrations/20260713165900_add_clan_xp_settings/migration.sql
+++ b/packages/database/prisma/migrations/20260713165900_add_clan_xp_settings/migration.sql
@@ -1,4 +1,3 @@
 -- AlterTable
-ALTER TABLE "guilds" ADD COLUMN     "clanXpFromActivity" BOOLEAN NOT NULL DEFAULT true,
-ADD COLUMN     "clanXpFromLevelUp" BOOLEAN NOT NULL DEFAULT false,
+ALTER TABLE "guilds" ADD COLUMN     "clanXpFromLevelUp" BOOLEAN NOT NULL DEFAULT false,
 ADD COLUMN     "clanXpPerLevelUp" INTEGER NOT NULL DEFAULT 50;

--- a/packages/database/prisma/migrations/20260716160900_add_clan_hq_leader/migration.sql
+++ b/packages/database/prisma/migrations/20260716160900_add_clan_hq_leader/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "clans" ADD COLUMN     "generalChannelId" TEXT,
+ADD COLUMN     "leaderRoleId" TEXT;

--- a/packages/database/prisma/migrations/20260716161200_add_clan_rewards_settings/migration.sql
+++ b/packages/database/prisma/migrations/20260716161200_add_clan_rewards_settings/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable
+ALTER TABLE "guilds" ADD COLUMN     "clanAnnouncementChannelId" TEXT,
+ADD COLUMN     "clanRewardGiveaway" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "clanRewardLeaderRole" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "clanRewardXpBoost" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "clanRewardXpBoostRate" DOUBLE PRECISION NOT NULL DEFAULT 1.2,
+ADD COLUMN     "lastWinningClanId" TEXT;

--- a/packages/database/prisma/migrations/20260716164000_add_clan_season_dates/migration.sql
+++ b/packages/database/prisma/migrations/20260716164000_add_clan_season_dates/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "guilds" ADD COLUMN     "clanSeasonEndsAt" TIMESTAMP(3),
+ADD COLUMN     "clanSeasonStartsAt" TIMESTAMP(3);

--- a/test_output.txt
+++ b/test_output.txt
@@ -1,0 +1,585 @@
+$ bun run --filter @kotbo/bot test:unit
+@kotbo/bot test:unit: bun test v1.3.12 (700fc117)
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/contracts.features.test.ts:
+@kotbo/bot test:unit: (pass) Contrats des features > Toutes les commandes exposent data + execute et ont un nom unique [7.14ms]
+@kotbo/bot test:unit: (pass) Contrats des features > Handlers, events, panels, services et utils exportent des symboles [5.28ms]
+@kotbo/bot test:unit: (pass) Contrats des features > Le registre des commandes importe toutes les commandes déclarées [3.50ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/unit/clanService.test.ts:
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: # Unhandled error between tests
+@kotbo/bot test:unit: -------------------------------
+@kotbo/bot test:unit:  9 | loadEnv({ path: path.resolve(currentDir, '../../../../.env') });
+@kotbo/bot test:unit: 10 | loadEnv({ path: path.resolve(currentDir, '../../.env') });
+@kotbo/bot test:unit: 11 | 
+@kotbo/bot test:unit: 12 | const connectionString = process.env.DATABASE_URL;
+@kotbo/bot test:unit: 13 | if (!connectionString) {
+@kotbo/bot test:unit: 14 |   throw new Error('DATABASE_URL non défini. Vérifie ton fichier .env.');
+@kotbo/bot test:unit:                  ^
+@kotbo/bot test:unit: error: DATABASE_URL non défini. Vérifie ton fichier .env.
+@kotbo/bot test:unit:       at /home/intercalaire/github/Kotbo/apps/bot/src/utils/db.ts:14:13
+@kotbo/bot test:unit:       at loadAndEvaluateModule (2:1)
+@kotbo/bot test:unit: -------------------------------
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/unit/keywordSessionStore.test.ts:
+@kotbo/bot test:unit: (pass) keywordSessionStore > genere une cle stable [6.71ms]
+@kotbo/bot test:unit: (pass) keywordSessionStore > cree, lit, avance et supprime une session [0.26ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/unit/scheduleService.test.ts:
+@kotbo/bot test:unit: [INFO] [Scheduler] Initialisation du service de planification...
+@kotbo/bot test:unit: [INFO] [Scheduler] 2 tâche(s) planifiée(s) active(s) trouvée(s).
+@kotbo/bot test:unit: [INFO] [Scheduler] Tâche "Task 1" (task-1) planifiée avec le motif : "0 0 * * *"
+@kotbo/bot test:unit: [INFO] [Scheduler] Tâche "Task 2" (task-2) planifiée avec le motif : "0 * * * *"
+@kotbo/bot test:unit: (pass) schedule service > initializeScheduler should fetch active tasks [3.55ms]
+@kotbo/bot test:unit: [INFO] [Scheduler] Début d'exécution de la tâche "Reset General" (CHANNEL_RESET) pour le serveur "Test Guild"
+@kotbo/bot test:unit: [INFO] [Scheduler] Tâche "Reset General" exécutée avec succès
+@kotbo/bot test:unit: (pass) schedule service > executeSchedule resets channel when type is CHANNEL_RESET [0.96ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/unit/codePolice.test.ts:
+@kotbo/bot test:unit: (pass) codePolice analysis > signale une boucle potentiellement infinie [4.56ms]
+@kotbo/bot test:unit: (pass) codePolice analysis > signale une recursion sans cas de sortie visible [0.23ms]
+@kotbo/bot test:unit: (pass) codePolice analysis > bloque un payload potentiellement malveillant [0.37ms]
+@kotbo/bot test:unit: (pass) codePolice analysis > detecte aussi des snippets de code plus declaratifs [0.14ms]
+@kotbo/bot test:unit: (pass) codePolice analysis > reconnait le python pour adapter le feedback [0.20ms]
+@kotbo/bot test:unit: (pass) codePolice analysis > ignore les mentions Discord quand il n'y a pas de vrai signal de code [0.22ms]
+@kotbo/bot test:unit: (pass) codePolice analysis > detecte une boucle for avec condition vide [0.19ms]
+@kotbo/bot test:unit: (pass) codePolice analysis > reconnait plusieurs signaux dans le contenu [0.15ms]
+@kotbo/bot test:unit: (pass) codePolice analysis > retourne generic si aucun langage spécifique n'est détecté [0.05ms]
+@kotbo/bot test:unit: (pass) codePolice analysis > ne formate pas si le contenu est trop court [0.14ms]
+@kotbo/bot test:unit: (pass) codePolice analysis > reconnaît un contenu déjà formaté [0.07ms]
+@kotbo/bot test:unit: (pass) codePolice analysis > reconnaît les backticks inline comme formatage [0.13ms]
+@kotbo/bot test:unit: (pass) codePolice analysis > ne considère pas du texte normal comme déjà formaté [0.06ms]
+@kotbo/bot test:unit: (pass) codePolice analysis > génère un message corrigé pour code JavaScript [0.57ms]
+@kotbo/bot test:unit: (pass) codePolice analysis > génère un message corrigé avec feedback de sécurité [0.14ms]
+@kotbo/bot test:unit: (pass) codePolice analysis > génère un avertissement de sécurité pour code dangereux [0.33ms]
+@kotbo/bot test:unit: (pass) codePolice analysis > tronque les messages trop longs dans le feedback [0.46ms]
+@kotbo/bot test:unit: (pass) codePolice analysis > détecte une réaction (regex invalide) sans crash [0.15ms]
+@kotbo/bot test:unit: (pass) codePolice analysis > détecte du contenu avec signaux spécifiques au langage [0.08ms]
+@kotbo/bot test:unit: (pass) codePolice analysis > hasRawCodeIndicators retourne true avec signaux [0.07ms]
+@kotbo/bot test:unit: (pass) codePolice analysis > hasRawCodeIndicators retourne false sur texte simple court [0.04ms]
+@kotbo/bot test:unit: (pass) codePolice analysis > hasRawCodeIndicators detects danger même avec mentions [0.29ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/unit/embeds.test.ts:
+@kotbo/bot test:unit: (pass) embeds utils > retourne un theme par defaut si categorie inconnue [0.05ms]
+@kotbo/bot test:unit: (pass) embeds utils > construit un embed news coherent [2.24ms]
+@kotbo/bot test:unit: (pass) embeds utils > construit un embed youtube coherent [0.44ms]
+@kotbo/bot test:unit: (pass) embeds utils > helpers utilitaires [0.22ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/unit/sessionStore.test.ts:
+@kotbo/bot test:unit: (pass) dashboard session store > stores encrypted Discord credentials and restores the session [1.44ms]
+@kotbo/bot test:unit: (pass) dashboard session store > deletes a session and rejects it afterwards [0.27ms]
+@kotbo/bot test:unit: (pass) dashboard session store > parses both production and development cookie names [0.15ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/unit/transcriptService.test.ts:
+@kotbo/bot test:unit: (pass) Transcript markdown & entity parser > converts custom emojis properly [0.57ms]
+@kotbo/bot test:unit: (pass) Transcript markdown & entity parser > auto-links HTTP/HTTPS urls [0.12ms]
+@kotbo/bot test:unit: (pass) Transcript markdown & entity parser > leaves urls inside code blocks unlinked [0.20ms]
+@kotbo/bot test:unit: (pass) Transcript markdown & entity parser > parses basic markdown successfully [0.07ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/unit/sanctionReportReminderPolicy.test.ts:
+@kotbo/bot test:unit: (pass) sanction report reminder policy > does nothing before J+3 [0.16ms]
+@kotbo/bot test:unit: (pass) sanction report reminder policy > reminds the moderator at J+3 [0.06ms]
+@kotbo/bot test:unit: (pass) sanction report reminder policy > does not remind again during the next 24 hours [0.04ms]
+@kotbo/bot test:unit: (pass) sanction report reminder policy > reminds again after 24 hours [0.03ms]
+@kotbo/bot test:unit: (pass) sanction report reminder policy > escalates once to managers at J+7 [0.08ms]
+@kotbo/bot test:unit: (pass) sanction report reminder policy > does nothing when a report exists [0.04ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/unit/dashboardApi.test.ts:
+@kotbo/bot test:unit: [WARN] [DashboardAPI] JWT_SECRET variable is not set. Generating one ephemeral fallback secret for this process.
+@kotbo/bot test:unit: (pass) Modular Routers Unit Tests > 1. Public Routes > GET /health returns service status [18.25ms]
+@kotbo/bot test:unit: 479 | 
+@kotbo/bot test:unit: 480 |       const handled = await handlePublicRoutes(req, res, parts, url, mockClient);
+@kotbo/bot test:unit: 481 |       expect(handled).toBeTrue();
+@kotbo/bot test:unit: 482 |       expect(res.statusCode).toBe(200);
+@kotbo/bot test:unit: 483 |       const data = JSON.parse(res.body);
+@kotbo/bot test:unit: 484 |       expect(data.discordClientId).toBe('test-client-id');
+@kotbo/bot test:unit:                                          ^
+@kotbo/bot test:unit: error: expect(received).toBe(expected)
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: Expected: "test-client-id"
+@kotbo/bot test:unit: Received: "client"
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit:       at <anonymous> (/home/intercalaire/github/Kotbo/apps/bot/src/tests/unit/dashboardApi.test.ts:484:36)
+@kotbo/bot test:unit: (fail) Modular Routers Unit Tests > 1. Public Routes > GET /api/config returns client info [1.57ms]
+@kotbo/bot test:unit: (pass) Modular Routers Unit Tests > 1. Public Routes > GET root OAuth discovery refuses templated MCP endpoints [0.77ms]
+@kotbo/bot test:unit: (pass) Modular Routers Unit Tests > 1. Public Routes > GET standard MCP protected resource metadata returns guild-scoped issuer [0.65ms]
+@kotbo/bot test:unit: (pass) Modular Routers Unit Tests > 1. Public Routes > GET standard MCP authorization server metadata returns concrete endpoints [0.73ms]
+@kotbo/bot test:unit: (pass) Modular Routers Unit Tests > 1. Public Routes > GET root protected resource metadata supports resource query parameter [0.88ms]
+@kotbo/bot test:unit: (pass) Modular Routers Unit Tests > 1. Public Routes > GET root authorization server metadata supports resource query parameter [0.50ms]
+@kotbo/bot test:unit: (pass) Modular Routers Unit Tests > 1. Public Routes > GET root authorization server metadata supports signed direct MCP resource URLs [1.11ms]
+@kotbo/bot test:unit: (pass) Modular Routers Unit Tests > 1b. MCP OAuth Routes > rejects encoded guildId template from OAuth discovery [2.07ms]
+@kotbo/bot test:unit: [INFO] [MCPAuth] authorize_get_page {"method":"GET","url":"/api/mcp/112233445566778899/oauth/authorize?client_id=test&redirect_uri=https%3A%2F%2Fclaude.ai%2Fapi%2Fmcp%2Fauth_callback&code_challenge=abc","ua":"","guildId":"112233445566778899","clientId":"test","redirectUri":"https://claude.ai/api/mcp/auth_callback","resource":null}
+@kotbo/bot test:unit: (pass) Modular Routers Unit Tests > 1b. MCP OAuth Routes > OAuth authorize page overrides global CSP so inline CSS can render [1.04ms]
+@kotbo/bot test:unit: [INFO] [MCPAuth] mcp_get_auth_challenge {"method":"GET","url":"/api/mcp/112233445566778899","ua":"","guildId":"112233445566778899"}
+@kotbo/bot test:unit: (pass) Modular Routers Unit Tests > 1b. MCP OAuth Routes > GET MCP endpoint without token starts OAuth discovery instead of returning 405 [0.71ms]
+@kotbo/bot test:unit: [INFO] [MCPAuth] mcp_initialize_compat {"method":"POST","url":"/api/mcp/112233445566778899","ua":"Bun/1.3.12","guildId":"112233445566778899","keyId":null,"protocolVersion":"2025-06-18","clientInfo":{"name":"ChatGPT","version":"test"}}
+@kotbo/bot test:unit: [INFO] [MCPAuth] mcp_jsonrpc_response {"method":"initialize","url":"/api/mcp/112233445566778899","ua":"Bun/1.3.12","guildId":"112233445566778899","keyId":null,"statusCode":200}
+@kotbo/bot test:unit: (pass) Modular Routers Unit Tests > 1b. MCP OAuth Routes > POST initialize without token is allowed for MCP client discovery [28.07ms]
+@kotbo/bot test:unit: [INFO] [MCPAuth] mcp_accept_header_patched {"method":"initialize","url":"/api/mcp/112233445566778899","ua":"python-httpx/0.28.1","guildId":"112233445566778899","keyId":null,"previousAccept":"*/*","accept":"application/json, text/event-stream"}
+@kotbo/bot test:unit: [INFO] [MCPAuth] mcp_content_type_header_patched {"method":"initialize","url":"/api/mcp/112233445566778899","ua":"python-httpx/0.28.1","guildId":"112233445566778899","keyId":null,"previousContentType":"{\"header\":\"text/plain\",\"rawHeader\":\"text/plain\"}","contentType":"application/json"}
+@kotbo/bot test:unit: [INFO] [MCPAuth] mcp_initialize_compat {"method":"POST","url":"/api/mcp/112233445566778899","ua":"python-httpx/0.28.1","guildId":"112233445566778899","keyId":null,"protocolVersion":"2025-06-18","clientInfo":{"name":"Claude","version":"httpx"}}
+@kotbo/bot test:unit: [INFO] [MCPAuth] mcp_jsonrpc_response {"method":"initialize","url":"/api/mcp/112233445566778899","ua":"python-httpx/0.28.1","guildId":"112233445566778899","keyId":null,"statusCode":200}
+@kotbo/bot test:unit: (pass) Modular Routers Unit Tests > 1b. MCP OAuth Routes > POST initialize tolerates Claude httpx loose transport headers [14.13ms]
+@kotbo/bot test:unit: [INFO] [MCPAuth] mcp_content_type_header_patched {"method":"initialize","url":"/api/mcp/112233445566778899","ua":"Bun/1.3.12","guildId":"112233445566778899","keyId":null,"previousContentType":"{\"header\":\"application/json\",\"rawHeader\":\"text/plain\"}","contentType":"application/json"}
+@kotbo/bot test:unit: [INFO] [MCPAuth] mcp_initialize_compat {"method":"POST","url":"/api/mcp/112233445566778899","ua":"Bun/1.3.12","guildId":"112233445566778899","keyId":null,"protocolVersion":"2025-06-18","clientInfo":{"name":"Claude","version":"raw-header-mismatch"}}
+@kotbo/bot test:unit: [INFO] [MCPAuth] mcp_jsonrpc_response {"method":"initialize","url":"/api/mcp/112233445566778899","ua":"Bun/1.3.12","guildId":"112233445566778899","keyId":null,"statusCode":200}
+@kotbo/bot test:unit: (pass) Modular Routers Unit Tests > 1b. MCP OAuth Routes > POST initialize normalizes raw content-type even when parsed header looks valid [10.49ms]
+@kotbo/bot test:unit: [INFO] [MCPAuth] mcp_jsonrpc_request {"method":"tools/list","url":"/api/mcp/112233445566778899","ua":"Bun/1.3.12","guildId":"112233445566778899","keyId":null}
+@kotbo/bot test:unit: [INFO] [MCPAuth] mcp_jsonrpc_response {"method":"tools/list","url":"/api/mcp/112233445566778899","ua":"Bun/1.3.12","guildId":"112233445566778899","keyId":null,"statusCode":200}
+@kotbo/bot test:unit: (pass) Modular Routers Unit Tests > 1b. MCP OAuth Routes > POST tools/list without token lists public tool descriptors instead of HTTP 401 [13.85ms]
+@kotbo/bot test:unit: [INFO] [MCPAuth] mcp_tools_call_claude_401 {"method":"POST","url":"/api/mcp/112233445566778899","ua":"Claude MCP Connector","guildId":"112233445566778899","tool":"test_tool"}
+@kotbo/bot test:unit: (pass) Modular Routers Unit Tests > 1b. MCP OAuth Routes > POST tools/call without token returns HTTP OAuth challenge for Claude lazy auth [11.93ms]
+@kotbo/bot test:unit: [INFO] [MCPAuth] token_request {"method":"POST","url":"/api/mcp/112233445566778899/oauth/token","ua":"","guildId":"112233445566778899","grantType":"client_credentials","clientId":"mcp-key-id","hasCode":false,"hasVerifier":false,"redirectUri":null,"resource":null}
+@kotbo/bot test:unit: [INFO] [MCPAuth] token_client_credentials_success {"method":"POST","url":"/api/mcp/112233445566778899/oauth/token","ua":"","guildId":"112233445566778899","clientId":"mcp-key-id","keyId":"mcp-key-id"}
+@kotbo/bot test:unit: (pass) Modular Routers Unit Tests > 1b. MCP OAuth Routes > OAuth token endpoint supports client_credentials with MCP key client ID and secret [1.15ms]
+@kotbo/bot test:unit: [INFO] [MCPAuth] authorize_post_code_issued {"method":"POST","url":"/api/mcp/112233445566778899/oauth/authorize?resource=https%3A%2F%2Fapi-kotbo.example%2Fapi%2Fmcp%2F112233445566778899","ua":"","guildId":"112233445566778899","clientId":"oauth-client-id","redirectUri":"https://claude.ai/api/mcp/auth_callback","resource":"https://api-kotbo.example/api/mcp/112233445566778899","keyId":"mcp-key-id","permissions":["READ_STATS"]}
+@kotbo/bot test:unit: [INFO] [MCPAuth] authorize_post_redirect {"method":"POST","url":"/api/mcp/112233445566778899/oauth/authorize?resource=https%3A%2F%2Fapi-kotbo.example%2Fapi%2Fmcp%2F112233445566778899","ua":"","guildId":"112233445566778899","redirectUri":"https://claude.ai/api/mcp/auth_callback","iss":"https://api-kotbo.example/api/mcp/112233445566778899","base":"https://api-kotbo.example/api/mcp/112233445566778899","resource":"https://api-kotbo.example/api/mcp/112233445566778899"}
+@kotbo/bot test:unit: [INFO] [MCPAuth] token_request {"method":"POST","url":"/api/mcp/112233445566778899/oauth/token","ua":"","guildId":"112233445566778899","grantType":"authorization_code","clientId":"oauth-client-id","hasCode":true,"hasVerifier":true,"redirectUri":"https://claude.ai/api/mcp/auth_callback","resource":"https://api-kotbo.example/api/mcp/112233445566778899"}
+@kotbo/bot test:unit: [INFO] [MCPAuth] token_authorization_code_success {"method":"POST","url":"/api/mcp/112233445566778899/oauth/token","ua":"","guildId":"112233445566778899","clientId":"oauth-client-id","keyId":"mcp-key-id","resource":"https://api-kotbo.example/api/mcp/112233445566778899"}
+@kotbo/bot test:unit: [INFO] [MCPAuth] mcp_bearer_valid {"method":"tools/list","url":"/api/mcp/112233445566778899","ua":"Bun/1.3.12","guildId":"112233445566778899","keyId":"mcp-key-id","tokenKind":"oauth_jwt","permissions":["READ_STATS"]}
+@kotbo/bot test:unit: [INFO] [MCPAuth] mcp_jsonrpc_request {"method":"tools/list","url":"/api/mcp/112233445566778899","ua":"Bun/1.3.12","guildId":"112233445566778899","keyId":"mcp-key-id"}
+@kotbo/bot test:unit: [INFO] [MCPAuth] mcp_jsonrpc_response {"method":"tools/list","url":"/api/mcp/112233445566778899","ua":"Bun/1.3.12","guildId":"112233445566778899","keyId":"mcp-key-id","statusCode":200}
+@kotbo/bot test:unit: (pass) Modular Routers Unit Tests > 1b. MCP OAuth Routes > OAuth authorization_code returns JWT access token and refresh token accepted by MCP endpoint [16.30ms]
+@kotbo/bot test:unit: [INFO] [MCPAuth] mcp_direct_valid {"method":"initialize","url":"/api/mcp-direct/112233445566778899/[token]","ua":"Claude MCP Connector","guildId":"112233445566778899","keyId":"direct-key-id","permissions":["READ_STATS"]}
+@kotbo/bot test:unit: [INFO] [MCPAuth] mcp_accept_header_patched {"method":"initialize","url":"/api/mcp-direct/112233445566778899/[token]","ua":"Claude MCP Connector","guildId":"112233445566778899","keyId":"direct-key-id","previousAccept":"*/*","accept":"application/json, text/event-stream"}
+@kotbo/bot test:unit: [INFO] [MCPAuth] mcp_initialize_compat {"method":"POST","url":"/api/mcp-direct/112233445566778899/[token]","ua":"Claude MCP Connector","guildId":"112233445566778899","keyId":"direct-key-id","protocolVersion":"2025-06-18","clientInfo":{"name":"Claude","version":"httpx"}}
+@kotbo/bot test:unit: [INFO] [MCPAuth] mcp_jsonrpc_response {"method":"initialize","url":"/api/mcp-direct/112233445566778899/[token]","ua":"Claude MCP Connector","guildId":"112233445566778899","keyId":"direct-key-id","statusCode":200}
+@kotbo/bot test:unit: [INFO] [MCPAuth] mcp_direct_valid {"method":"tools/list","url":"/api/mcp-direct/112233445566778899/[token]","ua":"Claude MCP Connector","guildId":"112233445566778899","keyId":"direct-key-id","permissions":["READ_STATS"]}
+@kotbo/bot test:unit: [INFO] [MCPAuth] mcp_jsonrpc_request {"method":"tools/list","url":"/api/mcp-direct/112233445566778899/[token]","ua":"Claude MCP Connector","guildId":"112233445566778899","keyId":"direct-key-id"}
+@kotbo/bot test:unit: [INFO] [MCPAuth] mcp_jsonrpc_response {"method":"tools/list","url":"/api/mcp-direct/112233445566778899/[token]","ua":"Claude MCP Connector","guildId":"112233445566778899","keyId":"direct-key-id","statusCode":200}
+@kotbo/bot test:unit: (pass) Modular Routers Unit Tests > 1b. MCP OAuth Routes > signed direct MCP URL authenticates without OAuth and hides token in logs [23.94ms]
+@kotbo/bot test:unit: [INFO] [MCPAuth] dcr_registered {"method":"POST","url":"/api/mcp-direct/112233445566778899/[token]/oauth/register","ua":"","guildId":"112233445566778899","clientId":"79d01521-80dd-4e80-b8bd-a20fc3867e3c","redirectUris":["https://claude.ai/api/mcp/auth_callback"],"clientName":"Claude"}
+@kotbo/bot test:unit: [INFO] [MCPAuth] direct_authorize_code_issued {"method":"GET","url":"/api/mcp-direct/112233445566778899/[token]/oauth/authorize?response_type=code&client_id=79d01521-80dd-4e80-b8bd-a20fc3867e3c&redirect_uri=https%3A%2F%2Fclaude.ai%2Fapi%2Fmcp%2Fauth_callback&code_challenge=FC5-su8JHawXD3IYznelSeci4DcVPCakdNkIeWg9p_A&code_challenge_method=S256&state=state&resource=https%3A%2F%2Fapi-kotbo.example%2Fapi%2Fmcp-direct%2F112233445566778899%2F[token]","ua":"","guildId":"112233445566778899","clientId":"79d01521-80dd-4e80-b8bd-a20fc3867e3c","redirectUri":"https://claude.ai/api/mcp/auth_callback","resource":"https://api-kotbo.example/api/mcp-direct/112233445566778899/[token]","keyId":"direct-key-id","permissions":["READ_STATS"]}
+@kotbo/bot test:unit: [INFO] [MCPAuth] token_request {"method":"POST","url":"/api/mcp-direct/112233445566778899/[token]/oauth/token","ua":"","guildId":"112233445566778899","grantType":"authorization_code","clientId":"79d01521-80dd-4e80-b8bd-a20fc3867e3c","hasCode":true,"hasVerifier":true,"redirectUri":"https://claude.ai/api/mcp/auth_callback","resource":"https://api-kotbo.example/api/mcp-direct/112233445566778899/[token]"}
+@kotbo/bot test:unit: [INFO] [MCPAuth] token_authorization_code_success {"method":"POST","url":"/api/mcp-direct/112233445566778899/[token]/oauth/token","ua":"","guildId":"112233445566778899","clientId":"79d01521-80dd-4e80-b8bd-a20fc3867e3c","keyId":"direct-key-id","resource":"https://api-kotbo.example/api/mcp-direct/112233445566778899/[token]"}
+@kotbo/bot test:unit: (pass) Modular Routers Unit Tests > 1b. MCP OAuth Routes > signed direct MCP URL supports automatic OAuth registration flow for Claude fallback [3.12ms]
+@kotbo/bot test:unit: (pass) Modular Routers Unit Tests > 2. Auth Routes > active Discord login is handled by the Hono router [0.84ms]
+@kotbo/bot test:unit: (pass) Modular Routers Unit Tests > 2. Auth Routes > legacy implicit token exchange is retired [0.30ms]
+@kotbo/bot test:unit: (pass) Modular Routers Unit Tests > 3. Error Routes > POST /api/report-error returns 400 for invalid payload [1.51ms]
+@kotbo/bot test:unit: 1097 |       const parts = splitPath(req.url!);
+@kotbo/bot test:unit: 1098 |       const url = new URL(req.url!, 'http://localhost');
+@kotbo/bot test:unit: 1099 | 
+@kotbo/bot test:unit: 1100 |       const handled = await handleUserRoutes(req, res, parts, url, mockClient);
+@kotbo/bot test:unit: 1101 |       expect(handled).toBeTrue();
+@kotbo/bot test:unit: 1102 |       expect(res.statusCode).toBe(200);
+@kotbo/bot test:unit:                                     ^
+@kotbo/bot test:unit: error: expect(received).toBe(expected)
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: Expected: 200
+@kotbo/bot test:unit: Received: 401
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit:       at <anonymous> (/home/intercalaire/github/Kotbo/apps/bot/src/tests/unit/dashboardApi.test.ts:1102:30)
+@kotbo/bot test:unit: (fail) Modular Routers Unit Tests > 4. User Routes > GET /api/user/me returns user info when authenticated [1.61ms]
+@kotbo/bot test:unit: 1120 |       // Mock resolvesAdminAccess to false
+@kotbo/bot test:unit: 1121 |       mockDb.globalAdmin.findUnique.mockResolvedValue(null);
+@kotbo/bot test:unit: 1122 | 
+@kotbo/bot test:unit: 1123 |       const handled = await handleAdminRoutes(req, res, parts, url, mockClient);
+@kotbo/bot test:unit: 1124 |       expect(handled).toBeTrue();
+@kotbo/bot test:unit: 1125 |       expect(res.statusCode).toBe(403);
+@kotbo/bot test:unit:                                     ^
+@kotbo/bot test:unit: error: expect(received).toBe(expected)
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: Expected: 403
+@kotbo/bot test:unit: Received: 401
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit:       at <anonymous> (/home/intercalaire/github/Kotbo/apps/bot/src/tests/unit/dashboardApi.test.ts:1125:30)
+@kotbo/bot test:unit: (fail) Modular Routers Unit Tests > 5. Admin Routes > GET /api/admin/stats is blocked without admin access [13.39ms]
+@kotbo/bot test:unit: [INFO] [DashboardRouting] Incoming: POST /api/dashboard/guilds/1122334455667788/recruitment/candidatures | parts: ["api","dashboard","guilds","1122334455667788","recruitment","candidatures"]
+@kotbo/bot test:unit: [WARN] [RecruitmentAPI] Webhook auth failed for guild 1122334455667788: missing_credentials
+@kotbo/bot test:unit: (pass) Modular Routers Unit Tests > 6. Dashboard Router dispatcher > Bypasses auth for recruitment webhook [3.43ms]
+@kotbo/bot test:unit: [INFO] [DashboardRouting] Incoming: GET /api/dashboard/guilds/1122334455667788/state | parts: ["api","dashboard","guilds","1122334455667788","state"]
+@kotbo/bot test:unit: (pass) Modular Routers Unit Tests > 6. Dashboard Router dispatcher > Requires user authentication for general guild settings [0.77ms]
+@kotbo/bot test:unit: [INFO] [DashboardRouting] Incoming: GET /api/dashboard/guilds/1122334455667788/notifications/features | parts: ["api","dashboard","guilds","1122334455667788","notifications","features"]
+@kotbo/bot test:unit: 1172 |       const parts = splitPath(req.url!);
+@kotbo/bot test:unit: 1173 |       const url = new URL(req.url!, 'http://localhost');
+@kotbo/bot test:unit: 1174 | 
+@kotbo/bot test:unit: 1175 |       const handled = await handleDashboardRoutes(req, res, parts, url, mockClient);
+@kotbo/bot test:unit: 1176 |       expect(handled).toBeTrue();
+@kotbo/bot test:unit: 1177 |       expect(res.statusCode).toBe(200);
+@kotbo/bot test:unit:                                     ^
+@kotbo/bot test:unit: error: expect(received).toBe(expected)
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: Expected: 200
+@kotbo/bot test:unit: Received: 401
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit:       at <anonymous> (/home/intercalaire/github/Kotbo/apps/bot/src/tests/unit/dashboardApi.test.ts:1177:30)
+@kotbo/bot test:unit: (fail) Modular Routers Unit Tests > 6. Dashboard Router dispatcher > GET /api/dashboard/guilds/:guildId/notifications/features returns 200 [0.56ms]
+@kotbo/bot test:unit: [INFO] [DashboardRouting] Incoming: POST /api/dashboard/guilds/1122334455667788/embed-builder | parts: ["api","dashboard","guilds","1122334455667788","embed-builder"]
+@kotbo/bot test:unit: 1211 |       const parts = splitPath(req.url!);
+@kotbo/bot test:unit: 1212 |       const url = new URL(req.url!, 'http://localhost');
+@kotbo/bot test:unit: 1213 | 
+@kotbo/bot test:unit: 1214 |       const handled = await handleDashboardRoutes(req, res, parts, url, mockClient);
+@kotbo/bot test:unit: 1215 |       expect(handled).toBeTrue();
+@kotbo/bot test:unit: 1216 |       expect(res.statusCode).toBe(200);
+@kotbo/bot test:unit:                                     ^
+@kotbo/bot test:unit: error: expect(received).toBe(expected)
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: Expected: 200
+@kotbo/bot test:unit: Received: 401
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit:       at <anonymous> (/home/intercalaire/github/Kotbo/apps/bot/src/tests/unit/dashboardApi.test.ts:1216:30)
+@kotbo/bot test:unit: (fail) Modular Routers Unit Tests > 6. Dashboard Router dispatcher > POST /api/dashboard/guilds/:guildId/embed-builder parses content and V2 embed fields [0.90ms]
+@kotbo/bot test:unit: [INFO] [DashboardRouting] Incoming: POST /api/dashboard/guilds/1122334455667788/clans/points | parts: ["api","dashboard","guilds","1122334455667788","clans","points"]
+@kotbo/bot test:unit: 1253 |         findUnique: mock(() => Promise.resolve(null)),
+@kotbo/bot test:unit: 1254 |       };
+@kotbo/bot test:unit: 1255 | 
+@kotbo/bot test:unit: 1256 |       const handled = await handleDashboardRoutes(req, res, parts, url, mockClient);
+@kotbo/bot test:unit: 1257 |       expect(handled).toBeTrue();
+@kotbo/bot test:unit: 1258 |       expect(res.statusCode).toBe(200);
+@kotbo/bot test:unit:                                     ^
+@kotbo/bot test:unit: error: expect(received).toBe(expected)
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: Expected: 200
+@kotbo/bot test:unit: Received: 401
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit:       at <anonymous> (/home/intercalaire/github/Kotbo/apps/bot/src/tests/unit/dashboardApi.test.ts:1258:30)
+@kotbo/bot test:unit: (fail) Modular Routers Unit Tests > 6. Dashboard Router dispatcher > POST /api/dashboard/guilds/:guildId/clans/points adds manual points [1.14ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/unit/welcomeThreadService.test.ts:
+@kotbo/bot test:unit: (pass) clampStepDelay > borne les valeurs trop petites et trop grandes [3.64ms]
+@kotbo/bot test:unit: (pass) clampStepDelay > conserve les valeurs valides [0.12ms]
+@kotbo/bot test:unit: (pass) clampStepDelay > gère les valeurs non finies [0.08ms]
+@kotbo/bot test:unit: (pass) resolveAutoArchiveDuration > mappe les durées supportées [0.08ms]
+@kotbo/bot test:unit: (pass) resolveAutoArchiveDuration > retombe sur 24h pour les valeurs inconnues [0.03ms]
+@kotbo/bot test:unit: (pass) parseEmbedColor > accepte un hex valide [0.12ms]
+@kotbo/bot test:unit: (pass) parseEmbedColor > retombe sur le blurple pour les valeurs invalides [0.04ms]
+@kotbo/bot test:unit: (pass) buildWelcomeMenuComponents > retourne aucun composant sans pages [0.30ms]
+@kotbo/bot test:unit: (pass) buildWelcomeMenuComponents > mode boutons : 5 boutons max par ligne [1.28ms]
+@kotbo/bot test:unit: (pass) buildWelcomeMenuComponents > mode select : une seule ligne avec toutes les options [1.16ms]
+@kotbo/bot test:unit: (pass) buildWelcomeMenuComponents > tronque à 25 pages maximum [0.73ms]
+@kotbo/bot test:unit: (pass) buildMenuPageEmbed > construit un embed avec titre, description et couleur [0.25ms]
+@kotbo/bot test:unit: (pass) MAX_THREAD_STEPS > la limite de séquence est raisonnable [0.03ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/unit/presenceDetectionService.test.ts:
+@kotbo/bot test:unit: (pass) presenceDetectionService > utilise le compte de presence approximate quand le cache dit 0 en ligne [0.44ms]
+@kotbo/bot test:unit: (pass) presenceDetectionService > ne fait pas de fetch si le cache a deja des membres en ligne [0.28ms]
+@kotbo/bot test:unit: (pass) presenceDetectionService > retourne le cache si le fetch de presence echoue [0.16ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/unit/isKotboPublicOrigin.test.ts:
+@kotbo/bot test:unit: (pass) isKotboPublicOrigin > allows kotbo.fr and www [0.10ms]
+@kotbo/bot test:unit: (pass) isKotboPublicOrigin > allows dash.kotbo.fr dashboard [0.05ms]
+@kotbo/bot test:unit: (pass) isKotboPublicOrigin > allows other kotbo.fr subdomains [0.04ms]
+@kotbo/bot test:unit: (pass) isKotboPublicOrigin > allows localhost dev origins [0.03ms]
+@kotbo/bot test:unit: (pass) isKotboPublicOrigin > rejects unrelated origins [0.04ms]
+@kotbo/bot test:unit: (pass) isKotboPublicOrigin > rejects invalid URLs [0.08ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/unit/widgetService.test.ts:
+@kotbo/bot test:unit: (pass) widgetService identities > uses a unique identity and includes the external username [14.88ms]
+@kotbo/bot test:unit: (pass) widgetService identities > falls back to identity 0 only for the legacy user [0.80ms]
+@kotbo/bot test:unit: (pass) widgetService identities > reports identity collisions instead of blaming OAuth authorization [0.46ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/unit/bannedWordsService.test.ts:
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Faux positifs (ne doit PAS flagguer) > ignore "cacao" avec la liste [caca] (caca est un sous-mot) [0.41ms]
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Faux positifs (ne doit PAS flagguer) > ignore "Xavier" avec la liste [xav] (xav est un sous-mot) [0.10ms]
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Faux positifs (ne doit PAS flagguer) > ignore "assassin" avec la liste [ass] (ass est un sous-mot) [0.02ms]
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Faux positifs (ne doit PAS flagguer) > ignore "classique" avec la liste [lass] (lass est un sous-mot) [0.24ms]
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Faux positifs (ne doit PAS flagguer) > ignore "cocasse" avec la liste [caca] (caca est un sous-mot) [0.02ms]
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Faux positifs (ne doit PAS flagguer) > ignore "patapon" avec la liste [pat] (pat est un sous-mot) [0.01ms]
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Faux positifs (ne doit PAS flagguer) > ignore "r2d2" avec la liste [r, d] (les chiffres ne sont pas des séparateurs)
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Faux positifs (ne doit PAS flagguer) > ignore "super2man" avec la liste [man] (les chiffres ne sont pas des séparateurs)
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Faux positifs (ne doit PAS flagguer) > ignore "bidon" avec la liste [bi] (mot banni court (< 4c) en bord de pseudo)
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Faux positifs (ne doit PAS flagguer) > ignore "" avec la liste [caca] (pseudo vide)
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Faux positifs (ne doit PAS flagguer) > ignore "   " avec la liste [caca] (pseudo composé uniquement d'espaces)
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Faux positifs (ne doit PAS flagguer) > ignore "caca" avec la liste [,    ] (mots bannis vides)
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Vrais positifs (DOIT flagguer) > flaggue "caca" avec la liste [caca] (mot exact) [0.12ms]
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Vrais positifs (DOIT flagguer) > flaggue "caca lol" avec la liste [caca] (début de mot composé) [0.03ms]
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Vrais positifs (DOIT flagguer) > flaggue "super caca" avec la liste [caca] (fin de mot composé) [0.06ms]
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Vrais positifs (DOIT flagguer) > flaggue "le-caca-lol" avec la liste [caca] (séparateur tiret) [0.09ms]
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Vrais positifs (DOIT flagguer) > flaggue "pseudo_caca" avec la liste [caca] (séparateur underscore)
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Vrais positifs (DOIT flagguer) > flaggue "caca123" avec la liste [caca] (frontière de chiffre (non-lettre)) [0.10ms]
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Vrais positifs (DOIT flagguer) > flaggue "CACA" avec la liste [caca] (insensible à la casse) [0.01ms]
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Vrais positifs (DOIT flagguer) > flaggue "caca!lol" avec la liste [caca] (frontière de ponctuation)
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Vrais positifs (DOIT flagguer) > flaggue "ass-boy" avec la liste [ass] (séparateur tiret)
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Vrais positifs (DOIT flagguer) > flaggue "je suis caca" avec la liste [sale, caca, merde] (un mot de la liste correspond) [0.03ms]
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Substring match mots longs (seuil ≥ 6c) > flaggue "connerieman" avec la liste [connerie] (connerie (8c ≥ 6) est un mot long) [0.11ms]
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Substring match mots longs (seuil ≥ 6c) > flaggue "leputaindetruc" avec la liste [putain] (putain (6c ≥ 6) est un mot long) [0.04ms]
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Substring match mots longs (seuil ≥ 6c) > ignore "sonofbitch0139" avec la liste [bitch] (bitch (5c < 6) est sous le seuil) [0.06ms]
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Substring match mots longs (seuil ≥ 6c) > ignore "fichier" avec la liste [chier] (chier (5c < 6) est sous le seuil) [0.04ms]
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Substring match mots longs (seuil ≥ 6c) > ignore "supermerdedu" avec la liste [merde] (merde (5c < 6) est sous le seuil) [0.03ms]
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Substring match mots longs (seuil ≥ 6c) > ignore "cacao" avec la liste [caca] (caca (4c < 6) est sous le seuil) [0.02ms]
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Substring match mots longs (seuil ≥ 6c) > ignore "cacahuète" avec la liste [caca] (caca (4c < 6) est sous le seuil)
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Cas limites > flaggue "éléphant" avec la liste [éléphant] (caractères accentués) [0.03ms]
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Cas limites > ignore "réélection" avec la liste [ré] (mot court avec accents) [0.03ms]
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Cas limites > ignore "caca" avec la liste [] (liste de mots vide)
+@kotbo/bot test:unit: (pass) containsBannedWord — Détection automatique > Cas limites > flaggue "caca" avec la liste [  caca  ] (mot banni avec espaces superflus)
+@kotbo/bot test:unit: (pass) isNicknameProblematic — Sécurités & Whitelist > ignore le pseudo de remplacement exact (SAFE_NICKNAME) [0.14ms]
+@kotbo/bot test:unit: (pass) isNicknameProblematic — Sécurités & Whitelist > ne bypass pas les variations contenant "automod" ou "pseudo non conforme" si elles contiennent des mots bannis [0.07ms]
+@kotbo/bot test:unit: (pass) isNicknameProblematic — Sécurités & Whitelist > ignore les pseudos de la whitelist du serveur [0.09ms]
+@kotbo/bot test:unit: (pass) isNicknameProblematic — Sécurités & Whitelist > ignore les membres exemptés (bypass) [0.04ms]
+@kotbo/bot test:unit: (pass) isNicknameProblematic — Sécurités & Whitelist > flaggue les pseudos réellement problématiques [0.04ms]
+@kotbo/bot test:unit: (pass) isNicknameProblematic — Sécurités & Whitelist > ne flaggue pas les pseudos propres [0.02ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/unit/activationCodeService.test.ts:
+@kotbo/bot test:unit: 22 |     activatedGuilds.clear();
+@kotbo/bot test:unit: 23 |     for (const guild of guilds) {
+@kotbo/bot test:unit: 24 |       activatedGuilds.add(guild.id);
+@kotbo/bot test:unit: 25 |     }
+@kotbo/bot test:unit: 26 | 
+@kotbo/bot test:unit: 27 |     logger.success('Activation', `Chargement réussi : ${activatedGuilds.size} serveur(s) activé(s) mis en cache.`);
+@kotbo/bot test:unit:                 ^
+@kotbo/bot test:unit: TypeError: logger.success is not a function. (In 'logger.success("Activation", `Chargement r\xE9ussi : ${activatedGuilds.size} serveur(s) activ\xE9(s) mis en cache.`)', 'logger.success' is undefined)
+@kotbo/bot test:unit:       at loadActivatedGuilds (/home/intercalaire/github/Kotbo/apps/bot/src/utils/activation.ts:27:12)
+@kotbo/bot test:unit:       at async <anonymous> (/home/intercalaire/github/Kotbo/apps/bot/src/tests/unit/activationCodeService.test.ts:67:11)
+@kotbo/bot test:unit: (fail) activation service > loadActivatedGuilds should populate the activatedGuilds Set from DB [0.71ms]
+@kotbo/bot test:unit: 78 |     mockDb.activationCode.update.mockResolvedValue({});
+@kotbo/bot test:unit: 79 |     mockDb.guild.upsert.mockResolvedValue({});
+@kotbo/bot test:unit: 80 | 
+@kotbo/bot test:unit: 81 |     await activateGuild('guild-123', 'KB-TEST-CODE');
+@kotbo/bot test:unit: 82 | 
+@kotbo/bot test:unit: 83 |     expect(mockDb.activationCode.update).toHaveBeenCalledWith({
+@kotbo/bot test:unit:                                               ^
+@kotbo/bot test:unit: error: expect(received).toHaveBeenCalledWith(...expected)
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: Expected: [
+@kotbo/bot test:unit:   {
+@kotbo/bot test:unit:     where: {
+@kotbo/bot test:unit:       code: "KB-TEST-CODE",
+@kotbo/bot test:unit:     },
+@kotbo/bot test:unit:     data: {
+@kotbo/bot test:unit:       usedAt: Any<Date>,
+@kotbo/bot test:unit:       usedByGuildId: "guild-123",
+@kotbo/bot test:unit:       isActive: false,
+@kotbo/bot test:unit:     },
+@kotbo/bot test:unit:   }
+@kotbo/bot test:unit: ]
+@kotbo/bot test:unit: But it was not called.
+@kotbo/bot test:unit:       at <anonymous> (/home/intercalaire/github/Kotbo/apps/bot/src/tests/unit/activationCodeService.test.ts:83:42)
+@kotbo/bot test:unit: (fail) activation service > activateGuild should update DB activation code, upsert guild, and add to cache [0.41ms]
+@kotbo/bot test:unit: 116 | 
+@kotbo/bot test:unit: 117 |     activatedGuilds.add('guild-123');
+@kotbo/bot test:unit: 118 | 
+@kotbo/bot test:unit: 119 |     await deactivateGuild('guild-123');
+@kotbo/bot test:unit: 120 | 
+@kotbo/bot test:unit: 121 |     expect(mockDb.activationCode.update).toHaveBeenCalledWith({
+@kotbo/bot test:unit:                                                ^
+@kotbo/bot test:unit: error: expect(received).toHaveBeenCalledWith(...expected)
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: Expected: [
+@kotbo/bot test:unit:   {
+@kotbo/bot test:unit:     where: {
+@kotbo/bot test:unit:       code: "KB-TEST-CODE",
+@kotbo/bot test:unit:     },
+@kotbo/bot test:unit:     data: {
+@kotbo/bot test:unit:       usedAt: null,
+@kotbo/bot test:unit:       usedByGuildId: null,
+@kotbo/bot test:unit:       isActive: true,
+@kotbo/bot test:unit:     },
+@kotbo/bot test:unit:   }
+@kotbo/bot test:unit: ]
+@kotbo/bot test:unit: But it was not called.
+@kotbo/bot test:unit:       at <anonymous> (/home/intercalaire/github/Kotbo/apps/bot/src/tests/unit/activationCodeService.test.ts:121:42)
+@kotbo/bot test:unit: (fail) activation service > deactivateGuild should set active to false in DB and delete from cache [0.21ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/unit/logger.test.ts:
+@kotbo/bot test:unit: 35 |     delete process.env.LOG_LEVEL;
+@kotbo/bot test:unit: 36 |   });
+@kotbo/bot test:unit: 37 | 
+@kotbo/bot test:unit: 38 |   test("affiche des logs d'information", () => {
+@kotbo/bot test:unit: 39 |     logger.info('TestTag', 'message info');
+@kotbo/bot test:unit: 40 |     expect(logOutput.length).toBeGreaterThan(0);
+@kotbo/bot test:unit:                                   ^
+@kotbo/bot test:unit: error: expect(received).toBeGreaterThan(expected)
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: Expected: > 0
+@kotbo/bot test:unit: Received: 0
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit:       at <anonymous> (/home/intercalaire/github/Kotbo/apps/bot/src/tests/unit/logger.test.ts:40:30)
+@kotbo/bot test:unit: (fail) logger > affiche des logs d'information [2.46ms]
+@kotbo/bot test:unit: 42 |     expect(logOutput[0]).toContain('message info');
+@kotbo/bot test:unit: 43 |     expect(logOutput[0]).toContain('INFO');
+@kotbo/bot test:unit: 44 |   });
+@kotbo/bot test:unit: 45 | 
+@kotbo/bot test:unit: 46 |   test('affiche des messages de succes', () => {
+@kotbo/bot test:unit: 47 |     logger.success('TestTag', 'operation complete');
+@kotbo/bot test:unit:                 ^
+@kotbo/bot test:unit: TypeError: logger.success is not a function. (In 'logger.success("TestTag", "operation complete")', 'logger.success' is undefined)
+@kotbo/bot test:unit:       at <anonymous> (/home/intercalaire/github/Kotbo/apps/bot/src/tests/unit/logger.test.ts:47:12)
+@kotbo/bot test:unit: (fail) logger > affiche des messages de succes [0.12ms]
+@kotbo/bot test:unit: 50 |     expect(logOutput[0]).toContain('TestTag');
+@kotbo/bot test:unit: 51 |   });
+@kotbo/bot test:unit: 52 | 
+@kotbo/bot test:unit: 53 |   test('affiche des avertissements', () => {
+@kotbo/bot test:unit: 54 |     logger.warn('TestTag', 'attention requise');
+@kotbo/bot test:unit: 55 |     expect(warnOutput.length).toBeGreaterThan(0);
+@kotbo/bot test:unit:                                    ^
+@kotbo/bot test:unit: error: expect(received).toBeGreaterThan(expected)
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: Expected: > 0
+@kotbo/bot test:unit: Received: 0
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit:       at <anonymous> (/home/intercalaire/github/Kotbo/apps/bot/src/tests/unit/logger.test.ts:55:31)
+@kotbo/bot test:unit: (fail) logger > affiche des avertissements [0.11ms]
+@kotbo/bot test:unit: 57 |     expect(warnOutput[0]).toContain('TestTag');
+@kotbo/bot test:unit: 58 |   });
+@kotbo/bot test:unit: 59 | 
+@kotbo/bot test:unit: 60 |   test('affiche des erreurs', () => {
+@kotbo/bot test:unit: 61 |     logger.error('TestTag', 'erreur critique');
+@kotbo/bot test:unit: 62 |     expect(errorOutput.length).toBeGreaterThan(0);
+@kotbo/bot test:unit:                                     ^
+@kotbo/bot test:unit: error: expect(received).toBeGreaterThan(expected)
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: Expected: > 0
+@kotbo/bot test:unit: Received: 0
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit:       at <anonymous> (/home/intercalaire/github/Kotbo/apps/bot/src/tests/unit/logger.test.ts:62:32)
+@kotbo/bot test:unit: (fail) logger > affiche des erreurs [0.14ms]
+@kotbo/bot test:unit: 64 |     expect(errorOutput[0]).toContain('TestTag');
+@kotbo/bot test:unit: 65 |   });
+@kotbo/bot test:unit: 66 | 
+@kotbo/bot test:unit: 67 |   test('affiche debug quand LOG_LEVEL=debug', () => {
+@kotbo/bot test:unit: 68 |     process.env.LOG_LEVEL = 'debug';
+@kotbo/bot test:unit: 69 |     logger.debug('TestTag', 'message debug');
+@kotbo/bot test:unit:                 ^
+@kotbo/bot test:unit: TypeError: logger.debug is not a function. (In 'logger.debug("TestTag", "message debug")', 'logger.debug' is undefined)
+@kotbo/bot test:unit:       at <anonymous> (/home/intercalaire/github/Kotbo/apps/bot/src/tests/unit/logger.test.ts:69:12)
+@kotbo/bot test:unit: (fail) logger > affiche debug quand LOG_LEVEL=debug [0.12ms]
+@kotbo/bot test:unit: 71 |     expect(logOutput[0]).toContain('DEBUG');
+@kotbo/bot test:unit: 72 |   });
+@kotbo/bot test:unit: 73 | 
+@kotbo/bot test:unit: 74 |   test("n'affiche pas debug quand LOG_LEVEL n'est pas debug", () => {
+@kotbo/bot test:unit: 75 |     process.env.LOG_LEVEL = 'info';
+@kotbo/bot test:unit: 76 |     logger.debug('TestTag', 'message debug');
+@kotbo/bot test:unit:                 ^
+@kotbo/bot test:unit: TypeError: logger.debug is not a function. (In 'logger.debug("TestTag", "message debug")', 'logger.debug' is undefined)
+@kotbo/bot test:unit:       at <anonymous> (/home/intercalaire/github/Kotbo/apps/bot/src/tests/unit/logger.test.ts:76:12)
+@kotbo/bot test:unit: (fail) logger > n'affiche pas debug quand LOG_LEVEL n'est pas debug [0.08ms]
+@kotbo/bot test:unit: 76 |     logger.debug('TestTag', 'message debug');
+@kotbo/bot test:unit: 77 |     expect(logOutput.length).toBe(0);
+@kotbo/bot test:unit: 78 |   });
+@kotbo/bot test:unit: 79 | 
+@kotbo/bot test:unit: 80 |   test("n'affiche pas debug sans LOG_LEVEL", () => {
+@kotbo/bot test:unit: 81 |     logger.debug('TestTag', 'message debug');
+@kotbo/bot test:unit:                 ^
+@kotbo/bot test:unit: TypeError: logger.debug is not a function. (In 'logger.debug("TestTag", "message debug")', 'logger.debug' is undefined)
+@kotbo/bot test:unit:       at <anonymous> (/home/intercalaire/github/Kotbo/apps/bot/src/tests/unit/logger.test.ts:81:12)
+@kotbo/bot test:unit: (fail) logger > n'affiche pas debug sans LOG_LEVEL [0.18ms]
+@kotbo/bot test:unit: 82 |     expect(logOutput.length).toBe(0);
+@kotbo/bot test:unit: 83 |   });
+@kotbo/bot test:unit: 84 | 
+@kotbo/bot test:unit: 85 |   test('formate les logs avec timestamp, couleurs et tag', () => {
+@kotbo/bot test:unit: 86 |     logger.info('Bot', 'Démarrage');
+@kotbo/bot test:unit: 87 |     expect(logOutput[0]).toContain('[');
+@kotbo/bot test:unit:                               ^
+@kotbo/bot test:unit: error: Received value must be an array type, or both received and expected values must be strings.
+@kotbo/bot test:unit:       at <anonymous> (/home/intercalaire/github/Kotbo/apps/bot/src/tests/unit/logger.test.ts:87:26)
+@kotbo/bot test:unit: (fail) logger > formate les logs avec timestamp, couleurs et tag [0.10ms]
+@kotbo/bot test:unit: 89 |     expect(logOutput[0]).toContain('Démarrage');
+@kotbo/bot test:unit: 90 |   });
+@kotbo/bot test:unit: 91 | 
+@kotbo/bot test:unit: 92 |   test('supporte plusieurs arguments', () => {
+@kotbo/bot test:unit: 93 |     logger.info('Tag', 'arg1', 'arg2', 'arg3');
+@kotbo/bot test:unit: 94 |     expect(logOutput[0]).toContain('arg1');
+@kotbo/bot test:unit:                               ^
+@kotbo/bot test:unit: error: Received value must be an array type, or both received and expected values must be strings.
+@kotbo/bot test:unit:       at <anonymous> (/home/intercalaire/github/Kotbo/apps/bot/src/tests/unit/logger.test.ts:94:26)
+@kotbo/bot test:unit: (fail) logger > supporte plusieurs arguments [0.09ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/unit/newsRss.test.ts:
+@kotbo/bot test:unit: (pass) news RSS generator > génère un document XML RSS 2.0 valide à partir d'articles [0.41ms]
+@kotbo/bot test:unit: (pass) news RSS generator > génère un canal vide si aucun article n'est passé [0.20ms]
+@kotbo/bot test:unit: (pass) news RSS generator > génère le bon lien atom:link avec filtrage par catégorie et sous-catégorie [0.10ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/unit/translationService.test.ts:
+@kotbo/bot test:unit: (pass) translationService > met en cache une traduction pour eviter les appels repetes [1.41ms]
+@kotbo/bot test:unit: (pass) translationService > retourne null en cas d erreur traducteur [0.40ms]
+@kotbo/bot test:unit: (pass) translationService > normalise la langue cible invalide vers fr [0.25ms]
+@kotbo/bot test:unit: (pass) translationService > clearCacheForTests vide bien le cache [0.58ms]
+@kotbo/bot test:unit: (pass) translationService > isTranslationAvailable retourne true [0.11ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/unit/metadataParser.test.ts:
+@kotbo/bot test:unit: (pass) fetchArticleMetadata > extrait title, description, image et flux rss [1.09ms]
+@kotbo/bot test:unit: (pass) fetchArticleMetadata > retourne des valeurs nulles en cas d'erreur reseau [0.19ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/unit/adminLockService.test.ts:
+@kotbo/bot test:unit: (pass) roleGrantsAdministrator > retourne true pour un bitfield contenant uniquement Administrator [0.39ms]
+@kotbo/bot test:unit: (pass) roleGrantsAdministrator > retourne true pour un bitfield combinant Administrator avec d'autres permissions [0.06ms]
+@kotbo/bot test:unit: (pass) roleGrantsAdministrator > retourne false pour un bitfield sans Administrator [0.06ms]
+@kotbo/bot test:unit: (pass) roleGrantsAdministrator > retourne false pour un bitfield vide [0.11ms]
+@kotbo/bot test:unit: (pass) isAdminLockBypassedCore > bypass le propriétaire du serveur inconditionnellement [0.09ms]
+@kotbo/bot test:unit: (pass) isAdminLockBypassedCore > bypass un membre possédant un rôle 'sécurité' [0.07ms]
+@kotbo/bot test:unit: (pass) isAdminLockBypassedCore > ne bypass pas un membre sans rôle 'sécurité' ni owner [0.04ms]
+@kotbo/bot test:unit: (pass) isAdminLockBypassedCore > ne bypass pas quand aucun rôle sécurité n'est configuré [0.04ms]
+@kotbo/bot test:unit: (pass) isAdminLockBypassedCore > un propriétaire configuré par erreur comme rôle sécurité ne casse pas le bypass des autres membres [0.04ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/unit/dashboardCors.test.ts:
+@kotbo/bot test:unit: (pass) dashboardCors > reflects dash.kotbo.fr origin in Access-Control-Allow-Origin [3.59ms]
+@kotbo/bot test:unit: (pass) dashboardCors > reflects kotbo.fr landing origin [0.39ms]
+@kotbo/bot test:unit: (pass) dashboardCors > handles OPTIONS preflight for dash.kotbo.fr [0.59ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/unit/ping.command.test.ts:
+@kotbo/bot test:unit: (pass) commande ping > repond puis edite la reponse avec un embed de latence [1.04ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/unit/transcript.command.test.ts:
+@kotbo/bot test:unit: (pass) commande transcript duration parser > parse correctement les durées valides [0.32ms]
+@kotbo/bot test:unit: (pass) commande transcript duration parser > retourne null pour les durées invalides [0.04ms]
+@kotbo/bot test:unit: (pass) commande transcript datetime and duration parser > parse correctement les durées relatives [0.10ms]
+@kotbo/bot test:unit: (pass) commande transcript datetime and duration parser > parse correctement les timestamps unix en secondes et millisecondes [0.05ms]
+@kotbo/bot test:unit: (pass) commande transcript datetime and duration parser > parse correctement le format de date français DD/MM/YYYY-HH:MM [0.09ms]
+@kotbo/bot test:unit: (pass) commande transcript datetime and duration parser > parse correctement le format de date français simple DD/MM/YYYY [0.05ms]
+@kotbo/bot test:unit: (pass) commande transcript datetime and duration parser > parse correctement le format ISO ou standard JS date [0.04ms]
+@kotbo/bot test:unit: (pass) commande transcript datetime and duration parser > retourne null pour les entrées invalides [0.04ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/unit/githubReleaseService.test.ts:
+@kotbo/bot test:unit: (pass) githubReleaseService > retourne une nouvelle release puis null au second passage identique [0.60ms]
+@kotbo/bot test:unit: (pass) githubReleaseService > retourne null si 404 [0.27ms]
+@kotbo/bot test:unit: (pass) githubReleaseService > formate le message release avec fallback description [0.08ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/unit/burstTracker.test.ts:
+@kotbo/bot test:unit: (pass) recordAndCheckBurst > ne déclenche pas tant que la limite n'est pas dépassée [0.21ms]
+@kotbo/bot test:unit: (pass) recordAndCheckBurst > déclenche au-delà de la limite dans la fenêtre [0.10ms]
+@kotbo/bot test:unit: (pass) recordAndCheckBurst > ignore les occurrences hors de la fenêtre temporelle [0.08ms]
+@kotbo/bot test:unit: (pass) recordAndCheckBurst > déclenche si n'importe laquelle des fenêtres fournies est dépassée (limite lente) [0.06ms]
+@kotbo/bot test:unit: (pass) recordAndCheckBurst > resetBurst réinitialise le compteur pour une clé [0.06ms]
+@kotbo/bot test:unit: (pass) recordAndCheckBurst > des clés différentes ont des compteurs indépendants [0.08ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/unit/language.test.ts:
+@kotbo/bot test:unit: (pass) language utils > retourne null quand le texte est trop court [0.76ms]
+@kotbo/bot test:unit: (pass) language utils > detecte une langue supportee sur un texte long [6.31ms]
+@kotbo/bot test:unit: (pass) language utils > mappe les noms de langue lisibles [0.07ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/unit/staffServerService.test.ts:
+@kotbo/bot test:unit: (pass) StaffServerService unit tests > resolveStaffNotifyChannelId > should resolve correct channel ID when mapping exists and link is enabled [0.34ms]
+@kotbo/bot test:unit: (pass) StaffServerService unit tests > resolveStaffNotifyChannelId > should return null if link is disabled [0.05ms]
+@kotbo/bot test:unit: (pass) StaffServerService unit tests > resolveStaffNotifyChannelId > should return null if channel ID is not configured [0.14ms]
+@kotbo/bot test:unit: (pass) StaffServerService unit tests > computeStaffRoleTransition > gained-first: transitioning from no staff roles to having one [0.16ms]
+@kotbo/bot test:unit: (pass) StaffServerService unit tests > computeStaffRoleTransition > lost-all: transitioning from having staff roles to having none [0.04ms]
+@kotbo/bot test:unit: (pass) StaffServerService unit tests > computeStaffRoleTransition > none: no change in staff roles presence [0.04ms]
+@kotbo/bot test:unit: (pass) StaffServerService unit tests > getStaffServerNotifyChannel > resolves and returns TextChannel when configured [0.87ms]
+@kotbo/bot test:unit: (pass) StaffServerService unit tests > getStaffServerNotifyChannel > returns null if resolved channel has mismatched guild ID [0.18ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: src/tests/unit/patchV2.test.ts:
+@kotbo/bot test:unit: (pass) transformUpdatePayload > convertit content en TextDisplay pour un update sur message V2 [2.54ms]
+@kotbo/bot test:unit: (pass) transformUpdatePayload > préserve les composants existants en les plaçant après le texte [0.07ms]
+@kotbo/bot test:unit: (pass) transformUpdatePayload > convertit un update string sur message V2 [0.05ms]
+@kotbo/bot test:unit: (pass) transformUpdatePayload > ne modifie pas un update content sur message legacy [0.05ms]
+@kotbo/bot test:unit: (pass) transformUpdatePayload > convertit toujours les embeds via transformPayload, cible V2 ou non [0.87ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit: 19 tests failed:
+@kotbo/bot test:unit: (fail) Modular Routers Unit Tests > 1. Public Routes > GET /api/config returns client info [1.57ms]
+@kotbo/bot test:unit: (fail) Modular Routers Unit Tests > 4. User Routes > GET /api/user/me returns user info when authenticated [1.61ms]
+@kotbo/bot test:unit: (fail) Modular Routers Unit Tests > 5. Admin Routes > GET /api/admin/stats is blocked without admin access [13.39ms]
+@kotbo/bot test:unit: (fail) Modular Routers Unit Tests > 6. Dashboard Router dispatcher > GET /api/dashboard/guilds/:guildId/notifications/features returns 200 [0.56ms]
+@kotbo/bot test:unit: (fail) Modular Routers Unit Tests > 6. Dashboard Router dispatcher > POST /api/dashboard/guilds/:guildId/embed-builder parses content and V2 embed fields [0.90ms]
+@kotbo/bot test:unit: (fail) Modular Routers Unit Tests > 6. Dashboard Router dispatcher > POST /api/dashboard/guilds/:guildId/clans/points adds manual points [1.14ms]
+@kotbo/bot test:unit: (fail) activation service > loadActivatedGuilds should populate the activatedGuilds Set from DB [0.71ms]
+@kotbo/bot test:unit: (fail) activation service > activateGuild should update DB activation code, upsert guild, and add to cache [0.41ms]
+@kotbo/bot test:unit: (fail) activation service > deactivateGuild should set active to false in DB and delete from cache [0.21ms]
+@kotbo/bot test:unit: (fail) logger > affiche des logs d'information [2.46ms]
+@kotbo/bot test:unit: (fail) logger > affiche des messages de succes [0.12ms]
+@kotbo/bot test:unit: (fail) logger > affiche des avertissements [0.11ms]
+@kotbo/bot test:unit: (fail) logger > affiche des erreurs [0.14ms]
+@kotbo/bot test:unit: (fail) logger > affiche debug quand LOG_LEVEL=debug [0.12ms]
+@kotbo/bot test:unit: (fail) logger > n'affiche pas debug quand LOG_LEVEL n'est pas debug [0.08ms]
+@kotbo/bot test:unit: (fail) logger > n'affiche pas debug sans LOG_LEVEL [0.18ms]
+@kotbo/bot test:unit: (fail) logger > formate les logs avec timestamp, couleurs et tag [0.10ms]
+@kotbo/bot test:unit: (fail) logger > supporte plusieurs arguments [0.09ms]
+@kotbo/bot test:unit: 
+@kotbo/bot test:unit:  190 pass
+@kotbo/bot test:unit:  19 fail
+@kotbo/bot test:unit:  1 error
+@kotbo/bot test:unit:  976 expect() calls
+@kotbo/bot test:unit: Ran 209 tests across 29 files. [1.75s]
+@kotbo/bot test:unit: Exited with code 1
+error: script "test:bot" exited with code 1


### PR DESCRIPTION
Apporte le gros de l’implémentation des clans sur le bot/dashboard avec sa gestion et ses automatisations

## Séparation de la page de configuration des clans en 3 onglets ergonomiques :
- Clans & Rôles : Paramètres de base et restriction interdisant le multi-clans.
- Gestion des Saisons : Tableau de bord dynamique indiquant le temps restant, et interface intuitive pour planifier les dates de la #saison.
- Gestion des Points : Paramétrage du gain automatique d'XP (par montée de niveau) et interfaces de dons manuels.
- Gestion Avancée des Points d'XP (Dashboard & API)

## Ajout d'une route API POST /api/dashboard/guilds/:guildId/clans/points.
- Possibilité d'ajouter (ou retirer) manuellement de l'XP à un membre précis.
- Possibilité d'ajouter de l'XP au clan de manière globale (géré via un utilisateur système virtuel en base de données pour ne pas fausser les statistiques des vrais membres).
- Synchronisation Intelligente des Doubles Comptes (Discord), Meme compte dans la coa

Lors de l'association de deux comptes discord ayant des clans différents, le système détermine le compte principal (basé sur le niveau d'XP MemberLevel).
Le compte secondaire est automatiquement transféré dans le clan du compte principal.
Les contributions d'XP du compte secondaire sont transférées et additionnées au nouveau clan pour éviter toute perte de points pendant la saison.

## Récompenses de Saison
- Chef de Coalition : Le meilleur contributeur du clan vainqueur d'une saison reçoit automatiquement un rôle honorifique. Un système de nettoyage (cleanup) retire l'ancien rôle de chef aux vainqueurs des saisons précédentes avant chaque nouvelle attribution.
- Boost d'XP Automatique : Possibilité d'activer sur le dashboard un multiplicateur d'XP (ex: +20%) qui s'appliquera automatiquement à tous les membres du clan gagnant lors de la saison suivante.


