### PR TITLE
feat(clans): add season history, double accounts pooling, and dashboard administration tools

### DIFF
--- a/apps/bot/src/api/routes/dashboard/clans.ts
+++ b/apps/bot/src/api/routes/dashboard/clans.ts
@@ -383,7 +383,7 @@ export async function handleClansRoutes(
     try {
       const guild = await prisma.guild.findUnique({
         where: { id: guildId },
-        select: { currentClanSeason: true },
+        select: { currentClanSeason: true, clanSeasonStartsAt: true, clanSeasonEndsAt: true },
       });
 
       if (!guild) {
@@ -393,13 +393,26 @@ export async function handleClansRoutes(
 
       const nextSeason = guild.currentClanSeason + 1;
 
+      let nextStartsAt: Date | null = null;
+      let nextEndsAt: Date | null = null;
+
+      if (guild.clanSeasonStartsAt && guild.clanSeasonEndsAt) {
+        const durationMs = guild.clanSeasonEndsAt.getTime() - guild.clanSeasonStartsAt.getTime();
+        nextStartsAt = new Date();
+        nextEndsAt = new Date(nextStartsAt.getTime() + durationMs);
+      }
+
       // 1. Décerner les bonus, renommer les QG et publier les annonces de fin de saison
       await handleEndSeason(guildId, client, auditUser, guild.currentClanSeason, nextSeason);
 
       // 2. Mettre à jour la saison en base de données
       await prisma.guild.update({
         where: { id: guildId },
-        data: { currentClanSeason: nextSeason },
+        data: { 
+          currentClanSeason: nextSeason,
+          clanSeasonStartsAt: nextStartsAt,
+          clanSeasonEndsAt: nextEndsAt,
+        },
       });
 
       await pushAudit(guildId, {
@@ -422,30 +435,195 @@ export async function handleClansRoutes(
     return true;
   }
 
+  // POST /api/dashboard/guilds/:guildId/clans/reset-all (Reset All Data)
+  if (subAction === 'reset-all' && method === 'POST') {
+    try {
+      // 1. Supprimer toutes les contributions
+      await prisma.clanMemberContribution.deleteMany({
+        where: { guildId }
+      });
+
+      // 2. Supprimer tous les clans du serveur
+      await prisma.clan.deleteMany({
+        where: { guildId }
+      });
+
+      // 3. Réinitialiser la guilde
+      await prisma.guild.update({
+        where: { id: guildId },
+        data: {
+          currentClanSeason: 1,
+          lastWinningClanId: null,
+          clanSeasonStartsAt: null,
+          clanSeasonEndsAt: null,
+          clansEnabled: false,
+        }
+      });
+
+      // 4. Audit
+      await pushAudit(guildId, {
+        user: auditUser,
+        action: 'Réinitialisation Totale des Clans',
+        context: getGuildName(client, guildId),
+        module: 'Clans',
+        eventType: 'Manuel',
+        details: 'Réinitialisation totale des clans, contributions et retour à la saison 1.',
+        channelId: null,
+      });
+
+      broadcastDashboardStateChange(guildId, 'clans_updated');
+
+      json(res, 200, { success: true });
+    } catch (err: any) {
+      logger.error('ClansAPI', 'Error resetting all clan data:', err);
+      json(res, 500, { error: 'Erreur lors de la réinitialisation des données de clans.' });
+    }
+    return true;
+  }
+
+  // POST /api/dashboard/guilds/:guildId/clans/rollback-season (Rollback Last Season)
+  if (subAction === 'rollback-season' && method === 'POST') {
+    try {
+      const guild = await prisma.guild.findUnique({
+        where: { id: guildId },
+        select: { currentClanSeason: true, clanRewardLeaderRole: true }
+      });
+
+      if (!guild) {
+        json(res, 404, { error: 'Serveur introuvable.' });
+        return true;
+      }
+
+      const currentSeason = guild.currentClanSeason;
+      if (currentSeason <= 1) {
+        json(res, 400, { error: 'Impossible de retourner en arrière de la saison 1.' });
+        return true;
+      }
+
+      const targetSeason = currentSeason - 1;
+      const restoredSeason = targetSeason - 1; // La saison qui a déterminé le vainqueur de targetSeason
+
+      // 1. Trouver le vainqueur de la saison restoredSeason (si >= 1)
+      let restoredWinningClanId: string | null = null;
+      if (restoredSeason >= 1) {
+        const clans = await prisma.clan.findMany({ where: { guildId } });
+        let maxXp = 0;
+        for (const clan of clans) {
+          const aggregate = await prisma.clanMemberContribution.aggregate({
+            where: { guildId, clanId: clan.id, season: restoredSeason },
+            _sum: { xp: true }
+          });
+          const xp = aggregate._sum.xp ?? 0;
+          if (xp > maxXp) {
+            maxXp = xp;
+            restoredWinningClanId = clan.id;
+          }
+        }
+      }
+
+      // 2. Mettre à jour la guilde
+      await prisma.guild.update({
+        where: { id: guildId },
+        data: {
+          currentClanSeason: targetSeason,
+          lastWinningClanId: restoredWinningClanId,
+          clanSeasonStartsAt: null,
+          clanSeasonEndsAt: null,
+        }
+      });
+
+      // 3. Supprimer toutes les contributions de la saison "annulée" (currentSeason)
+      await prisma.clanMemberContribution.deleteMany({
+        where: { guildId, season: currentSeason }
+      });
+
+      // 4. Rétablir les rôles de chefs de clan
+      const clans = await prisma.clan.findMany({ where: { guildId } });
+      const discordGuild = client.guilds.cache.get(guildId) || await client.guilds.fetch(guildId).catch(() => null);
+      if (discordGuild) {
+        // Retirer les chefs actuels
+        for (const clan of clans) {
+          if (clan.leaderRoleId) {
+            const role = discordGuild.roles.cache.get(clan.leaderRoleId) || await discordGuild.roles.fetch(clan.leaderRoleId).catch(() => null);
+            if (role) {
+              for (const [, m] of role.members) {
+                await m.roles.remove(clan.leaderRoleId, "Annulation clôture saison").catch(() => null);
+              }
+            }
+          }
+        }
+
+        // Rétablir les chefs de restoredSeason
+        if (guild.clanRewardLeaderRole && restoredSeason >= 1) {
+          for (const clan of clans) {
+            if (clan.leaderRoleId) {
+              const top = await prisma.clanMemberContribution.findFirst({
+                where: { guildId, clanId: clan.id, season: restoredSeason, userId: { not: 'system_manual_points' } },
+                orderBy: { xp: 'desc' }
+              });
+              if (top && top.xp > 0) {
+                const member = discordGuild.members.cache.get(top.userId) || await discordGuild.members.fetch(top.userId).catch(() => null);
+                if (member) {
+                  await member.roles.add(clan.leaderRoleId, `Rétablissement chef saison ${restoredSeason}`).catch(() => null);
+                }
+              }
+            }
+          }
+        }
+
+        // 5. Renommer les catégories QG pour le vainqueur rétabli
+        const { ChannelType } = await import('discord.js');
+        for (const clan of clans) {
+          if (clan.generalChannelId) {
+            const channel = discordGuild.channels.cache.get(clan.generalChannelId) || await discordGuild.channels.fetch(clan.generalChannelId).catch(() => null);
+            if (channel && channel.type === ChannelType.GuildCategory) {
+              const isWinner = restoredWinningClanId && clan.id === restoredWinningClanId;
+              const cleanName = channel.name.replace(/^\[🏆\s*.*?\]\s*/, '');
+              const targetName = isWinner ? `[🏆 ${clan.name}] ${cleanName}` : cleanName;
+              if (channel.name !== targetName) {
+                await channel.setName(targetName, "Annulation clôture saison").catch(() => null);
+              }
+            }
+          }
+        }
+      }
+
+      // 6. Audit
+      await pushAudit(guildId, {
+        user: auditUser,
+        action: 'Annulation Clôture de Saison',
+        context: getGuildName(client, guildId),
+        module: 'Clans',
+        eventType: 'Manuel',
+        details: `Retour à la saison ${targetSeason} depuis la saison ${currentSeason}. Données de la saison ${currentSeason} supprimées.`,
+        channelId: null,
+      });
+
+      broadcastDashboardStateChange(guildId, 'clans_updated');
+
+      json(res, 200, { currentClanSeason: targetSeason });
+    } catch (err: any) {
+      logger.error('ClansAPI', 'Error rolling back clan season:', err);
+      json(res, 500, { error: 'Erreur lors de l\'annulation de la saison.' });
+    }
+    return true;
+  }
+
   // POST /api/dashboard/guilds/:guildId/clans/points (Add points manually to a clan or a member)
   if (subAction === 'points' && method === 'POST') {
     try {
       const body = await readJsonBody<{
-        clanId: string;
+        clanId?: string | null;
         userId?: string | null;
         amount: number;
       }>(req);
 
-      if (!body?.clanId || typeof body.amount !== 'number') {
-        json(res, 400, { error: 'Paramètres clanId et amount (nombre) requis.' });
+      if (typeof body.amount !== 'number') {
+        json(res, 400, { error: 'Le paramètre amount (nombre) est requis.' });
         return true;
       }
 
-      // 1. Vérifier si le clan existe
-      const clan = await prisma.clan.findUnique({
-        where: { id: body.clanId }
-      });
-      if (!clan || clan.guildId !== guildId) {
-        json(res, 404, { error: 'Clan introuvable pour ce serveur.' });
-        return true;
-      }
-
-      // 2. Récupérer la saison en cours
+      // 1. Récupérer la saison en cours
       const guild = await prisma.guild.findUnique({
         where: { id: guildId },
         select: { currentClanSeason: true }
@@ -454,16 +632,76 @@ export async function handleClansRoutes(
         json(res, 404, { error: 'Serveur introuvable.' });
         return true;
       }
-
       const season = guild.currentClanSeason;
-      const targetUserId = body.userId?.trim() || 'system_manual_points';
 
-      // 3. Upsert la contribution
+      let resolvedClanId: string;
+      let resolvedClanName: string;
+      let targetUserId: string;
+
+      if (body.userId?.trim()) {
+        const userId = body.userId.trim();
+        // Vérifier si l'utilisateur existe dans la base de données
+        const dbMember = await prisma.member.findUnique({
+          where: { id: userId }
+        });
+        if (!dbMember) {
+          json(res, 404, { error: "L'utilisateur n'existe pas dans la base de données de Kotbo (il doit interagir sur Discord d'abord)." });
+          return true;
+        }
+
+        // Récupérer le membre Discord et ses rôles
+        const discordGuild = client.guilds.cache.get(guildId) || await client.guilds.fetch(guildId).catch(() => null);
+        if (!discordGuild) {
+          json(res, 500, { error: "Impossible d'accéder au serveur Discord." });
+          return true;
+        }
+
+        const member = discordGuild.members.cache.get(userId) || await discordGuild.members.fetch(userId).catch(() => null);
+        if (!member) {
+          json(res, 404, { error: "L'utilisateur est introuvable sur le serveur Discord." });
+          return true;
+        }
+
+        const clans = await prisma.clan.findMany({ where: { guildId } });
+        const memberClan = clans.find(c => member.roles.cache.has(c.roleId));
+        if (!memberClan) {
+          json(res, 400, { error: "Ce membre n'appartient à aucun clan configuré sur Discord." });
+          return true;
+        }
+
+        resolvedClanId = memberClan.id;
+        resolvedClanName = memberClan.name;
+
+        // Résoudre l'identifiant Double Compte (DC) canonique
+        const { getAllLinkedUserIds } = await import('../../../services/moderation/altAccountService.js');
+        const linkedIds = await getAllLinkedUserIds(guildId, userId).catch(() => [userId]);
+        targetUserId = linkedIds.sort()[0];
+      } else {
+        if (!body.clanId) {
+          json(res, 400, { error: 'Le paramètre clanId est requis si aucun utilisateur n\'est spécifié.' });
+          return true;
+        }
+
+        // Vérifier si le clan existe
+        const clan = await prisma.clan.findUnique({
+          where: { id: body.clanId }
+        });
+        if (!clan || clan.guildId !== guildId) {
+          json(res, 404, { error: 'Clan introuvable pour ce serveur.' });
+          return true;
+        }
+
+        resolvedClanId = clan.id;
+        resolvedClanName = clan.name;
+        targetUserId = 'system_manual_points';
+      }
+
+      // 2. Upsert la contribution
       const contribution = await prisma.clanMemberContribution.upsert({
         where: {
           guildId_clanId_userId_season: {
             guildId,
-            clanId: body.clanId,
+            clanId: resolvedClanId,
             userId: targetUserId,
             season,
           }
@@ -473,7 +711,7 @@ export async function handleClansRoutes(
         },
         create: {
           guildId,
-          clanId: body.clanId,
+          clanId: resolvedClanId,
           userId: targetUserId,
           season,
           xp: body.amount
@@ -486,7 +724,7 @@ export async function handleClansRoutes(
         context: getGuildName(client, guildId),
         module: 'Clans',
         eventType: 'Manuel',
-        details: `Ajout manuel de ${body.amount} XP au clan "${clan.name}"` + (body.userId ? ` pour l'utilisateur ${body.userId}` : ' (global)'),
+        details: `Ajout manuel de ${body.amount} XP au clan "${resolvedClanName}"` + (body.userId ? ` pour l'utilisateur ${body.userId}` : ' (global)'),
         channelId: null,
       });
 

--- a/apps/bot/src/commands/community/clan.ts
+++ b/apps/bot/src/commands/community/clan.ts
@@ -5,6 +5,9 @@ import {
   PermissionFlagsBits,
   EmbedBuilder,
   MessageFlags,
+  StringSelectMenuBuilder,
+  StringSelectMenuOptionBuilder,
+  ActionRowBuilder,
 } from 'discord.js';
 import type { SlashCommandDefinition } from '../../commands.js';
 import prisma from '../../utils/db.js';
@@ -35,6 +38,17 @@ export const data = new SlashCommandBuilder()
           .setDescription('Le nom du clan')
           .setRequired(true)
           .setAutocomplete(true)
+      )
+  )
+  .addSubcommand((sub) =>
+    sub
+      .setName('historique')
+      .setDescription('📜 Affiche l\'historique des saisons passées')
+      .addIntegerOption((opt) =>
+        opt
+          .setName('saison')
+          .setDescription('Le numéro de la saison à consulter (ex: 5)')
+          .setRequired(false)
       )
   )
   .addSubcommand((sub) =>
@@ -220,7 +234,7 @@ export async function execute(interaction: ChatInputCommandInteraction) {
         .setTitle(`🛡️ Clan ${clan.name}`)
         .setDescription(clan.description || '*Aucune description.*')
         .addFields(
-          { name: 'Rôle Discord', value: role ? `<@&${role.id}>` : `ID: ${clan.roleId}`, inline: true },
+          { name: 'Rôle Discord', value: role ? `@${role.name}` : `ID: ${clan.roleId}`, inline: true },
           { name: 'Membres actifs', value: `\`${memberCount}\``, inline: true },
           { name: 'XP de Saison', value: `\`${totalXp.toLocaleString('fr-FR')} XP\``, inline: true }
         )
@@ -241,6 +255,36 @@ export async function execute(interaction: ChatInputCommandInteraction) {
       });
 
       await interaction.editReply({ embeds: [embed] });
+    }
+
+    // ── SUBCOMMAND: historique ────────────────────────────────────────────────
+    if (sub === 'historique') {
+      await interaction.deferReply({ flags: [MessageFlags.Ephemeral] });
+
+      const guildSettings = await prisma.guild.findUnique({
+        where: { id: guildId },
+        select: { currentClanSeason: true }
+      });
+
+      const currentSeason = guildSettings?.currentClanSeason ?? 1;
+      if (currentSeason <= 1) {
+        await interaction.editReply('❌ Aucun historique de saison n\'est disponible pour le moment. La Saison 1 est toujours en cours !');
+        return;
+      }
+
+      const inputSeason = interaction.options.getInteger('saison');
+      const targetSeason = inputSeason !== null ? inputSeason : (currentSeason - 1);
+
+      if (targetSeason < 1 || targetSeason >= currentSeason) {
+        await interaction.editReply(`❌ Saison invalide. Veuillez spécifier une saison passée (entre 1 et ${currentSeason - 1}).`);
+        return;
+      }
+
+      const embed = await renderSeasonHistoryEmbed(guildId, targetSeason, interaction.guild!);
+
+      await interaction.editReply({
+        embeds: [embed]
+      });
       return;
     }
 
@@ -292,3 +336,79 @@ export async function execute(interaction: ChatInputCommandInteraction) {
 }
 
 export const clanCommand = { data, autocomplete, execute } satisfies SlashCommandDefinition;
+
+// ── HELPER: Rendu de l'historique d'une saison ────────────────────────────────
+export async function renderSeasonHistoryEmbed(guildId: string, season: number, discordGuild: any) {
+  // 1. Récupérer les clans
+  const clans = await prisma.clan.findMany({ where: { guildId } });
+
+  // 2. Calculer l'XP totale par clan pour cette saison
+  const clansWithXp = await Promise.all(
+    clans.map(async (clan) => {
+      const aggregate = await prisma.clanMemberContribution.aggregate({
+        where: { guildId, clanId: clan.id, season },
+        _sum: { xp: true },
+      });
+      const totalXp = aggregate._sum.xp ?? 0;
+      return { clan, totalXp };
+    })
+  );
+
+  // Trier les clans par XP décroissante
+  clansWithXp.sort((a, b) => b.totalXp - a.totalXp);
+
+  // Trouver le vainqueur (XP > 0)
+  let winningClan = null;
+  if (clansWithXp.length > 0 && clansWithXp[0].totalXp > 0) {
+    winningClan = clansWithXp[0].clan;
+  }
+
+  // 3. Trouver le meilleur contributeur pour chaque clan
+  const leaders: { clanName: string; userName: string; xp: number }[] = [];
+  for (const clan of clans) {
+    const top = await prisma.clanMemberContribution.findFirst({
+      where: { guildId, clanId: clan.id, season, userId: { not: 'system_manual_points' } },
+      orderBy: { xp: 'desc' },
+    });
+    if (top) {
+      const member = await discordGuild.members.fetch(top.userId).catch(() => null);
+      const name = member ? member.displayName : `Utilisateur ${top.userId}`;
+      leaders.push({ clanName: clan.name, userName: name, xp: top.xp });
+    }
+  }
+
+  const embed = new EmbedBuilder()
+    .setColor(0xF59E0B) // Amber/Gold color
+    .setTitle(`📜 Historique de la Saison de Clans ${season}`)
+    .setTimestamp();
+
+  let desc = '';
+  if (winningClan) {
+    desc += `🏆 **Clan Vainqueur** : **${winningClan.name}** (\`${clansWithXp[0].totalXp.toLocaleString('fr-FR')} XP\`)\n\n`;
+  } else {
+    desc += `🏆 **Clan Vainqueur** : *Aucun vainqueur* (aucun point marqué)\n\n`;
+  }
+
+  // Classement des clans
+  desc += `**📊 Classement des Clans :**\n`;
+  if (clansWithXp.length > 0 && clansWithXp.some(c => c.totalXp > 0)) {
+    for (let i = 0; i < clansWithXp.length; i++) {
+      const c = clansWithXp[i];
+      desc += `${rankEmoji(i + 1)} **${c.clan.name}** : \`${c.totalXp.toLocaleString('fr-FR')} XP\`\n`;
+    }
+  } else {
+    desc += `*Aucun point enregistré.*\n`;
+  }
+
+  desc += `\n**👑 Meilleurs Contributeurs par Clan :**\n`;
+  if (leaders.length > 0) {
+    for (const leader of leaders) {
+      desc += `▸ **${leader.clanName}** : **${leader.userName}** (\`${leader.xp.toLocaleString('fr-FR')} XP\`)\n`;
+    }
+  } else {
+    desc += `*Aucun contributeur.*`;
+  }
+
+  embed.setDescription(desc);
+  return embed;
+}

--- a/apps/bot/src/events/crons.ts
+++ b/apps/bot/src/events/crons.ts
@@ -399,13 +399,13 @@ export async function registerCrons(client: Client): Promise<void> {
     }, 3000);
   }, { timezone: 'Europe/Paris' });
 
-  // 🛡️ Clan Seasons: Vérification quotidienne à 0h05
-  cron.schedule('5 0 * * *', async () => {
+  // 🛡️ Clan Seasons: Vérification toutes les 15 minutes
+  cron.schedule('*/15 * * * *', async () => {
     await runCronJob('clan-season-check', async () => {
       const { checkAndProgressClanSeasons } = await import('../services/community/clanService.js');
       await checkAndProgressClanSeasons(client);
     }, 3000);
-  }, { timezone: 'Europe/Paris' });
+  });
 
   // 🏪 Marketplace: Expiration des annonces toutes les 10 minutes
   cron.schedule('*/10 * * * *', async () => {

--- a/apps/bot/src/services/community/clanService.ts
+++ b/apps/bot/src/services/community/clanService.ts
@@ -441,6 +441,12 @@ export async function handleEndSeason(
         leaderUserId = topWinnerContributor.userId;
         leaderXp = topWinnerContributor.xp;
       }
+    } else {
+      // Pas de vainqueur cette saison, reset lastWinningClanId
+      await prisma.guild.update({
+        where: { id: guildId },
+        data: { lastWinningClanId: null },
+      });
     }
 
     // 4. Attribuer le rôle de chef de clan pour chaque clan si activé

--- a/apps/bot/src/services/progression/levelingService.ts
+++ b/apps/bot/src/services/progression/levelingService.ts
@@ -234,12 +234,16 @@ async function processLevelUp(guildId: string, userId: string, newLevel: number,
           if (memberClanRole) {
             const clan = clans.find(c => c.roleId === memberClanRole.id);
             if (clan) {
+              const { getAllLinkedUserIds } = await import('../moderation/altAccountService.js');
+              const linkedIds = await getAllLinkedUserIds(guildId, userId).catch(() => [userId]);
+              const canonicalUserId = linkedIds.sort()[0];
+
               await prisma.clanMemberContribution.upsert({
                 where: {
                   guildId_clanId_userId_season: {
                     guildId,
                     clanId: clan.id,
-                    userId,
+                    userId: canonicalUserId,
                     season: guildConfig.currentClanSeason
                   }
                 },
@@ -249,7 +253,7 @@ async function processLevelUp(guildId: string, userId: string, newLevel: number,
                 create: {
                   guildId,
                   clanId: clan.id,
-                  userId,
+                  userId: canonicalUserId,
                   season: guildConfig.currentClanSeason,
                   xp: guildConfig.clanXpPerLevelUp
                 }

--- a/apps/bot/src/utils/emojis.ts
+++ b/apps/bot/src/utils/emojis.ts
@@ -191,6 +191,7 @@ export async function loadApplicationEmojis(client: Client): Promise<void> {
         loaded++;
       } else {
         logger.warn('Emojis', `Emoji d'application "${discordName}" introuvable, fallback: ${UNICODE_FALLBACKS[key] || '?'}`);
+        emojiStore[key] = UNICODE_FALLBACKS[key] || '';
       }
     }
 

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -3283,8 +3283,24 @@ export async function resetClanSeason(guildId = authStore.selectedGuildId): Prom
   });
 }
 
+export async function resetAllClans(guildId = authStore.selectedGuildId): Promise<{ success: boolean } | null> {
+  return dashboardRequest('/clans/reset-all', {
+    method: 'POST',
+    guildId,
+    errorContext: 'API Error (Reset All Clans):',
+  });
+}
+
+export async function rollbackClanSeason(guildId = authStore.selectedGuildId): Promise<{ currentClanSeason: number } | null> {
+  return dashboardRequest('/clans/rollback-season', {
+    method: 'POST',
+    guildId,
+    errorContext: 'API Error (Rollback Clan Season):',
+  });
+}
+
 export async function addClanPoints(
-  payload: { clanId: string; userId?: string | null; amount: number },
+  payload: { clanId?: string | null; userId?: string | null; amount: number },
   guildId = authStore.selectedGuildId
 ): Promise<{ success: boolean; contribution?: any } | null> {
   return dashboardRequest('/clans/points', {

--- a/apps/dashboard/src/pages/Clans.svelte
+++ b/apps/dashboard/src/pages/Clans.svelte
@@ -21,6 +21,8 @@
     distributeClans,
     clearClans,
     resetClanSeason,
+    resetAllClans,
+    rollbackClanSeason,
     addClanPoints,
     type ClanEntry,
     type ClansDataResult
@@ -65,7 +67,7 @@
   let savedClanSeasonEndsAt = $state<string | null>(null);
 
   // Tab routing
-  let activeTab = $state<'clans' | 'seasons' | 'points'>('clans');
+  let activeTab = $state<'clans' | 'seasons' | 'points' | 'admin'>('clans');
 
   // Form states
   let formName = $state('');
@@ -79,7 +81,6 @@
   // Points Management tab states & handlers
   let selectedClanIdForPoints = $state('');
   let manualPointsAmountClan = $state(100);
-  let selectedClanIdForMemberPoints = $state('');
   let manualPointsMemberUserId = $state('');
   let manualPointsAmountMember = $state(100);
 
@@ -98,10 +99,10 @@
   }
 
   async function handleAddMemberPoints() {
-    if (!canManageSettings || !selectedClanIdForMemberPoints || !manualPointsMemberUserId || !manualPointsAmountMember) return;
+    if (!canManageSettings || !manualPointsMemberUserId || !manualPointsAmountMember) return;
     await actionState.run(async () => {
       const res = await addClanPoints({
-        clanId: selectedClanIdForMemberPoints,
+        clanId: null,
         userId: manualPointsMemberUserId,
         amount: manualPointsAmountMember,
       });
@@ -113,9 +114,9 @@
     }, { successMessage: 'Points du membre ajustés avec succès !' });
   }
 
-  // Confirmation state for reset/clear/distribute
+  // Confirmation state for reset/clear/distribute/reset-all/rollback
   let confirmInput = $state('');
-  let confirmActionType = $state<'clear' | 'reset' | 'distribute' | null>(null);
+  let confirmActionType = $state<'clear' | 'reset' | 'distribute' | 'reset-all' | 'rollback' | null>(null);
   let showConfirmModal = $state(false);
 
   const canManageSettings = $derived(
@@ -472,7 +473,7 @@
     }, { successMessage: 'Clan supprimé.' });
   }
 
-  function openConfirmation(type: 'clear' | 'reset' | 'distribute') {
+  function openConfirmation(type: 'clear' | 'reset' | 'distribute' | 'reset-all' | 'rollback') {
     confirmActionType = type;
     confirmInput = '';
     showConfirmModal = true;
@@ -485,9 +486,13 @@
       ? 'RETIRER' 
       : confirmActionType === 'reset' 
       ? 'RESET' 
-      : 'DISTRIBUER';
+      : confirmActionType === 'distribute'
+      ? 'DISTRIBUER'
+      : confirmActionType === 'reset-all'
+      ? 'RESET ALL'
+      : 'ANNULER';
 
-    if (confirmInput.toUpperCase() !== expected) {
+    if (confirmInput.toUpperCase() !== expected.toUpperCase()) {
       alert('Veuillez saisir le mot de confirmation correct.');
       return;
     }
@@ -508,6 +513,17 @@
         const res = await distributeClans();
         if (!res) throw new Error('Erreur lors du lancement');
         await refreshData(true);
+      } else if (confirmActionType === 'reset-all') {
+        const res = await resetAllClans();
+        if (!res) throw new Error('Erreur lors de la réinitialisation complète');
+        clansEnabled = false;
+        currentClanSeason = 1;
+        await refreshData(true);
+      } else if (confirmActionType === 'rollback') {
+        const res = await rollbackClanSeason();
+        if (!res) throw new Error('Erreur lors de l\'annulation');
+        currentClanSeason = res.currentClanSeason;
+        await refreshData(true);
       }
       return true;
     }, {
@@ -515,7 +531,11 @@
         ? 'Retrait de tous les rôles démarré en arrière-plan.'
         : confirmActionType === 'reset'
         ? 'Nouvelle saison de clans démarrée !'
-        : 'Distribution aléatoire lancée en arrière-plan.'
+        : confirmActionType === 'distribute'
+        ? 'Distribution aléatoire lancée en arrière-plan.'
+        : confirmActionType === 'reset-all'
+        ? 'Toutes les données de clans ont été réinitialisées !'
+        : 'La clôture de la saison a bien été annulée.'
     });
   }
 
@@ -556,6 +576,12 @@
       onclick={() => activeTab = 'points'}
     >
       ⚡ Gestion des Points
+    </button>
+    <button
+      class="px-5 py-3 text-sm font-semibold border-b-2 transition-all cursor-pointer {activeTab === 'admin' ? 'border-primary text-primary font-bold bg-primary/5 rounded-t-lg' : 'border-transparent text-on-surface-variant/70 hover:text-on-surface hover:bg-surface-container-low/30'}"
+      onclick={() => activeTab = 'admin'}
+    >
+      ⚙️ Administration
     </button>
   </div>
 
@@ -1016,17 +1042,6 @@
 
             <div class="space-y-4">
               <div class="space-y-1.5">
-                <label for="manual-points-member-clan-select" class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest block ml-1">Sélectionner son Clan</label>
-                <SearchableSelect
-                  id="manual-points-member-clan-select"
-                  bind:value={selectedClanIdForMemberPoints}
-                  options={clans.map(c => ({ id: c.id, name: c.name }))}
-                  placeholder="Choisir un clan"
-                  disabled={!canManageSettings}
-                />
-              </div>
-
-              <div class="space-y-1.5">
                 <label for="manual-points-member-user-id" class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest block ml-1">ID Discord du Membre</label>
                 <input
                   id="manual-points-member-user-id"
@@ -1054,7 +1069,7 @@
                   type="button"
                   onclick={handleAddMemberPoints}
                   class="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-secondary hover:bg-secondary/80 text-white font-semibold text-xs rounded-lg transition-colors cursor-pointer"
-                  disabled={!selectedClanIdForMemberPoints || !manualPointsMemberUserId}
+                  disabled={!manualPointsMemberUserId}
                 >
                   ⚡ Ajuster les points du Membre
                 </button>
@@ -1063,8 +1078,69 @@
           </section>
 
         </div>
+      {:else if activeTab === 'admin'}
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6" transition:fade={{ duration: 150 }}>
+          
+          <!-- Card 1: Recommencer à la Saison 1 (Reset All) -->
+          <section class="bg-surface-container-low/40 border border-rose-500/20 p-6 rounded-xl space-y-6 flex flex-col justify-between">
+            <div class="space-y-4">
+              <h3 class="text-lg font-semibold border-b border-rose-500/10 pb-2 flex items-center gap-2 text-rose-500">
+                <Papicon icon="AlertTriangle" size={16} />
+                Réinitialisation Totale
+              </h3>
+              
+              <p class="text-xs text-on-surface-variant/80 leading-relaxed">
+                Ce bouton permet de <strong>réinitialiser complètement toutes les données liées aux clans</strong>. Tous les clans configurés, les rôles Discord associés (dans la base de données) et l'ensemble de l'historique d'XP de toutes les saisons seront effacés définitivement.
+              </p>
+              
+              <div class="p-3 bg-rose-500/10 rounded-lg border border-rose-500/10 text-rose-500 text-xs flex gap-2">
+                <Papicon icon="Info" size={16} class="shrink-0 mt-0.5" />
+                <span><strong>IMPORTANT :</strong> Si vous souhaitez simplement clore la saison active et passer à la saison suivante sans perdre vos clans, utilisez l'onglet <strong>📅 Gestion des Saisons</strong>.</span>
+              </div>
+            </div>
 
-      </div>
+            {#if canManageSettings}
+              <button
+                type="button"
+                onclick={() => openConfirmation('reset-all')}
+                class="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-rose-600 hover:bg-rose-700 text-white font-bold text-xs rounded-lg transition-colors cursor-pointer mt-4"
+              >
+                💥 Réinitialiser toutes les données de Clans
+              </button>
+            {/if}
+          </section>
+
+          <!-- Card 2: Annuler la dernière saison (Rollback) -->
+          <section class="bg-surface-container-low/40 border border-orange-500/20 p-6 rounded-xl space-y-6 flex flex-col justify-between">
+            <div class="space-y-4">
+              <h3 class="text-lg font-semibold border-b border-orange-500/10 pb-2 flex items-center gap-2 text-orange-500">
+                <Papicon icon="RotateCcw" size={16} />
+                Annuler la dernière saison
+              </h3>
+              
+              <p class="text-xs text-on-surface-variant/80 leading-relaxed">
+                Ce bouton permet d'<strong>annuler la dernière clôture de saison</strong>. Si vous êtes actuellement à la Saison {currentClanSeason}, vous retournerez à la Saison {currentClanSeason - 1}.
+              </p>
+              
+              <p class="text-xs text-on-surface-variant/80 leading-relaxed">
+                Toutes les contributions d'XP enregistrées pour la saison active (Saison {currentClanSeason}) seront supprimées. Le vainqueur de la saison précédente (Saison {currentClanSeason - 2}) ainsi que ses chefs de clans associés seront rétablis.
+              </p>
+            </div>
+
+            {#if canManageSettings}
+              <button
+                type="button"
+                onclick={() => openConfirmation('rollback')}
+                class="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-orange-600 hover:bg-orange-700 text-white font-bold text-xs rounded-lg transition-colors cursor-pointer mt-4"
+                disabled={currentClanSeason <= 1}
+              >
+                🔄 Annuler la dernière saison
+              </button>
+            {/if}
+          </section>
+
+        </div>
+      {/if}
     {/if}
   {/if}
 </ModulePage>
@@ -1184,12 +1260,14 @@
         <p class="text-xs text-on-surface-variant/80 mt-1">
           {#if confirmActionType === 'clear'}
             Vous vous apprêtez à <strong>retirer tous les rôles de clan</strong> de tous les membres du serveur. Cette action s'exécute progressivement en arrière-plan.
-          {:else}
-            {#if confirmActionType === 'reset'}
-              Vous vous apprêtez à <strong>clore la saison active</strong> de clans et à passer à la suivante. Les scores d'XP des clans repartiront à 0.
-            {:else if confirmActionType === 'distribute'}
-              Vous vous apprêtez à <strong>distribuer aléatoirement un clan</strong> à tous les membres sans clan. Cette action s'exécute progressivement en arrière-plan.
-            {/if}
+          {:else if confirmActionType === 'reset'}
+            Vous vous apprêtez à <strong>clore la saison active</strong> de clans et à passer à la suivante. Les scores d'XP des clans repartiront à 0.
+          {:else if confirmActionType === 'distribute'}
+            Vous vous apprêtez à <strong>distribuer aléatoirement un clan</strong> à tous les membres sans clan. Cette action s'exécute progressivement en arrière-plan.
+          {:else if confirmActionType === 'reset-all'}
+            <span class="text-rose-500 font-bold">⚠️ ATTENTION :</span> Vous vous apprêtez à <strong>réinitialiser toutes les données de clans</strong> (suppression définitive de tous les clans configurés, de toutes les contributions de saison et retour à la saison 1). Cette action est totalement irréversible.
+          {:else if confirmActionType === 'rollback'}
+            Vous vous apprêtez à <strong>annuler la dernière clôture de saison</strong>. Vous retournerez à la saison {currentClanSeason - 1}. Les contributions de la saison active (Saison {currentClanSeason}) seront supprimées, et le vainqueur de la saison {currentClanSeason - 2} ainsi que ses chefs de clan associés seront rétablis.
           {/if}
         </p>
       </div>
@@ -1197,13 +1275,13 @@
       <div class="space-y-4">
         <div class="space-y-1.5">
           <label for="confirm-word" class="text-[10px] font-bold text-on-surface-variant/60 ml-1 uppercase tracking-widest">
-            Saisissez <strong>{confirmActionType === 'clear' ? 'RETIRER' : confirmActionType === 'reset' ? 'RESET' : 'DISTRIBUER'}</strong> pour confirmer
+            Saisissez <strong>{#if confirmActionType === 'clear'}RETIRER{:else if confirmActionType === 'reset'}RESET{:else if confirmActionType === 'distribute'}DISTRIBUER{:else if confirmActionType === 'reset-all'}RESET ALL{:else}ANNULER{/if}</strong> pour confirmer
           </label>
           <input
             id="confirm-word"
             type="text"
             bind:value={confirmInput}
-            placeholder={confirmActionType === 'clear' ? 'RETIRER' : confirmActionType === 'reset' ? 'RESET' : 'DISTRIBUER'}
+            placeholder={confirmActionType === 'clear' ? 'RETIRER' : confirmActionType === 'reset' ? 'RESET' : confirmActionType === 'distribute' ? 'DISTRIBUER' : confirmActionType === 'reset-all' ? 'RESET ALL' : 'ANNULER'}
             class="w-full bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-primary/30 transition-all text-on-surface focus:outline-none font-bold uppercase tracking-wider"
           />
         </div>


### PR DESCRIPTION
…rd administration tools

## 📝 Description
Onglet administratif sur le dashboard pour les clans, correction de bug, scan cron plus rapide pour la fin de saison, rajout d'une commande slash sur le bot, verification suplementaire pour les doubles comptes (DC)


## 🎯 Changements principaux
- /clan historique saison X, pour avoir le classement d'une saison qui a eu lieu
- integration d'un 4eme onglet administratif
- bouton de SUPPRESSION total des clans sur le dashboard et bouton de retour en arriere de une saison
- verification cron toutes les 15min si une saison est fini ou pas
- correction des emojis
- verification suplementaire pour les doubles comptes (DC)
- changement dans l'ajout manuel des points a un utilisateur
