### PR TITLE
fix(clans): fiabilise les opérations de masse et impose le clan unique

### DIFF
--- a/apps/bot/messages/en.json
+++ b/apps/bot/messages/en.json
@@ -1049,6 +1049,7 @@
   "c4_clan_opt_saison": "The season number to view (e.g. 5)",
   "c4_clan_distribute_desc": "🎲 (Admin) Randomly assign members without a clan",
   "c4_clan_clear_desc": "🧹 (Admin) Remove all clan roles from the server",
+  "c4_clan_dedupe_desc": "🧩 (Admin) Fix members holding several clans",
   "c4_clan_guild_only": "❌ This command must be run in a server.",
   "c4_clan_module_disabled": "❌ The clan module is currently disabled on this server.",
   "c4_clan_list_empty": "No clan is configured on this server.",

--- a/apps/bot/messages/fr.json
+++ b/apps/bot/messages/fr.json
@@ -1049,6 +1049,7 @@
   "c4_clan_opt_saison": "Le numéro de la saison à consulter (ex: 5)",
   "c4_clan_distribute_desc": "🎲 (Admin) Répartit aléatoirement les membres sans clan",
   "c4_clan_clear_desc": "🧹 (Admin) Retire tous les rôles de clan du serveur",
+  "c4_clan_dedupe_desc": "🧩 (Admin) Corrige les membres qui portent plusieurs clans",
   "c4_clan_guild_only": "❌ Cette commande doit être exécutée sur un serveur.",
   "c4_clan_module_disabled": "❌ Le module de clans est actuellement désactivé sur ce serveur.",
   "c4_clan_list_empty": "Aucun clan n'est configuré sur ce serveur.",

--- a/apps/bot/src/commands/community/clan.ts
+++ b/apps/bot/src/commands/community/clan.ts
@@ -11,7 +11,7 @@ import {
 } from 'discord.js';
 import type { SlashCommandDefinition } from '../../commands.js';
 import prisma from '../../utils/db.js';
-import { runDistribution, runClear } from '../../services/community/clanService.js';
+import { runDistribution, runClear, runDeduplicate } from '../../services/community/clanService.js';
 import { E, rankEmoji } from '../../utils/emojis.js';
 import { COLORS_RAW } from '../../utils/embeds.js';
 import { getEffectiveLocale, getCommandMetadata } from '../../utils/i18n.js';
@@ -74,6 +74,12 @@ export const data = new SlashCommandBuilder()
       .setName('clear')
       .setDescription(m.c4_clan_clear_desc({}, { locale: 'en' }))
       .setDescriptionLocalizations({ fr: m.c4_clan_clear_desc({}, { locale: 'fr' }) })
+  )
+  .addSubcommand((sub) =>
+    sub
+      .setName('dedupe')
+      .setDescription(m.c4_clan_dedupe_desc({}, { locale: 'en' }))
+      .setDescriptionLocalizations({ fr: m.c4_clan_dedupe_desc({}, { locale: 'fr' }) })
   ) as any;
 
 export async function autocomplete(interaction: AutocompleteInteraction) {
@@ -343,6 +349,29 @@ export async function execute(interaction: ChatInputCommandInteraction) {
       try {
         const initiator = `${interaction.user.username} (${interaction.user.id})`;
         const message = await runClear(guildId, interaction.client, initiator);
+        await interaction.editReply(message);
+      } catch (err: any) {
+        await interaction.editReply(m.c4_clan_error({ message: err.message }, { locale }));
+      }
+      return;
+    }
+
+    // ── SUBCOMMAND: dedupe (Admin Only) ───────────────────────────────────────
+    if (sub === 'dedupe') {
+      const isExecutorAdmin = interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild);
+      if (!isExecutorAdmin) {
+        await interaction.reply({
+          content: m.c4_clan_admin_required({}, { locale }),
+          flags: [MessageFlags.Ephemeral],
+        });
+        return;
+      }
+
+      await interaction.deferReply({ flags: [MessageFlags.Ephemeral] });
+
+      try {
+        const initiator = `${interaction.user.username} (${interaction.user.id})`;
+        const message = await runDeduplicate(guildId, interaction.client, initiator);
         await interaction.editReply(message);
       } catch (err: any) {
         await interaction.editReply(m.c4_clan_error({ message: err.message }, { locale }));

--- a/apps/bot/src/events/clanEvents.ts
+++ b/apps/bot/src/events/clanEvents.ts
@@ -10,10 +10,15 @@ export function registerClanListener(client: Client) {
 
       const config = await prisma.guild.findUnique({
         where: { id: guildId },
-        select: { clansEnabled: true, clansUnique: true, logChannelId: true },
+        select: { clansEnabled: true, logChannelId: true },
       });
 
-      if (!config?.clansEnabled || !config?.clansUnique) return;
+      // L'unicité n'est plus optionnelle : le reste du module ne sait pas
+      // représenter un membre à plusieurs clans. L'attribution d'XP retient le
+      // premier rôle de clan rencontré, sans règle métier, alors que les
+      // effectifs le comptent dans chacun de ses clans — d'où des classements
+      // faux. Le réglage `clansUnique` existe encore en base mais n'est plus lu.
+      if (!config?.clansEnabled) return;
 
       const clans = await prisma.clan.findMany({
         where: { guildId },

--- a/apps/bot/src/services/community/clanService.ts
+++ b/apps/bot/src/services/community/clanService.ts
@@ -4,7 +4,7 @@ import { logger } from '../../utils/logger.js';
 import { pushAudit, broadcastDashboardStateChange } from '../../api/shared.js';
 import { getClient } from '../../utils/client.js';
 
-export const clanTasks = new Map<string, { type: 'distribute' | 'clear'; processed: number; total: number }>();
+export const clanTasks = new Map<string, { type: 'distribute' | 'clear' | 'dedupe'; processed: number; total: number }>();
 
 // ─── Balise de champion sur la catégorie QG ──────────────────────────────────
 // Format unifié : « <nom de base> [🏆 CHAMPION · <bonus>] ». La balise est
@@ -448,6 +448,182 @@ export async function runClear(guildId: string, client: Client, initiatorName: s
 }
 
 /**
+ * Répare les membres qui portent plusieurs rôles de clan.
+ *
+ * La sécurité de clan unique est **réactive** : elle se déclenche à l'ajout d'un
+ * rôle et ne repasse jamais sur l'existant. Un cumul né avant son activation,
+ * pendant une coupure de la passerelle, ou d'un retrait de rôle refusé par
+ * Discord, reste donc en place indéfiniment et gonfle les effectifs affichés.
+ *
+ * Clan conservé, dans l'ordre : celui où le membre a le plus contribué cette
+ * saison — on ne lui fait pas perdre son XP — sinon le moins peuplé, ce qui
+ * rééquilibre au passage. Les rôles retirés voient leurs contributions migrées
+ * vers le clan conservé.
+ */
+export async function runDeduplicate(guildId: string, client: Client, initiatorName: string): Promise<string> {
+  if (clanTasks.has(guildId)) {
+    throw new Error('Une opération de masse est déjà en cours sur ce serveur.');
+  }
+  clanTasks.set(guildId, { type: 'dedupe', processed: 0, total: 0 });
+
+  let duplicates: { member: GuildMember; clanIds: string[] }[];
+  let discordGuild: Guild;
+  let clansById: Map<string, { id: string; name: string; roleId: string }>;
+  let currentSeason: number;
+
+  try {
+    const guildData = await prisma.guild.findUnique({
+      where: { id: guildId },
+      select: { currentClanSeason: true },
+    });
+    currentSeason = guildData?.currentClanSeason ?? 1;
+
+    const clans = await prisma.clan.findMany({ where: { guildId } });
+    if (clans.length < 2) {
+      throw new Error('Il faut au moins deux clans configurés pour qu\'un doublon soit possible.');
+    }
+
+    const resolvedGuild = client.guilds.cache.get(guildId) || await client.guilds.fetch(guildId).catch(() => null);
+    if (!resolvedGuild) {
+      throw new Error('Serveur introuvable sur Discord.');
+    }
+    discordGuild = resolvedGuild;
+
+    const allMembers = await discordGuild.members.fetch().catch(() => null);
+    if (!allMembers) {
+      throw new Error('Impossible de récupérer la liste des membres Discord.');
+    }
+
+    clansById = new Map(clans.map((clan) => [clan.id, { id: clan.id, name: clan.name, roleId: clan.roleId }]));
+    const clanByRoleId = new Map(clans.map((clan) => [clan.roleId, clan]));
+
+    duplicates = [];
+    for (const member of allMembers.values()) {
+      const held = member.roles.cache
+        .filter((role) => clanByRoleId.has(role.id))
+        .map((role) => clanByRoleId.get(role.id)!.id);
+
+      if (held.length > 1) {
+        duplicates.push({ member, clanIds: held });
+      }
+    }
+
+    if (duplicates.length === 0) {
+      clanTasks.delete(guildId);
+      return 'Aucun membre ne cumule plusieurs clans.';
+    }
+  } catch (err) {
+    clanTasks.delete(guildId);
+    throw err;
+  }
+
+  clanTasks.set(guildId, { type: 'dedupe', processed: 0, total: duplicates.length });
+  broadcastDashboardStateChange(guildId, 'clans_updated');
+
+  const total = duplicates.length;
+
+  (async () => {
+    logger.info('ClanService', `Nettoyage de ${total} membre(s) à clans multiples dans "${discordGuild.name}" par ${initiatorName}`);
+
+    // Import dynamique, comme dans `awardClanPointsToMembers` : le module des
+    // doubles comptes n'a pas à être chargé pour qui n'utilise pas les clans.
+    const { getAllLinkedUserIds } = await import('../moderation/altAccountService.js');
+
+    // Effectifs courants, pour départager les membres sans contribution en
+    // faveur du clan le moins peuplé.
+    const counts = new Map<string, number>();
+    for (const clan of clansById.values()) {
+      counts.set(clan.id, discordGuild.roles.cache.get(clan.roleId)?.members.size ?? 0);
+    }
+
+    let lastProgressAt = 0;
+    let repaired = 0;
+
+    for (let i = 0; i < duplicates.length; i++) {
+      const currentTask = clanTasks.get(guildId);
+      if (!currentTask || currentTask.type !== 'dedupe') break;
+
+      const { member, clanIds } = duplicates[i];
+
+      // Les contributions sont stockées sous l'identifiant canonique d'un groupe
+      // de comptes liés (cf. `awardClanPointsToMembers`). Chercher sur le seul
+      // `member.id` ferait lire zéro XP à un double compte, et on le déplacerait
+      // alors vers un clan où il n'a rien construit.
+      const linkedIds = await getAllLinkedUserIds(guildId, member.id).catch(() => [member.id]);
+      const canonicalUserId = linkedIds.sort()[0] ?? member.id;
+
+      const contributions = await prisma.clanMemberContribution.groupBy({
+        by: ['clanId'],
+        where: { guildId, userId: canonicalUserId, season: currentSeason, clanId: { in: clanIds } },
+        _sum: { xp: true },
+      }).catch(() => [] as { clanId: string; _sum: { xp: number | null } }[]);
+
+      const xpByClanId = new Map(contributions.map((row) => [row.clanId, row._sum.xp ?? 0]));
+
+      const keptClanId = [...clanIds].sort((a, b) => {
+        const xpDiff = (xpByClanId.get(b) ?? 0) - (xpByClanId.get(a) ?? 0);
+        if (xpDiff !== 0) return xpDiff;
+        return (counts.get(a) ?? 0) - (counts.get(b) ?? 0);
+      })[0];
+
+      const removedClanIds = clanIds.filter((clanId) => clanId !== keptClanId);
+      const rolesToRemove = removedClanIds
+        .map((clanId) => clansById.get(clanId)?.roleId)
+        .filter((roleId): roleId is string => !!roleId);
+
+      try {
+        await member.roles.remove(rolesToRemove, 'Nettoyage : un membre ne peut appartenir qu\'à un seul clan');
+        repaired += 1;
+
+        for (const clanId of removedClanIds) {
+          counts.set(clanId, Math.max(0, (counts.get(clanId) ?? 1) - 1));
+          // L'XP gagnée sous l'ancien rôle suit le membre : la retirer serait
+          // le punir d'un doublon qu'il n'a pas provoqué.
+          await migrateContributions(guildId, canonicalUserId, clanId, keptClanId);
+        }
+
+        logger.info(
+          'ClanService',
+          `${member.user.tag} conservé dans "${clansById.get(keptClanId)?.name}", retiré de [${removedClanIds.map((id) => clansById.get(id)?.name).join(', ')}].`,
+        );
+      } catch (e) {
+        logger.warn('ClanService', `Impossible de nettoyer les clans de ${member.user.tag}:`, e);
+      }
+
+      clanTasks.set(guildId, { type: 'dedupe', processed: i + 1, total });
+
+      const now = Date.now();
+      if (now - lastProgressAt >= CLAN_TASK_PROGRESS_INTERVAL_MS || i === duplicates.length - 1) {
+        lastProgressAt = now;
+        broadcastDashboardStateChange(guildId, 'clans_updated');
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 450));
+    }
+
+    logger.info('ClanService', `Nettoyage des clans multiples terminé pour "${discordGuild.name}" : ${repaired}/${total} membre(s) corrigé(s).`);
+    clanTasks.delete(guildId);
+    broadcastDashboardStateChange(guildId, 'clans_updated');
+  })().catch((e) => {
+    logger.error('ClanService', 'Erreur critique dans le thread de nettoyage:', e);
+    clanTasks.delete(guildId);
+    broadcastDashboardStateChange(guildId, 'clans_updated');
+  });
+
+  await pushAudit(guildId, {
+    user: initiatorName,
+    action: 'Nettoyage des clans multiples',
+    context: discordGuild.name,
+    module: 'Clans',
+    eventType: 'Manuel',
+    details: `Nettoyage lancé pour ${total} membre(s) portant plusieurs rôles de clan.`,
+    channelId: null,
+  }).catch(() => null);
+
+  return `${total} membre(s) portent plusieurs clans. Le nettoyage a commencé en arrière-plan et progresse doucement pour respecter les limites de Discord. Le clan conservé est celui où le membre a le plus contribué cette saison.`;
+}
+
+/**
  * Synchronise les clans pour les comptes reliés (doubles comptes).
  * Si un utilisateur (ou les deux) possède déjà un clan, on harmonise.
  */
@@ -521,22 +697,44 @@ export async function syncMemberClanFromDcLink(
         targetClan = clan1;
         logger.info('ClanService', `Synchro DC : Alignement de ${member2.user.tag} vers le clan de ${member1.user.tag} ("${clan1.name}" avec ${xp1} XP vs ${xp2} XP)`);
         
-        // Retirer le rôle du clan 2 à member2 et ajouter le rôle du clan 1
-        await member2.roles.remove(clan2.roleId, `Double compte aligné sur ${member1.user.tag} (synchro auto)`).catch(() => null);
-        await member2.roles.add(clan1.roleId, `Double compte aligné sur ${member1.user.tag} (synchro auto)`).catch(() => null);
+        // Retirer le rôle du clan 2 à member2 puis ajouter celui du clan 1.
+        //
+        // L'ajout est conditionné à la réussite du retrait : si Discord refuse
+        // le retrait (hiérarchie, permissions, coupure), poser quand même le
+        // second rôle laissait le membre avec **deux clans**, en silence, et
+        // définitivement — la sécurité de clan unique ne repasse jamais sur
+        // l'existant. Mieux vaut le laisser sur son clan d'origine.
+        const removed2 = await member2.roles.remove(clan2.roleId, `Double compte aligné sur ${member1.user.tag} (synchro auto)`)
+          .then(() => true)
+          .catch((err: unknown) => {
+            logger.error('ClanService', `Retrait du clan "${clan2.name}" impossible pour ${member2.user.tag}, alignement abandonné :`, err);
+            return false;
+          });
 
-        // Migrer les contributions de member2 du clan2 vers clan1
-        await migrateContributions(guildId, u2, clan2.id, clan1.id);
+        if (removed2) {
+          await member2.roles.add(clan1.roleId, `Double compte aligné sur ${member1.user.tag} (synchro auto)`).catch(() => null);
+
+          // Migrer les contributions de member2 du clan2 vers clan1
+          await migrateContributions(guildId, u2, clan2.id, clan1.id);
+        }
       } else {
         targetClan = clan2;
         logger.info('ClanService', `Synchro DC : Alignement de ${member1.user.tag} vers le clan de ${member2.user.tag} ("${clan2.name}" avec ${xp2} XP vs ${xp1} XP)`);
         
-        // Retirer le rôle du clan 1 à member1 et ajouter le rôle du clan 2
-        await member1.roles.remove(clan1.roleId, `Double compte aligné sur ${member2.user.tag} (synchro auto)`).catch(() => null);
-        await member1.roles.add(clan2.roleId, `Double compte aligné sur ${member2.user.tag} (synchro auto)`).catch(() => null);
+        // Même précaution que ci-dessus : pas d'ajout sans retrait réussi.
+        const removed1 = await member1.roles.remove(clan1.roleId, `Double compte aligné sur ${member2.user.tag} (synchro auto)`)
+          .then(() => true)
+          .catch((err: unknown) => {
+            logger.error('ClanService', `Retrait du clan "${clan1.name}" impossible pour ${member1.user.tag}, alignement abandonné :`, err);
+            return false;
+          });
 
-        // Migrer les contributions de member1 du clan1 vers clan2
-        await migrateContributions(guildId, u1, clan1.id, clan2.id);
+        if (removed1) {
+          await member1.roles.add(clan2.roleId, `Double compte aligné sur ${member2.user.tag} (synchro auto)`).catch(() => null);
+
+          // Migrer les contributions de member1 du clan1 vers clan2
+          await migrateContributions(guildId, u1, clan1.id, clan2.id);
+        }
       }
     } else {
       // Attribuer le clan à celui qui ne l'a pas

--- a/apps/dashboard/messages/en.json
+++ b/apps/dashboard/messages/en.json
@@ -82,6 +82,7 @@
   "clan_bg_task_active": "Background task active",
   "clan_task_type_distribute": "Random distribution",
   "clan_task_type_clear": "Role removal",
+  "clan_task_type_dedupe": "Multi-clan cleanup",
   "clan_list_heading": "Configured Clans",
   "clan_clear_all_title": "Remove all clan roles from the server",
   "clan_clear_all_btn": "Remove from all",

--- a/apps/dashboard/messages/fr.json
+++ b/apps/dashboard/messages/fr.json
@@ -82,6 +82,7 @@
   "clan_bg_task_active": "Tâche en arrière-plan active",
   "clan_task_type_distribute": "Distribution aléatoire",
   "clan_task_type_clear": "Retrait des rôles",
+  "clan_task_type_dedupe": "Nettoyage des clans multiples",
   "clan_list_heading": "Clans Configurés",
   "clan_clear_all_title": "Retirer tous les rôles de clan du serveur",
   "clan_clear_all_btn": "Retirer à tous",

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -3391,7 +3391,7 @@ export interface ClansDataResult {
   clanSeasonStartsAt: string | null;
   clanSeasonEndsAt: string | null;
   clans: ClanEntry[];
-  taskInProgress: { type: 'distribute' | 'clear'; processed: number; total: number } | null;
+  taskInProgress: { type: 'distribute' | 'clear' | 'dedupe'; processed: number; total: number } | null;
 }
 
 export async function fetchClansData(guildId = authStore.selectedGuildId): Promise<ClansDataResult | null> {

--- a/apps/dashboard/src/pages/Clans.svelte
+++ b/apps/dashboard/src/pages/Clans.svelte
@@ -38,7 +38,6 @@
 
   // States
   let clansEnabled = $state(false);
-  let clansUnique = $state(true);
   let clanAutoAssignOnJoin = $state(false);
   let currentClanSeason = $state(1);
   let clanXpFromLevelUp = $state(false);
@@ -63,7 +62,6 @@
 
   // Saved states (for dirty checking)
   let savedClansEnabled = $state(false);
-  let savedClansUnique = $state(true);
   let savedClanAutoAssignOnJoin = $state(false);
   let savedClanXpFromLevelUp = $state(false);
   let savedClanXpPerLevelUp = $state(50);
@@ -244,7 +242,6 @@
   // Sync state changes with the unsaved changes bar
   $effect(() => {
     const dirty = clansEnabled !== savedClansEnabled
-      || clansUnique !== savedClansUnique
       || clanAutoAssignOnJoin !== savedClanAutoAssignOnJoin
       || clanXpFromLevelUp !== savedClanXpFromLevelUp
       || clanXpPerLevelUp !== savedClanXpPerLevelUp
@@ -261,7 +258,6 @@
           onSave: () => handleSaveSettings(),
           onReset: () => {
             clansEnabled = savedClansEnabled;
-            clansUnique = savedClansUnique;
             clanAutoAssignOnJoin = savedClanAutoAssignOnJoin;
             clanXpFromLevelUp = savedClanXpFromLevelUp;
             clanXpPerLevelUp = savedClanXpPerLevelUp;
@@ -347,7 +343,6 @@
       const res = await fetchClansData();
       if (res) {
         clansEnabled = res.clansEnabled;
-        clansUnique = res.clansUnique;
         clanAutoAssignOnJoin = res.clanAutoAssignOnJoin;
         currentClanSeason = res.currentClanSeason;
         clanXpFromLevelUp = res.clanXpFromLevelUp;
@@ -368,7 +363,6 @@
         setSeasonDates(res.clanSeasonStartsAt, res.clanSeasonEndsAt);
         
         savedClansEnabled = res.clansEnabled;
-        savedClansUnique = res.clansUnique;
         savedClanAutoAssignOnJoin = res.clanAutoAssignOnJoin;
         savedClanXpFromLevelUp = res.clanXpFromLevelUp;
         savedClanXpPerLevelUp = res.clanXpPerLevelUp;
@@ -407,7 +401,6 @@
     await actionState.run(async () => {
       const res = await updateClanSettings({
         clansEnabled,
-        clansUnique,
         clanAutoAssignOnJoin,
         clanXpFromLevelUp,
         clanXpPerLevelUp,
@@ -424,7 +417,6 @@
       if (!res) throw new Error(m.clan_err_save());
       
       savedClansEnabled = res.clansEnabled;
-      savedClansUnique = res.clansUnique;
       savedClanAutoAssignOnJoin = res.clanAutoAssignOnJoin;
       savedClanXpFromLevelUp = res.clanXpFromLevelUp;
       savedClanXpPerLevelUp = res.clanXpPerLevelUp;
@@ -766,14 +758,6 @@
 
             <div class="flex items-center justify-between pt-4 border-t border-outline-variant/10">
               <div>
-                <span class="text-sm font-medium text-on-surface">{m.clan_unique_title()}</span>
-                <p class="text-xs text-on-surface-variant/70">{m.clan_unique_desc()}</p>
-              </div>
-              <ToggleSwitch checked={clansUnique} onToggle={(v) => clansUnique = v} disabled={!canManageSettings} />
-            </div>
-
-            <div class="flex items-center justify-between pt-4 border-t border-outline-variant/10">
-              <div>
                 <span class="text-sm font-medium text-on-surface">{m.clan_autoassign_title()}</span>
                 <p class="text-xs text-on-surface-variant/70">{m.clan_autoassign_desc()}</p>
               </div>
@@ -854,7 +838,7 @@
 
             <div class="space-y-2">
               <div class="flex justify-between text-xs font-medium text-on-surface-variant">
-                <span>{taskInProgress.type === 'distribute' ? m.clan_task_type_distribute() : m.clan_task_type_clear()}</span>
+                <span>{taskInProgress.type === 'distribute' ? m.clan_task_type_distribute() : taskInProgress.type === 'dedupe' ? m.clan_task_type_dedupe() : m.clan_task_type_clear()}</span>
                 <span>{taskInProgress.processed} / {taskInProgress.total}</span>
               </div>
               <div class="w-full bg-surface-container-high rounded-full h-2">

--- a/packages/database/prisma/guild.prisma
+++ b/packages/database/prisma/guild.prisma
@@ -147,6 +147,8 @@ model Guild {
   updatedAt DateTime @updatedAt
 
   clansEnabled      Boolean @default(false)
+  /// Héritée : l'unicité de clan est désormais toujours appliquée. La colonne
+  /// reste pour ne pas casser les bases existantes, mais plus rien ne la lit.
   clansUnique       Boolean @default(true)
   clanAutoAssignOnJoin Boolean @default(false)
   currentClanSeason Int     @default(1)


### PR DESCRIPTION
Distribution et retrait de masse : le verrou anti-double-lancement était posé après la préparation, qui dure plusieurs secondes (`members.fetch`), si bien que deux appels rapprochés lançaient deux opérations concurrentes sur les mêmes membres. Il est désormais posé avant le premier await, et relâché si la préparation échoue.

Écarte de la distribution les clans dont le rôle Discord n'existe plus : leur effectif restant à zéro, ils étaient élus à chaque tour comme clan le moins peuplé et toutes les attributions échouaient en silence — personne n'obtenait de clan alors que l'opération se déclarait terminée. Un rôle en échec répété sort aussi de la répartition.

Diffuse la progression au plus toutes les deux secondes au lieu d'une fois par membre : chaque notification fait recharger l'état complet de la guilde à tous les panels ouverts.

Synchro des doubles comptes : l'ajout du nouveau rôle suivait le retrait de l'ancien même quand celui-ci échouait, laissant le membre avec deux clans, en silence et définitivement. L'ajout est maintenant conditionné à la réussite du retrait.

Ajoute /clan dedupe, qui répare les cumuls existants : le clan conservé est celui où le membre a le plus contribué cette saison (identifiant canonique des comptes liés), à défaut le moins peuplé, et les contributions des clans quittés sont migrées vers celui conservé.

Retire l'option « Clan Unique » du panel et applique l'unicité en permanence : le reste du module ne sait pas représenter un membre à plusieurs clans, puisque l'attribution d'XP retient le premier rôle rencontré sans règle métier alors que les effectifs le comptent dans chacun de ses clans. La colonne reste en base, marquée comme héritée, pour éviter une migration.