### PR TITLE
feat(clans): auto-assign clan on member join with DC exclusion

### DIFF
--- a/apps/bot/src/api/routes/dashboard/clans.ts
+++ b/apps/bot/src/api/routes/dashboard/clans.ts
@@ -28,6 +28,7 @@ export async function handleClansRoutes(
         select: {
           clansEnabled: true,
           clansUnique: true,
+          clansAutoAssignOnJoin: true,
           currentClanSeason: true,
           clanXpFromLevelUp: true,
           clanXpPerLevelUp: true,
@@ -83,6 +84,7 @@ export async function handleClansRoutes(
       json(res, 200, {
         clansEnabled: guildData.clansEnabled,
         clansUnique: guildData.clansUnique,
+        clansAutoAssignOnJoin: guildData.clansAutoAssignOnJoin,
         currentClanSeason: guildData.currentClanSeason,
         clanXpFromLevelUp: guildData.clanXpFromLevelUp,
         clanXpPerLevelUp: guildData.clanXpPerLevelUp,
@@ -109,6 +111,7 @@ export async function handleClansRoutes(
       const body = await readJsonBody<{
         clansEnabled?: boolean;
         clansUnique?: boolean;
+        clansAutoAssignOnJoin?: boolean;
         clanXpFromLevelUp?: boolean;
         clanXpPerLevelUp?: number;
         clanAnnouncementChannelId?: string | null;
@@ -123,6 +126,7 @@ export async function handleClansRoutes(
       const updateData: Record<string, any> = {};
       if (body?.clansEnabled !== undefined) updateData.clansEnabled = body.clansEnabled;
       if (body?.clansUnique !== undefined) updateData.clansUnique = body.clansUnique;
+      if (body?.clansAutoAssignOnJoin !== undefined) updateData.clansAutoAssignOnJoin = body.clansAutoAssignOnJoin;
       if (body?.clanXpFromLevelUp !== undefined) updateData.clanXpFromLevelUp = body.clanXpFromLevelUp;
       if (body?.clanXpPerLevelUp !== undefined) {
         if (typeof body.clanXpPerLevelUp !== 'number' || body.clanXpPerLevelUp < 0) {
@@ -165,7 +169,7 @@ export async function handleClansRoutes(
         context: getGuildName(client, guildId),
         module: 'Clans',
         eventType: 'Manuel',
-        details: `Paramètres clans mis à jour. Activé: ${updatedGuild.clansEnabled}, Unique: ${updatedGuild.clansUnique}, XP Level Up: ${updatedGuild.clanXpFromLevelUp} (${updatedGuild.clanXpPerLevelUp} pts)`,
+        details: `Paramètres clans mis à jour. Activé: ${updatedGuild.clansEnabled}, Unique: ${updatedGuild.clansUnique}, Auto-assign: ${updatedGuild.clansAutoAssignOnJoin}, XP Level Up: ${updatedGuild.clanXpFromLevelUp} (${updatedGuild.clanXpPerLevelUp} pts)`,
         channelId: null,
       });
 
@@ -174,6 +178,7 @@ export async function handleClansRoutes(
       json(res, 200, {
         clansEnabled: updatedGuild.clansEnabled,
         clansUnique: updatedGuild.clansUnique,
+        clansAutoAssignOnJoin: updatedGuild.clansAutoAssignOnJoin,
         clanXpFromLevelUp: updatedGuild.clanXpFromLevelUp,
         clanXpPerLevelUp: updatedGuild.clanXpPerLevelUp,
         clanAnnouncementChannelId: updatedGuild.clanAnnouncementChannelId,

--- a/apps/bot/src/events/clanEvents.ts
+++ b/apps/bot/src/events/clanEvents.ts
@@ -3,6 +3,58 @@ import prisma from '../utils/db.js';
 import { logger } from '../utils/logger.js';
 
 export function registerClanListener(client: Client) {
+  client.on(Events.GuildMemberAdd, async (member: GuildMember) => {
+    try {
+      if (member.user.bot) return;
+
+      const guildId = member.guild.id;
+      const config = await prisma.guild.findUnique({
+        where: { id: guildId },
+        select: { clansEnabled: true, clansAutoAssignOnJoin: true },
+      });
+
+      if (!config?.clansEnabled || !config.clansAutoAssignOnJoin) return;
+
+      const linkedAccount = await prisma.linkedAccount.findFirst({
+        where: {
+          guildId,
+          status: 'VALIDATED',
+          OR: [
+            { user1Id: member.id },
+            { user2Id: member.id },
+          ],
+        },
+        select: { id: true },
+      });
+
+      if (linkedAccount) return;
+
+      const clans = await prisma.clan.findMany({
+        where: { guildId },
+        select: { id: true, name: true, roleId: true },
+      });
+
+      if (clans.length === 0) return;
+
+      const availableClans = clans
+        .map((clan) => ({
+          ...clan,
+          memberCount: member.guild.roles.cache.get(clan.roleId)?.members.size ?? 0,
+        }))
+        .filter((clan) => clan.memberCount >= 0);
+
+      if (availableClans.length === 0) return;
+
+      availableClans.sort((a, b) => a.memberCount - b.memberCount || a.name.localeCompare(b.name, 'fr'));
+      const targetClan = availableClans[0];
+
+      await member.roles.add(targetClan.roleId, 'Attribution automatique du clan à l\'arrivée').catch(() => null);
+      logger.info('ClansSecurity', `Attribution automatique du clan "${targetClan.name}" à ${member.user.tag}`);
+    } catch (error) {
+      logger.error('ClansSecurity', `Erreur lors de l'attribution automatique du clan pour ${member.user.tag}:`, error);
+    }
+  });
+
   // 1. Sécurité de Clan Unique (guildMemberUpdate)
   client.on(Events.GuildMemberUpdate, async (oldMember: GuildMember, newMember: GuildMember) => {
     try {

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -3154,6 +3154,7 @@ export interface ClanEntry {
 export interface ClansDataResult {
   clansEnabled: boolean;
   clansUnique: boolean;
+  clansAutoAssignOnJoin: boolean;
   currentClanSeason: number;
   clanXpFromLevelUp: boolean;
   clanXpPerLevelUp: number;
@@ -3182,6 +3183,7 @@ export async function updateClanSettings(
   payload: {
     clansEnabled?: boolean;
     clansUnique?: boolean;
+    clansAutoAssignOnJoin?: boolean;
     clanXpFromLevelUp?: boolean;
     clanXpPerLevelUp?: number;
     clanAnnouncementChannelId?: string | null;
@@ -3196,6 +3198,7 @@ export async function updateClanSettings(
 ): Promise<{
   clansEnabled: boolean;
   clansUnique: boolean;
+  clansAutoAssignOnJoin: boolean;
   clanXpFromLevelUp: boolean;
   clanXpPerLevelUp: number;
   clanAnnouncementChannelId: string | null;

--- a/apps/dashboard/src/pages/Clans.svelte
+++ b/apps/dashboard/src/pages/Clans.svelte
@@ -36,6 +36,7 @@
   // States
   let clansEnabled = $state(false);
   let clansUnique = $state(true);
+  let clansAutoAssignOnJoin = $state(false);
   let currentClanSeason = $state(1);
   let clanXpFromLevelUp = $state(false);
   let clanXpPerLevelUp = $state(50);
@@ -58,6 +59,7 @@
   // Saved states (for dirty checking)
   let savedClansEnabled = $state(false);
   let savedClansUnique = $state(true);
+  let savedClansAutoAssignOnJoin = $state(false);
   let savedClanXpFromLevelUp = $state(false);
   let savedClanXpPerLevelUp = $state(50);
   let savedClanAnnouncementChannelId = $state<string | null>(null);
@@ -183,6 +185,7 @@
   $effect(() => {
     const dirty = clansEnabled !== savedClansEnabled 
       || clansUnique !== savedClansUnique
+      || clansAutoAssignOnJoin !== savedClansAutoAssignOnJoin
       || clanXpFromLevelUp !== savedClanXpFromLevelUp
       || clanXpPerLevelUp !== savedClanXpPerLevelUp
       || clanAnnouncementChannelId !== savedClanAnnouncementChannelId
@@ -197,6 +200,7 @@
           onReset: () => {
             clansEnabled = savedClansEnabled;
             clansUnique = savedClansUnique;
+            clansAutoAssignOnJoin = savedClansAutoAssignOnJoin;
             clanXpFromLevelUp = savedClanXpFromLevelUp;
             clanXpPerLevelUp = savedClanXpPerLevelUp;
             clanAnnouncementChannelId = savedClanAnnouncementChannelId;
@@ -280,6 +284,7 @@
       if (res) {
         clansEnabled = res.clansEnabled;
         clansUnique = res.clansUnique;
+        clansAutoAssignOnJoin = res.clansAutoAssignOnJoin;
         currentClanSeason = res.currentClanSeason;
         clanXpFromLevelUp = res.clanXpFromLevelUp;
         clanXpPerLevelUp = res.clanXpPerLevelUp;
@@ -298,6 +303,7 @@
         
         savedClansEnabled = res.clansEnabled;
         savedClansUnique = res.clansUnique;
+        savedClansAutoAssignOnJoin = res.clansAutoAssignOnJoin;
         savedClanXpFromLevelUp = res.clanXpFromLevelUp;
         savedClanXpPerLevelUp = res.clanXpPerLevelUp;
         savedClanAnnouncementChannelId = res.clanAnnouncementChannelId;
@@ -333,6 +339,7 @@
       const res = await updateClanSettings({
         clansEnabled,
         clansUnique,
+        clansAutoAssignOnJoin,
         clanXpFromLevelUp,
         clanXpPerLevelUp,
         clanAnnouncementChannelId: clanAnnouncementChannelId || null,
@@ -347,6 +354,7 @@
       
       savedClansEnabled = res.clansEnabled;
       savedClansUnique = res.clansUnique;
+      savedClansAutoAssignOnJoin = res.clansAutoAssignOnJoin;
       savedClanXpFromLevelUp = res.clanXpFromLevelUp;
       savedClanXpPerLevelUp = res.clanXpPerLevelUp;
       savedClanAnnouncementChannelId = res.clanAnnouncementChannelId;
@@ -617,6 +625,14 @@
                 <p class="text-xs text-on-surface-variant/70">Force un seul rôle de clan par membre Discord.</p>
               </div>
               <ToggleSwitch checked={clansUnique} onToggle={(v) => clansUnique = v} disabled={!canManageSettings} />
+            </div>
+
+            <div class="flex items-center justify-between pt-4 border-t border-outline-variant/10">
+              <div>
+                <span class="text-sm font-medium text-on-surface">Attribution automatique à l'arrivée</span>
+                <p class="text-xs text-on-surface-variant/70">Donne un clan automatiquement à chaque nouveau membre, sauf si le compte est lié à un double compte.</p>
+              </div>
+              <ToggleSwitch checked={clansAutoAssignOnJoin} onToggle={(v) => clansAutoAssignOnJoin = v} disabled={!canManageSettings} />
             </div>
           </div>
         </section>

--- a/packages/database/prisma/guild.prisma
+++ b/packages/database/prisma/guild.prisma
@@ -110,6 +110,7 @@ model Guild {
 
   clansEnabled      Boolean @default(false)
   clansUnique       Boolean @default(true)
+  clansAutoAssignOnJoin Boolean @default(false)
   currentClanSeason Int     @default(1)
   clanSeasonStartsAt DateTime?
   clanSeasonEndsAt   DateTime?


### PR DESCRIPTION
Ajout d'un bouton pour automatiser la gestion de donner un clan a toute personne qui rejoin le serveur (gestion des DC appliquer)