### PR TITLE
feat(leveling): add configurable message-length XP bonus

### DIFF
--- a/apps/bot/src/api/routes/dashboard/generalistModules.ts
+++ b/apps/bot/src/api/routes/dashboard/generalistModules.ts
@@ -102,6 +102,9 @@ export async function handleGeneralistModulesRoutes(
           ignoredRoles?: string[];
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           xpMultipliers?: any;
+          lengthBonusEnabled?: boolean;
+          lengthBonusThreshold?: number;
+          lengthBonusMaxMultiplier?: number;
         }>(req);
 
         if (!body) {
@@ -123,6 +126,13 @@ export async function handleGeneralistModulesRoutes(
             ignoredChannels: body.ignoredChannels,
             ignoredRoles: body.ignoredRoles,
             xpMultipliers: body.xpMultipliers,
+            lengthBonusEnabled: body.lengthBonusEnabled,
+            lengthBonusThreshold: body.lengthBonusThreshold !== undefined
+              ? Math.max(1, Math.floor(body.lengthBonusThreshold))
+              : undefined,
+            lengthBonusMaxMultiplier: body.lengthBonusMaxMultiplier !== undefined
+              ? Math.min(10, Math.max(1, body.lengthBonusMaxMultiplier))
+              : undefined,
           },
         });
 

--- a/apps/bot/src/modules/leveling.module.ts
+++ b/apps/bot/src/modules/leveling.module.ts
@@ -18,7 +18,8 @@ export function registerLevelingBusSubscribers(client: Client): void {
   kotboEventBus.subscribe('message:new', async (payload) => {
     if (payload.isBot || payload.isCommand) return;
 
-    await handleTextXp(payload.guildId, payload.authorId, client, payload.channelId);
+    const messageLength = (payload.content ?? '').trim().length;
+    await handleTextXp(payload.guildId, payload.authorId, client, payload.channelId, messageLength);
     await handleUserActivity(payload.guildId, payload.authorId, 'text').catch(() => null);
   }, MODULE_NAME);
 

--- a/apps/bot/src/services/progression/levelingService.ts
+++ b/apps/bot/src/services/progression/levelingService.ts
@@ -62,6 +62,9 @@ export async function getOrCreateLevelConfig(guildId: string) {
         ignoredChannels: [],
         ignoredRoles: [],
         xpMultipliers: {},
+        lengthBonusEnabled: false,
+        lengthBonusThreshold: 200,
+        lengthBonusMaxMultiplier: 2.0,
       },
     });
   }
@@ -71,9 +74,27 @@ export async function getOrCreateLevelConfig(guildId: string) {
 }
 
 /**
+ * Calcule le facteur multiplicateur d'XP en fonction de la longueur du message.
+ * Progression linéaire de 1.0 (message vide/court) jusqu'à `maxMultiplier`
+ * atteint à `threshold` caractères, puis plafonné.
+ */
+export function computeLengthBonusFactor(
+  messageLength: number,
+  enabled: boolean,
+  threshold: number,
+  maxMultiplier: number,
+): number {
+  if (!enabled) return 1;
+  if (!threshold || threshold <= 0) return 1;
+  if (!maxMultiplier || maxMultiplier <= 1) return 1;
+  const ratio = Math.min(1, Math.max(0, messageLength / threshold));
+  return 1 + ratio * (maxMultiplier - 1);
+}
+
+/**
  * Ajoute de l'XP à un utilisateur (Textuel)
  */
-export async function handleTextXp(guildId: string, userId: string, client: Client, channelId: string) {
+export async function handleTextXp(guildId: string, userId: string, client: Client, channelId: string, messageLength = 0) {
   try {
     const config = await getOrCreateLevelConfig(guildId);
     if (!config.enabled) return;
@@ -118,10 +139,18 @@ export async function handleTextXp(guildId: string, userId: string, client: Clie
       }
     }
 
-    // Assigner l'XP en appliquant le multiplicateur
+    // Bonus selon la longueur du message (plus le message est long, plus le gain est élevé)
+    const lengthFactor = computeLengthBonusFactor(
+      messageLength,
+      Boolean(config.lengthBonusEnabled),
+      Number(config.lengthBonusThreshold ?? 0),
+      Number(config.lengthBonusMaxMultiplier ?? 1),
+    );
+
+    // Assigner l'XP en appliquant le multiplicateur de rôle puis le bonus de longueur
     const baseGain = Math.floor(Math.random() * (config.xpMax - config.xpMin + 1)) + config.xpMin;
-    const xpGain = Math.floor(baseGain * multiplier);
-    
+    const xpGain = Math.floor(baseGain * multiplier * lengthFactor);
+
     if (xpGain > 0) {
       await addXp(guildId, userId, xpGain, client, channelId);
     }

--- a/apps/dashboard/src/pages/Leveling.svelte
+++ b/apps/dashboard/src/pages/Leveling.svelte
@@ -60,7 +60,10 @@
     stackRewards: false,
     ignoredChannels: [] as string[],
     ignoredRoles: [] as string[],
-    xpMultipliers: {} as Record<string, number>
+    xpMultipliers: {} as Record<string, number>,
+    lengthBonusEnabled: false,
+    lengthBonusThreshold: 200,
+    lengthBonusMaxMultiplier: 2.0
   });
 
   // Snapshot of last-saved state
@@ -75,7 +78,10 @@
     stackRewards: false,
     ignoredChannels: [] as string[],
     ignoredRoles: [] as string[],
-    xpMultipliers: {} as Record<string, number>
+    xpMultipliers: {} as Record<string, number>,
+    lengthBonusEnabled: false,
+    lengthBonusThreshold: 200,
+    lengthBonusMaxMultiplier: 2.0
   })));
 
   // Clan states for boost configuration
@@ -166,7 +172,10 @@
           stackRewards: res.config.stackRewards ?? false,
           ignoredChannels: res.config.ignoredChannels ?? [],
           ignoredRoles: res.config.ignoredRoles ?? [],
-          xpMultipliers: res.config.xpMultipliers ?? {}
+          xpMultipliers: res.config.xpMultipliers ?? {},
+          lengthBonusEnabled: res.config.lengthBonusEnabled ?? false,
+          lengthBonusThreshold: res.config.lengthBonusThreshold ?? 200,
+          lengthBonusMaxMultiplier: res.config.lengthBonusMaxMultiplier ?? 2.0
         };
         savedConfig = JSON.parse(JSON.stringify(config));
         rewards = res.rewards || [];
@@ -523,6 +532,57 @@
                 class="w-full bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-4 py-3 text-sm focus:ring-2 focus:ring-primary/30 transition-all text-on-surface focus:outline-none"
                 disabled={!canManageSettings}
               />
+            </div>
+
+            <!-- Bonus d'XP selon la longueur du message -->
+            <div class="col-span-2 mt-2 bg-surface-container-high/20 border border-outline-variant/5 rounded-lg px-6 py-4 space-y-4">
+              <div class="flex items-center justify-between">
+                <div>
+                  <span class="text-xs font-bold text-on-surface">Bonus d'XP selon la longueur du message</span>
+                  <p class="text-[10px] text-on-surface-variant/60 font-medium">Plus un message est long, plus il rapporte d'XP (jusqu'au multiplicateur maximum).</p>
+                </div>
+                <ToggleSwitch
+                  checked={config.lengthBonusEnabled}
+                  onToggle={(v: boolean) => { config.lengthBonusEnabled = v; }}
+                  disabled={!canManageSettings}
+                />
+              </div>
+
+              {#if config.lengthBonusEnabled}
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6 pt-3 border-t border-outline-variant/10 animate-in fade-in duration-200">
+                  <div class="space-y-1.5">
+                    <label for="lengthBonusThreshold" class="text-[10px] font-bold text-on-surface-variant/60 ml-2 uppercase tracking-widest">Longueur pour le bonus max (caractères)</label>
+                    <input
+                      id="lengthBonusThreshold"
+                      type="number"
+                      min="1"
+                      bind:value={config.lengthBonusThreshold}
+                      class="w-full bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-4 py-3 text-sm focus:ring-2 focus:ring-primary/30 transition-all text-on-surface focus:outline-none"
+                      disabled={!canManageSettings}
+                    />
+                    <p class="text-[10px] text-on-surface-variant/50 ml-2">Un message d'au moins {config.lengthBonusThreshold} caractères touche le bonus maximum.</p>
+                  </div>
+
+                  <div class="space-y-1.5">
+                    <label for="lengthBonusMaxMultiplier" class="text-[10px] font-bold text-on-surface-variant/60 ml-2 uppercase tracking-widest">Multiplicateur maximum (×)</label>
+                    <input
+                      id="lengthBonusMaxMultiplier"
+                      type="number"
+                      min="1"
+                      max="10"
+                      step="0.1"
+                      bind:value={config.lengthBonusMaxMultiplier}
+                      class="w-full bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-4 py-3 text-sm focus:ring-2 focus:ring-primary/30 transition-all text-on-surface focus:outline-none"
+                      disabled={!canManageSettings}
+                    />
+                    <p class="text-[10px] text-on-surface-variant/50 ml-2">Un message très court garde ×1, un message long va jusqu'à ×{config.lengthBonusMaxMultiplier}.</p>
+                  </div>
+                </div>
+
+                <div class="p-3 bg-primary/5 border border-primary/15 rounded-lg text-[11px] text-primary/90 leading-relaxed">
+                  💡 Le bonus augmente progressivement avec la longueur. Exemple : un message de {Math.round((config.lengthBonusThreshold || 1) / 2)} caractères applique ≈ ×{(1 + 0.5 * ((config.lengthBonusMaxMultiplier || 1) - 1)).toFixed(2)}, un message de {config.lengthBonusThreshold}+ caractères applique ×{Number(config.lengthBonusMaxMultiplier).toFixed(2)}.
+                </div>
+              {/if}
             </div>
 
             <!-- Toggle cumul récompenses -->

--- a/packages/database/prisma/levels.prisma
+++ b/packages/database/prisma/levels.prisma
@@ -39,6 +39,13 @@ model LevelConfig {
   ignoredRoles    String[] @default([])
   xpMultipliers   Json?
 
+  // Bonus d'XP selon la longueur du message : plus un message est long, plus
+  // le gain est multiplié, jusqu'à `lengthBonusMaxMultiplier` atteint à
+  // `lengthBonusThreshold` caractères (progression linéaire, plafonnée).
+  lengthBonusEnabled       Boolean @default(false)
+  lengthBonusThreshold     Int     @default(200)
+  lengthBonusMaxMultiplier Float   @default(2.0)
+
   guild Guild @relation(fields: [guildId], references: [id], onDelete: Cascade)
 
   @@map("level_configs")

--- a/packages/database/prisma/migrations/20260720130000_add_xp_length_bonus/migration.sql
+++ b/packages/database/prisma/migrations/20260720130000_add_xp_length_bonus/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "level_configs" ADD COLUMN     "lengthBonusEnabled" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "lengthBonusThreshold" INTEGER NOT NULL DEFAULT 200,
+ADD COLUMN     "lengthBonusMaxMultiplier" DOUBLE PRECISION NOT NULL DEFAULT 2.0;


### PR DESCRIPTION
Nouvelle pondération configurable dans l'onglet Configuration du module Leveling : plus un message est long, plus le gain d'XP est multiplié (progression linéaire jusqu'à un multiplicateur maximum atteint à un seuil de caractères). Réglages : toggle d'activation, seuil de longueur (défaut 200 car.), multiplicateur max (défaut ×2, borné 1–10). Se combine avec les multiplicateurs de rôle et le boost de clan.