### PR TITLE
- Fix member points endpoint using nonexistent prisma.member model

### DIFF
--- a/apps/bot/src/api/routes/dashboard/clans.ts
+++ b/apps/bot/src/api/routes/dashboard/clans.ts
@@ -3,7 +3,7 @@ import { Client } from 'discord.js';
 import prisma from '../../../utils/db.js';
 import { logger } from '../../../utils/logger.js';
 import { json, readJsonBody, getGuildName, pushAudit, broadcastDashboardStateChange, type AuthClaims, type DashboardAccess } from '../../shared.js';
-import { clanTasks, runDistribution, runClear, handleEndSeason } from '../../../services/community/clanService.js';
+import { clanTasks, runDistribution, runClear, handleEndSeason, buildCategoryName } from '../../../services/community/clanService.js';
 
 export async function handleClansRoutes(
   req: IncomingMessage,
@@ -581,12 +581,15 @@ export async function handleClansRoutes(
         for (const clan of clans) {
           if (clan.generalChannelId) {
             const channel = discordGuild.channels.cache.get(clan.generalChannelId) || await discordGuild.channels.fetch(clan.generalChannelId).catch(() => null);
-            if (channel && channel.type === ChannelType.GuildCategory) {
-              const isWinner = restoredWinningClanId && clan.id === restoredWinningClanId;
-              const cleanName = channel.name.replace(/^\[🏆\s*.*?\]\s*/, '');
-              const targetName = isWinner ? `[🏆 ${clan.name}] ${cleanName}` : cleanName;
-              if (channel.name !== targetName) {
-                await channel.setName(targetName, "Annulation clôture saison").catch(() => null);
+            // On renomme la catégorie parente du salon QG (même logique que la fin de saison).
+            const category = channel && 'parent' in channel && channel.parent && channel.parent.type === ChannelType.GuildCategory
+              ? channel.parent
+              : (channel && channel.type === ChannelType.GuildCategory ? channel : null);
+            if (category) {
+              const isWinner = Boolean(restoredWinningClanId && clan.id === restoredWinningClanId);
+              const targetName = buildCategoryName(category.name, isWinner);
+              if (category.name !== targetName) {
+                await category.setName(targetName, "Annulation clôture saison").catch(() => null);
               }
             }
           }
@@ -645,9 +648,9 @@ export async function handleClansRoutes(
 
       if (body.userId?.trim()) {
         const userId = body.userId.trim();
-        // Vérifier si l'utilisateur existe dans la base de données
-        const dbMember = await prisma.member.findUnique({
-          where: { id: userId }
+        // Vérifier si l'utilisateur existe dans la base de données (profil membre du serveur)
+        const dbMember = await prisma.memberProfile.findUnique({
+          where: { guildId_userId: { guildId, userId } }
         });
         if (!dbMember) {
           json(res, 404, { error: "L'utilisateur n'existe pas dans la base de données de Kotbo (il doit interagir sur Discord d'abord)." });

--- a/apps/bot/src/services/community/clanService.ts
+++ b/apps/bot/src/services/community/clanService.ts
@@ -6,6 +6,28 @@ import { getClient } from '../../utils/client.js';
 
 export const clanTasks = new Map<string, { type: 'distribute' | 'clear'; processed: number; total: number }>();
 
+// ─── Balise de champion sur la catégorie QG ──────────────────────────────────
+// Format unifié : « <nom de base> [🏆 CHAMPION · <bonus>] ». La balise est
+// toujours placée en fin de nom, ce qui permet de la retirer proprement (peu
+// importe où elle a été ajoutée par une version précédente) via stripTrophyTag.
+
+/** Retire toute balise trophée « [🏆 ...] » d'un nom de catégorie (début, milieu ou fin). */
+export function stripTrophyTag(name: string): string {
+  return name.replace(/\s*\[🏆[^\]]*\]\s*/gu, ' ').replace(/\s{2,}/g, ' ').trim();
+}
+
+/**
+ * Construit le nom de catégorie du QG d'un clan pour une fin de saison.
+ * - Perdant : nom de base nettoyé (aucune balise).
+ * - Gagnant : nom de base + « [🏆 CHAMPION] » (avec la liste des bonus actifs si présents).
+ */
+export function buildCategoryName(currentName: string, isWinner: boolean, rewards: string[] = []): string {
+  const base = stripTrophyTag(currentName);
+  if (!isWinner) return base;
+  const suffix = rewards.length > 0 ? `CHAMPION · ${rewards.join(' + ')}` : 'CHAMPION';
+  return `${base} [🏆 ${suffix}]`;
+}
+
 export async function runDistribution(guildId: string, client: Client, initiatorName: string): Promise<string> {
   if (clanTasks.has(guildId)) {
     throw new Error('Une opération de masse est déjà en cours sur ce serveur.');
@@ -552,29 +574,20 @@ export async function handleEndSeason(
         
       if (channel && channel.parent && channel.parent.type === ChannelType.GuildCategory) {
         const category = channel.parent as CategoryChannel;
-        const isWinner = winningClan && clan.id === winningClan.id;
-        
-        let targetName = category.name;
-        // Retirer uniquement la balise [🏆 ...] de fin si elle existe
-        const trophyIndex = targetName.indexOf('[🏆');
-        if (trophyIndex !== -1) {
-          targetName = targetName.substring(0, trophyIndex).trim();
+        const isWinner = Boolean(winningClan && clan.id === winningClan.id);
+
+        // Le gagnant est toujours marqué d'un 🏆 (avec ses bonus actifs le cas
+        // échéant) ; les perdants sont systématiquement nettoyés de toute balise.
+        const activeRewards: string[] = [];
+        if (guildSettings.clanRewardXpBoost) {
+          activeRewards.push(`+${Math.round((guildSettings.clanRewardXpBoostRate - 1) * 100)}% XP`);
         }
-        
-        if (isWinner) {
-          const activeRewards: string[] = [];
-          if (guildSettings.clanRewardXpBoost) {
-            activeRewards.push(`+${Math.round((guildSettings.clanRewardXpBoostRate - 1) * 100)}% XP`);
-          }
-          if (guildSettings.clanRewardGiveaway) {
-            activeRewards.push('GIVEAWAY BOOST');
-          }
-          
-          if (activeRewards.length > 0) {
-            targetName = `${targetName} [🏆 ${activeRewards.join(' + ')}]`;
-          }
+        if (guildSettings.clanRewardGiveaway) {
+          activeRewards.push('GIVEAWAY BOOST');
         }
-        
+
+        const targetName = buildCategoryName(category.name, isWinner, activeRewards);
+
         if (category.name !== targetName) {
           logger.info('ClanService', `Renommage du QG du clan "${clan.name}" en "${targetName}"`);
           await category.setName(targetName, `Mise à jour QG - Fin de la Saison ${currentSeason}`).catch((err) => {

--- a/apps/dashboard/src/pages/Clans.svelte
+++ b/apps/dashboard/src/pages/Clans.svelte
@@ -400,6 +400,43 @@
     }, { successMessage: 'Planification de la saison enregistrée avec succès !' });
   }
 
+  // Remplit les champs date/heure à partir de deux objets Date (heure locale)
+  function applyDateRange(start: Date, end: Date) {
+    const toLocal = (d: Date) => {
+      const tzOffset = d.getTimezoneOffset() * 60000;
+      return new Date(d.getTime() - tzOffset).toISOString();
+    };
+    const s = toLocal(start);
+    const e = toLocal(end);
+    startDate = s.slice(0, 10);
+    startTime = s.slice(11, 16);
+    endDate = e.slice(0, 10);
+    endTime = e.slice(11, 16);
+  }
+
+  // Presets de remplissage rapide : début = maintenant, fin = maintenant + N mois
+  function applyQuickRange(months: number) {
+    const start = new Date();
+    const end = new Date(start);
+    end.setMonth(end.getMonth() + months);
+    applyDateRange(start, end);
+  }
+
+  // Enchaîne la prochaine saison juste après la saison actuelle planifiée,
+  // en conservant la même durée (fallback 3 mois si la durée est indéterminée).
+  const canChainNextSeason = $derived(!!savedClanSeasonEndsAt);
+  function applyChainAfterCurrent() {
+    if (!savedClanSeasonEndsAt) return;
+    const start = new Date(savedClanSeasonEndsAt);
+    let durationMs = 1000 * 60 * 60 * 24 * 90; // ~3 mois par défaut
+    if (savedClanSeasonStartsAt) {
+      const d = new Date(savedClanSeasonEndsAt).getTime() - new Date(savedClanSeasonStartsAt).getTime();
+      if (d > 0) durationMs = d;
+    }
+    const end = new Date(start.getTime() + durationMs);
+    applyDateRange(start, end);
+  }
+
   async function handleClearSeasonPlanning() {
     if (!canManageSettings) return;
     if (!confirm("Voulez-vous vraiment annuler la planification de la saison ?")) return;
@@ -629,7 +666,7 @@
 
             <div class="flex items-center justify-between pt-4 border-t border-outline-variant/10">
               <div>
-                <span class="text-sm font-medium text-on-surface">Attribution Automatique à la Jointure</span>
+                <span class="text-sm font-medium text-on-surface">Attribution d'un clan à l'arrivée sur le serveur</span>
                 <p class="text-xs text-on-surface-variant/70">Attribue automatiquement le clan le moins peuplé à chaque nouveau membre qui rejoint le serveur. Les membres reconnus comme double compte validé ne sont pas concernés (leur clan est aligné sur celui de leur compte principal).</p>
               </div>
               <ToggleSwitch checked={clanAutoAssignOnJoin} onToggle={(v) => clanAutoAssignOnJoin = v} disabled={!canManageSettings} />
@@ -893,6 +930,21 @@
               Planifier la saison de clans
             </h3>
 
+            {#if canManageSettings}
+              <div class="flex flex-wrap items-center gap-2">
+                <span class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest mr-1">Remplissage rapide</span>
+                <button type="button" onclick={() => applyQuickRange(1)} class="px-2.5 py-1 bg-surface-container-high/50 hover:bg-primary/15 hover:text-primary text-on-surface-variant text-[11px] font-semibold rounded-md transition-colors cursor-pointer">1 mois</button>
+                <button type="button" onclick={() => applyQuickRange(3)} class="px-2.5 py-1 bg-surface-container-high/50 hover:bg-primary/15 hover:text-primary text-on-surface-variant text-[11px] font-semibold rounded-md transition-colors cursor-pointer">Trimestre</button>
+                <button type="button" onclick={() => applyQuickRange(6)} class="px-2.5 py-1 bg-surface-container-high/50 hover:bg-primary/15 hover:text-primary text-on-surface-variant text-[11px] font-semibold rounded-md transition-colors cursor-pointer">6 mois</button>
+                <button type="button" onclick={() => applyQuickRange(12)} class="px-2.5 py-1 bg-surface-container-high/50 hover:bg-primary/15 hover:text-primary text-on-surface-variant text-[11px] font-semibold rounded-md transition-colors cursor-pointer">1 an</button>
+                {#if canChainNextSeason}
+                  <button type="button" onclick={applyChainAfterCurrent} class="px-2.5 py-1 bg-secondary/15 hover:bg-secondary/25 text-secondary text-[11px] font-semibold rounded-md transition-colors cursor-pointer flex items-center gap-1" title="Enchaîner juste après la fin de la saison actuelle, avec la même durée">
+                    <Papicon icon="Refresh" size={11} /> Enchaîner après l'actuelle
+                  </button>
+                {/if}
+              </div>
+            {/if}
+
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
               <!-- Début de saison -->
               <div class="space-y-2">
@@ -934,8 +986,15 @@
             </div>
 
             <div class="p-4 bg-primary/5 border border-primary/20 rounded-xl text-xs text-primary leading-relaxed space-y-1">
-              <p class="font-bold">💡 Fonctionnement Automatique</p>
-              <p>Lorsque la date de fin est dépassée, le Bot lancera automatiquement le traitement de fin de saison. Si une date de début et de fin étaient configurées, le système calculera automatiquement l'intervalle et programmera la saison suivante pour la même durée.</p>
+              <p class="font-bold">💡 Renouvellement automatique</p>
+              <p>Lorsque la date de fin est dépassée, le Bot clôture automatiquement la saison (récompenses, renommage des QG, annonce) puis <strong>reprogramme aussitôt la saison suivante pour la même durée</strong>. Une saison de 3 mois se renouvelle donc toute seule chaque trimestre, sans intervention.</p>
+              {#if savedClanSeasonStartsAt && savedClanSeasonEndsAt}
+                <p class="pt-1 flex items-center gap-1.5 text-primary/90">
+                  <Papicon icon="Refresh" size={12} /> Renouvellement automatique <strong>actif</strong> (durée identique reconduite à chaque fin de saison).
+                </p>
+              {:else}
+                <p class="pt-1 text-primary/70">Aucune date planifiée : la saison en cours ne se clôturera pas d'elle-même (renouvellement automatique inactif).</p>
+              {/if}
             </div>
 
             {#if canManageSettings}


### PR DESCRIPTION
- Fix member points endpoint using nonexistent prisma.member model
  (switched to memberProfile scoped by guild)
- Always tag winning clan category with 🏆, always clear losers,
  unify trophy tag format between season close and rollback
- Add quick date presets (1/3/6/12 months) and "chain after current"
  button in season planning, plus clearer auto-renewal indicator