### PR TITLE
feat(clans): improve season planning UI, WS real-time, manual points fix, leader roles & leveling xp boost display

### DIFF
--- a/apps/bot/src/api/routes/dashboard/clans.ts
+++ b/apps/bot/src/api/routes/dashboard/clans.ts
@@ -2,7 +2,7 @@ import { IncomingMessage, ServerResponse } from 'node:http';
 import { Client } from 'discord.js';
 import prisma from '../../../utils/db.js';
 import { logger } from '../../../utils/logger.js';
-import { json, readJsonBody, getGuildName, pushAudit, type AuthClaims, type DashboardAccess } from '../../shared.js';
+import { json, readJsonBody, getGuildName, pushAudit, broadcastDashboardStateChange, type AuthClaims, type DashboardAccess } from '../../shared.js';
 import { clanTasks, runDistribution, runClear, handleEndSeason } from '../../../services/community/clanService.js';
 
 export async function handleClansRoutes(
@@ -169,6 +169,8 @@ export async function handleClansRoutes(
         channelId: null,
       });
 
+      broadcastDashboardStateChange(guildId, 'clans_updated');
+
       json(res, 200, {
         clansEnabled: updatedGuild.clansEnabled,
         clansUnique: updatedGuild.clansUnique,
@@ -249,6 +251,8 @@ export async function handleClansRoutes(
         channelId: null,
       });
 
+      broadcastDashboardStateChange(guildId, 'clans_updated');
+
       json(res, 201, { clan });
     } catch (err) {
       logger.error('ClansAPI', 'Error creating clan:', err);
@@ -311,6 +315,8 @@ export async function handleClansRoutes(
         channelId: null,
       });
 
+      broadcastDashboardStateChange(guildId, 'clans_updated');
+
       json(res, 200, { clan: updatedClan });
     } catch (err) {
       logger.error('ClansAPI', 'Error updating clan:', err);
@@ -337,6 +343,8 @@ export async function handleClansRoutes(
         details: `Clan "${deletedClan.name}" supprimé.`,
         channelId: null,
       });
+
+      broadcastDashboardStateChange(guildId, 'clans_updated');
 
       json(res, 200, { success: true });
     } catch (err) {
@@ -403,6 +411,8 @@ export async function handleClansRoutes(
         details: `Saison de clan réinitialisée. Nouvelle saison active: ${nextSeason}`,
         channelId: null,
       });
+
+      broadcastDashboardStateChange(guildId, 'clans_updated');
 
       json(res, 200, { currentClanSeason: nextSeason });
     } catch (err) {
@@ -479,6 +489,8 @@ export async function handleClansRoutes(
         details: `Ajout manuel de ${body.amount} XP au clan "${clan.name}"` + (body.userId ? ` pour l'utilisateur ${body.userId}` : ' (global)'),
         channelId: null,
       });
+
+      broadcastDashboardStateChange(guildId, 'clans_updated');
 
       json(res, 200, { success: true, contribution });
     } catch (err) {

--- a/apps/bot/src/services/community/clanService.ts
+++ b/apps/bot/src/services/community/clanService.ts
@@ -430,6 +430,17 @@ export async function handleEndSeason(
         where: { id: guildId },
         data: { lastWinningClanId: winningClan.id },
       });
+
+      // Trouver le chef du clan gagnant pour l'annonce
+      const topWinnerContributor = await prisma.clanMemberContribution.findFirst({
+        where: { guildId, clanId: winningClan.id, season: currentSeason, userId: { not: 'system_manual_points' } },
+        orderBy: { xp: 'desc' },
+      });
+
+      if (topWinnerContributor && topWinnerContributor.xp > 0) {
+        leaderUserId = topWinnerContributor.userId;
+        leaderXp = topWinnerContributor.xp;
+      }
     }
 
     // 4. Attribuer le rôle de chef de clan pour chaque clan si activé

--- a/apps/bot/src/services/community/clanService.ts
+++ b/apps/bot/src/services/community/clanService.ts
@@ -1,7 +1,7 @@
 import { Client, EmbedBuilder, ChannelType, CategoryChannel } from 'discord.js';
 import prisma from '../../utils/db.js';
 import { logger } from '../../utils/logger.js';
-import { pushAudit } from '../../api/shared.js';
+import { pushAudit, broadcastDashboardStateChange } from '../../api/shared.js';
 import { getClient } from '../../utils/client.js';
 
 export const clanTasks = new Map<string, { type: 'distribute' | 'clear'; processed: number; total: number }>();
@@ -43,6 +43,7 @@ export async function runDistribution(guildId: string, client: Client, initiator
   
   // Démarrer la tâche asynchrone bridée
   clanTasks.set(guildId, { type: 'distribute', processed: 0, total: targetList.length });
+  broadcastDashboardStateChange(guildId, 'clans_updated');
 
   // Lancement asynchrone non-bloquant
   (async () => {
@@ -79,12 +80,14 @@ export async function runDistribution(guildId: string, client: Client, initiator
         processed: i + 1,
         total: shuffledList.length,
       });
+      broadcastDashboardStateChange(guildId, 'clans_updated');
 
       await new Promise((resolve) => setTimeout(resolve, 450));
     }
 
     logger.info('ClanService', `Distribution équilibrée terminée pour "${discordGuild.name}"`);
     clanTasks.delete(guildId);
+    broadcastDashboardStateChange(guildId, 'clans_updated');
   })().catch((e) => logger.error('ClanService', 'Erreur critique dans le thread de distribution:', e));
 
   await pushAudit(guildId, {
@@ -136,6 +139,7 @@ export async function runClear(guildId: string, client: Client, initiatorName: s
 
   // Démarrer la tâche
   clanTasks.set(guildId, { type: 'clear', processed: 0, total: targetList.length });
+  broadcastDashboardStateChange(guildId, 'clans_updated');
 
   // Lancement asynchrone
   (async () => {
@@ -159,12 +163,14 @@ export async function runClear(guildId: string, client: Client, initiatorName: s
         processed: i + 1,
         total: targetList.length,
       });
+      broadcastDashboardStateChange(guildId, 'clans_updated');
 
       await new Promise((resolve) => setTimeout(resolve, 450));
     }
 
     logger.info('ClanService', `Retrait de tous les clans terminé pour "${discordGuild.name}"`);
     clanTasks.delete(guildId);
+    broadcastDashboardStateChange(guildId, 'clans_updated');
   })().catch((e) => logger.error('ClanService', 'Erreur critique dans le thread de retrait:', e));
 
   await pushAudit(guildId, {
@@ -424,24 +430,25 @@ export async function handleEndSeason(
         where: { id: guildId },
         data: { lastWinningClanId: winningClan.id },
       });
+    }
 
-      // Trouver le chef de coalition (meilleur contributeur réel) du clan gagnant
-      const topContributor = await prisma.clanMemberContribution.findFirst({
-        where: { guildId, clanId: winningClan.id, season: currentSeason, userId: { not: 'system_manual_points' } },
-        orderBy: { xp: 'desc' },
-      });
+    // 4. Attribuer le rôle de chef de clan pour chaque clan si activé
+    if (guildSettings.clanRewardLeaderRole) {
+      for (const clan of clans) {
+        if (!clan.leaderRoleId) continue;
 
-      if (topContributor && topContributor.xp > 0) {
-        leaderUserId = topContributor.userId;
-        leaderXp = topContributor.xp;
+        // Trouver le meilleur contributeur de ce clan pour la saison
+        const topContributor = await prisma.clanMemberContribution.findFirst({
+          where: { guildId, clanId: clan.id, season: currentSeason, userId: { not: 'system_manual_points' } },
+          orderBy: { xp: 'desc' },
+        });
 
-        // Attribuer le rôle de chef si configuré et activé
-        if (guildSettings.clanRewardLeaderRole && winningClan.leaderRoleId) {
-          const member = discordGuild.members.cache.get(leaderUserId) 
-            || await discordGuild.members.fetch(leaderUserId).catch(() => null);
+        if (topContributor && topContributor.xp > 0) {
+          const member = discordGuild.members.cache.get(topContributor.userId) 
+            || await discordGuild.members.fetch(topContributor.userId).catch(() => null);
           if (member) {
-            await member.roles.add(winningClan.leaderRoleId, `Sacre du Chef de Coalition - Fin de la Saison ${currentSeason}`).catch((err) => {
-              logger.warn('ClanService', `Impossible d'attribuer le rôle de chef de clan à ${member.user.tag}:`, err);
+            await member.roles.add(clan.leaderRoleId, `Chef du clan ${clan.name} - Fin de la Saison ${currentSeason}`).catch((err) => {
+              logger.warn('ClanService', `Impossible d'attribuer le rôle de chef du clan ${clan.name} à ${member.user.tag}:`, err);
             });
           }
         }

--- a/apps/dashboard/src/pages/Clans.svelte
+++ b/apps/dashboard/src/pages/Clans.svelte
@@ -2,6 +2,7 @@
   import { onMount, onDestroy, untrack } from 'svelte';
   import { fade, scale } from 'svelte/transition';
   import { dashboardStore } from '../lib/stores/dashboard.svelte';
+  import { authStore } from '../lib/stores/auth.svelte';
   import { createAsyncActionState } from '../lib/asyncAction.svelte';
   import { unsavedChanges } from '../lib/stores/unsavedChanges.svelte';
   import Papicon from '../lib/components/Papicon.svelte';
@@ -47,8 +48,10 @@
   // Season dates states
   let clanSeasonStartsAt = $state<string | null>(null);
   let clanSeasonEndsAt = $state<string | null>(null);
-  let formSeasonStartsAt = $state('');
-  let formSeasonEndsAt = $state('');
+  let startDate = $state('');
+  let startTime = $state('00:00');
+  let endDate = $state('');
+  let endTime = $state('00:00');
 
   // Saved states (for dirty checking)
   let savedClansEnabled = $state(false);
@@ -90,6 +93,7 @@
       if (!res) throw new Error('Erreur lors de l\'ajout de points au clan.');
       await refreshData(true);
       manualPointsAmountClan = 100;
+      return true;
     }, { successMessage: 'Points ajustés avec succès !' });
   }
 
@@ -105,6 +109,7 @@
       await refreshData(true);
       manualPointsMemberUserId = '';
       manualPointsAmountMember = 100;
+      return true;
     }, { successMessage: 'Points du membre ajustés avec succès !' });
   }
 
@@ -128,6 +133,51 @@
     return new Date(d.getTime() - tzOffset).toISOString().slice(0, 16);
   };
 
+  const formSeasonStartsAt = $derived(startDate ? `${startDate}T${startTime}` : '');
+  const formSeasonEndsAt = $derived(endDate ? `${endDate}T${endTime}` : '');
+
+  function parseDateToIso(dateVal: string, timeVal: string): string | null {
+    if (!dateVal) return null;
+    const combined = `${dateVal}T${timeVal || '00:00'}`;
+    const d = new Date(combined);
+    if (isNaN(d.getTime())) return null;
+    return d.toISOString();
+  }
+
+  function setSeasonDates(startsAt: string | null, endsAt: string | null) {
+    if (startsAt) {
+      const d = new Date(startsAt);
+      if (!isNaN(d.getTime())) {
+        const tzOffset = d.getTimezoneOffset() * 60000;
+        const localIso = new Date(d.getTime() - tzOffset).toISOString();
+        startDate = localIso.slice(0, 10);
+        startTime = localIso.slice(11, 16);
+      } else {
+        startDate = '';
+        startTime = '00:00';
+      }
+    } else {
+      startDate = '';
+      startTime = '00:00';
+    }
+
+    if (endsAt) {
+      const d = new Date(endsAt);
+      if (!isNaN(d.getTime())) {
+        const tzOffset = d.getTimezoneOffset() * 60000;
+        const localIso = new Date(d.getTime() - tzOffset).toISOString();
+        endDate = localIso.slice(0, 10);
+        endTime = localIso.slice(11, 16);
+      } else {
+        endDate = '';
+        endTime = '00:00';
+      }
+    } else {
+      endDate = '';
+      endTime = '00:00';
+    }
+  }
+
   // Sync state changes with the unsaved changes bar
   $effect(() => {
     const dirty = clansEnabled !== savedClansEnabled 
@@ -136,9 +186,7 @@
       || clanXpPerLevelUp !== savedClanXpPerLevelUp
       || clanAnnouncementChannelId !== savedClanAnnouncementChannelId
       || clanRewardGiveaway !== savedClanRewardGiveaway
-      || clanRewardLeaderRole !== savedClanRewardLeaderRole
-      || formSeasonStartsAt !== formatLocal(savedClanSeasonStartsAt)
-      || formSeasonEndsAt !== formatLocal(savedClanSeasonEndsAt);
+      || clanRewardLeaderRole !== savedClanRewardLeaderRole;
 
     if (dirty && canManageSettings) {
       untrack(() => {
@@ -153,8 +201,7 @@
             clanAnnouncementChannelId = savedClanAnnouncementChannelId;
             clanRewardGiveaway = savedClanRewardGiveaway;
             clanRewardLeaderRole = savedClanRewardLeaderRole;
-            formSeasonStartsAt = formatLocal(savedClanSeasonStartsAt);
-            formSeasonEndsAt = formatLocal(savedClanSeasonEndsAt);
+            setSeasonDates(savedClanSeasonStartsAt, savedClanSeasonEndsAt);
           }
         });
       });
@@ -167,13 +214,24 @@
     }
   });
 
-  // Polling mechanism while a background operation is active
+  function handleWsMessage(e: Event) {
+    const detail = (e as CustomEvent).detail;
+    if (
+      detail?.type === 'dashboard_state_changed' &&
+      detail?.guildId === authStore.selectedGuildId &&
+      detail?.reason === 'clans_updated'
+    ) {
+      void refreshData(true);
+    }
+  }
+
+  // Polling mechanism while a background operation is active (kept as fallback)
   let pollInterval: ReturnType<typeof setInterval> | null = null;
   $effect(() => {
     if (taskInProgress && !pollInterval) {
       pollInterval = setInterval(() => {
         void refreshData(true);
-      }, 2000);
+      }, 5000); // Polling plus espacé car doublé par les WebSockets
     } else if (!taskInProgress && pollInterval) {
       clearInterval(pollInterval);
       pollInterval = null;
@@ -181,6 +239,7 @@
   });
 
   onDestroy(() => {
+    window.removeEventListener('kotbo-ws-message', handleWsMessage);
     if (unsavedChanges.pageLabel === 'Configuration des Clans') {
       unsavedChanges.clear();
     }
@@ -233,21 +292,18 @@
         clans = res.clans;
         taskInProgress = res.taskInProgress;
 
-        // Formater les dates pour l'input type datetime-local (YYYY-MM-DDTHH:MM)
-        formSeasonStartsAt = formatLocal(res.clanSeasonStartsAt);
-        formSeasonEndsAt = formatLocal(res.clanSeasonEndsAt);
-
-        if (!silent) {
-          savedClansEnabled = res.clansEnabled;
-          savedClansUnique = res.clansUnique;
-          savedClanXpFromLevelUp = res.clanXpFromLevelUp;
-          savedClanXpPerLevelUp = res.clanXpPerLevelUp;
-          savedClanAnnouncementChannelId = res.clanAnnouncementChannelId;
-          savedClanRewardGiveaway = res.clanRewardGiveaway;
-          savedClanRewardLeaderRole = res.clanRewardLeaderRole;
-          savedClanSeasonStartsAt = res.clanSeasonStartsAt;
-          savedClanSeasonEndsAt = res.clanSeasonEndsAt;
-        }
+        // Formater les dates pour l'interface
+        setSeasonDates(res.clanSeasonStartsAt, res.clanSeasonEndsAt);
+        
+        savedClansEnabled = res.clansEnabled;
+        savedClansUnique = res.clansUnique;
+        savedClanXpFromLevelUp = res.clanXpFromLevelUp;
+        savedClanXpPerLevelUp = res.clanXpPerLevelUp;
+        savedClanAnnouncementChannelId = res.clanAnnouncementChannelId;
+        savedClanRewardGiveaway = res.clanRewardGiveaway;
+        savedClanRewardLeaderRole = res.clanRewardLeaderRole;
+        savedClanSeasonStartsAt = res.clanSeasonStartsAt;
+        savedClanSeasonEndsAt = res.clanSeasonEndsAt;
       }
     } catch (err) {
       console.error(err);
@@ -257,6 +313,7 @@
   }
 
   onMount(async () => {
+    window.addEventListener('kotbo-ws-message', handleWsMessage);
     await dashboardStore.refresh();
     await refreshData();
     const channelsData = await fetchDiscordChannels().catch(() => null);
@@ -282,8 +339,8 @@
         clanRewardLeaderRole,
         clanRewardXpBoost,
         clanRewardXpBoostRate,
-        clanSeasonStartsAt: formSeasonStartsAt ? new Date(formSeasonStartsAt).toISOString() : null,
-        clanSeasonEndsAt: formSeasonEndsAt ? new Date(formSeasonEndsAt).toISOString() : null
+        clanSeasonStartsAt: parseDateToIso(startDate, startTime),
+        clanSeasonEndsAt: parseDateToIso(endDate, endTime)
       });
       if (!res) throw new Error('Erreur de sauvegarde');
       
@@ -300,6 +357,58 @@
       return true;
     }, { successMessage: 'Paramètres des clans sauvegardés avec succès !' });
     return success;
+  }
+
+  async function handleSaveSeasonPlanning() {
+    if (!canManageSettings) return;
+    
+    const startsAtIso = parseDateToIso(startDate, startTime);
+    const endsAtIso = parseDateToIso(endDate, endTime);
+    
+    if (!startsAtIso || !endsAtIso) {
+      actionState.setError("Veuillez sélectionner des dates de début et de fin valides.");
+      return;
+    }
+    
+    if (new Date(startsAtIso) >= new Date(endsAtIso)) {
+      actionState.setError("La date de fin doit être postérieure à la date de début.");
+      return;
+    }
+
+    await actionState.run(async () => {
+      const res = await updateClanSettings({
+        clanSeasonStartsAt: startsAtIso,
+        clanSeasonEndsAt: endsAtIso
+      });
+      if (!res) throw new Error("Erreur de sauvegarde de la planification.");
+      
+      savedClanSeasonStartsAt = res.clanSeasonStartsAt;
+      savedClanSeasonEndsAt = res.clanSeasonEndsAt;
+      clanSeasonStartsAt = res.clanSeasonStartsAt;
+      clanSeasonEndsAt = res.clanSeasonEndsAt;
+      setSeasonDates(res.clanSeasonStartsAt, res.clanSeasonEndsAt);
+      return true;
+    }, { successMessage: 'Planification de la saison enregistrée avec succès !' });
+  }
+
+  async function handleClearSeasonPlanning() {
+    if (!canManageSettings) return;
+    if (!confirm("Voulez-vous vraiment annuler la planification de la saison ?")) return;
+
+    await actionState.run(async () => {
+      const res = await updateClanSettings({
+        clanSeasonStartsAt: null,
+        clanSeasonEndsAt: null
+      });
+      if (!res) throw new Error("Erreur lors de l'annulation de la planification.");
+      
+      savedClanSeasonStartsAt = null;
+      savedClanSeasonEndsAt = null;
+      clanSeasonStartsAt = null;
+      clanSeasonEndsAt = null;
+      setSeasonDates(null, null);
+      return true;
+    }, { successMessage: 'Planification de la saison réinitialisée !' });
   }
 
   function openCreateModal() {
@@ -743,26 +852,42 @@
             </h3>
 
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
+              <!-- Début de saison -->
               <div class="space-y-2">
-                <label for="clanSeasonStartsAtInput" class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest block ml-1">Date & Heure de Début</label>
-                <input
-                  id="clanSeasonStartsAtInput"
-                  type="datetime-local"
-                  bind:value={formSeasonStartsAt}
-                  class="w-full bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-4 py-2.5 text-sm text-on-surface focus:outline-none focus:ring-2 focus:ring-primary/30 transition-all font-medium"
-                  disabled={!canManageSettings}
-                />
+                <span class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest block ml-1">Début de la Saison</span>
+                <div class="grid grid-cols-3 gap-2">
+                  <input
+                    type="date"
+                    bind:value={startDate}
+                    class="col-span-2 bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-3 py-2.5 text-sm text-on-surface focus:outline-none focus:ring-2 focus:ring-primary/30 transition-all font-medium"
+                    disabled={!canManageSettings}
+                  />
+                  <input
+                    type="time"
+                    bind:value={startTime}
+                    class="col-span-1 bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-3 py-2.5 text-sm text-on-surface focus:outline-none focus:ring-2 focus:ring-primary/30 transition-all font-medium"
+                    disabled={!canManageSettings}
+                  />
+                </div>
               </div>
 
+              <!-- Fin de saison -->
               <div class="space-y-2">
-                <label for="clanSeasonEndsAtInput" class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest block ml-1">Date & Heure de Fin</label>
-                <input
-                  id="clanSeasonEndsAtInput"
-                  type="datetime-local"
-                  bind:value={formSeasonEndsAt}
-                  class="w-full bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-4 py-2.5 text-sm text-on-surface focus:outline-none focus:ring-2 focus:ring-primary/30 transition-all font-medium"
-                  disabled={!canManageSettings}
-                />
+                <span class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest block ml-1">Fin de la Saison</span>
+                <div class="grid grid-cols-3 gap-2">
+                  <input
+                    type="date"
+                    bind:value={endDate}
+                    class="col-span-2 bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-3 py-2.5 text-sm text-on-surface focus:outline-none focus:ring-2 focus:ring-primary/30 transition-all font-medium"
+                    disabled={!canManageSettings}
+                  />
+                  <input
+                    type="time"
+                    bind:value={endTime}
+                    class="col-span-1 bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-3 py-2.5 text-sm text-on-surface focus:outline-none focus:ring-2 focus:ring-primary/30 transition-all font-medium"
+                    disabled={!canManageSettings}
+                  />
+                </div>
               </div>
             </div>
 
@@ -770,6 +895,27 @@
               <p class="font-bold">💡 Fonctionnement Automatique</p>
               <p>Lorsque la date de fin est dépassée, le Bot lancera automatiquement le traitement de fin de saison. Si une date de début et de fin étaient configurées, le système calculera automatiquement l'intervalle et programmera la saison suivante pour la même durée.</p>
             </div>
+
+            {#if canManageSettings}
+              <div class="flex items-center justify-end gap-3 pt-4 border-t border-outline-variant/10">
+                <button
+                  type="button"
+                  onclick={handleClearSeasonPlanning}
+                  class="px-4 py-2 border border-outline-variant/30 text-on-surface hover:bg-surface-container-high/40 font-semibold text-xs rounded-lg transition-colors cursor-pointer"
+                  disabled={!savedClanSeasonStartsAt && !savedClanSeasonEndsAt && !startDate && !endDate}
+                >
+                  Annuler la planification
+                </button>
+                <button
+                  type="button"
+                  onclick={handleSaveSeasonPlanning}
+                  class="px-4 py-2 bg-primary hover:bg-primary-hover text-on-primary font-semibold text-xs rounded-lg transition-colors cursor-pointer"
+                  disabled={!startDate || !endDate}
+                >
+                  Enregistrer la planification
+                </button>
+              </div>
+            {/if}
           </section>
         </div>
 

--- a/apps/dashboard/src/pages/Leveling.svelte
+++ b/apps/dashboard/src/pages/Leveling.svelte
@@ -607,7 +607,7 @@
                     <SearchableSelect 
                       id="multRole"
                       bind:value={newMultRoleId}
-                      options={availableRoles.filter(r => !Object.keys(config.xpMultipliers).includes(r.id)).map(r => ({ id: r.id, name: `@${r.name}` }))} 
+                      options={availableRoles.filter(r => !Object.keys(config.xpMultipliers).includes(r.id) && !(clanRewardXpBoost && lastWinningClanId && clans.find(c => c.id === lastWinningClanId)?.roleId === r.id)).map(r => ({ id: r.id, name: `@${r.name}` }))} 
                       placeholder="Choisir un rôle" 
                       className="w-full bg-surface-container-high/40 border border-outline-variant/10 rounded-lg"
                       clearable={true}
@@ -650,6 +650,24 @@
                     </tr>
                   </thead>
                   <tbody class="divide-y divide-outline-variant/5">
+                    {#if clanRewardXpBoost && lastWinningClanId && clans.find(c => c.id === lastWinningClanId)}
+                      {@const winningClan = clans.find(c => c.id === lastWinningClanId)}
+                      {#if winningClan.roleId}
+                        <tr class="bg-amber-500/10 border-l-4 border-amber-500 transition-all font-semibold">
+                          <td class="px-6 py-3.5 text-sm font-semibold flex items-center gap-2">
+                            <span>🏆 {getRoleName(winningClan.roleId)}</span>
+                            <span class="text-[9px] uppercase tracking-wider bg-amber-500/20 text-amber-500 px-1.5 py-0.5 rounded font-bold">Clan Gagnant (Boost XP)</span>
+                          </td>
+                          <td class="px-6 py-3.5 text-sm font-semibold text-amber-500">{clanRewardXpBoostRate}x</td>
+                          {#if canManageSettings}
+                            <td class="px-6 py-3.5 text-right text-xs text-on-surface-variant/60 font-medium italic">
+                              Actif (Géré automatiquement)
+                            </td>
+                          {/if}
+                        </tr>
+                      {/if}
+                    {/if}
+
                     {#each Object.entries(config.xpMultipliers) as [roleId, mult]}
                       <tr class="hover:bg-surface-hover/20 transition-all font-semibold">
                         <td class="px-6 py-3.5 text-sm font-semibold">{getRoleName(roleId)}</td>
@@ -667,11 +685,13 @@
                           </td>
                         {/if}
                       </tr>
-                    {:else}
+                    {/each}
+
+                    {#if Object.keys(config.xpMultipliers).length === 0 && !(clanRewardXpBoost && lastWinningClanId && clans.find(c => c.id === lastWinningClanId)?.roleId)}
                       <tr>
                         <td colspan={canManageSettings ? 3 : 2} class="px-6 py-6 text-center text-xs text-on-surface-variant/60 font-medium">Aucun multiplicateur configuré.</td>
                       </tr>
-                    {/each}
+                    {/if}
                   </tbody>
                 </table>
               </div>


### PR DESCRIPTION
## 📝 Description
Mise a jour sur les fonctionnaliter des clans

## 🎯 Changements principaux
- Role de chef attribuer a chaque premier de clan
- changement dans les websockets
- correction des erreur visuel quand on ajoute des points depuis le dashboard
- ajout d'une option boost d'xp pour les vaiqueurs
- affichage vusuel d'un boost d'xp pour les vainqueurs
- mise a jour du message d'annonce qui avait quelques soucis
