### PR TITLE
fix(clans): le sélecteur de langue passe par userPrefs

### DIFF
--- a/apps/dashboard/src/pages/LevelingClanPublic.svelte
+++ b/apps/dashboard/src/pages/LevelingClanPublic.svelte
@@ -3,8 +3,9 @@
   import Papicon from '../lib/components/Papicon.svelte';
   import Skeleton from '../lib/components/Skeleton.svelte';
   import { fetchPublicClans } from '../lib/api';
-  import { m, dateLocale, getLocale, setLocale, locales, type Locale } from '../lib/i18n';
+  import { m, dateLocale, getLocale, locales, type Locale } from '../lib/i18n';
   import { themeStore } from '../lib/stores/theme.svelte';
+  import { userPrefs } from '../lib/stores/userPreferences.svelte';
 
   interface Props {
     serverId: string;
@@ -55,7 +56,7 @@
   const currentLocale = getLocale();
   function switchLocale(loc: Locale) {
     if (loc === currentLocale) return;
-    setLocale(loc);
+    userPrefs.set('language', loc);
   }
 
   // Grille : autant de colonnes que de clans (responsive, se replie si trop étroit)


### PR DESCRIPTION
Le bouton appelait setLocale() directement sans mettre à jour kotbo_prefs.language. Au rechargement, userPrefs réappliquait l'ancienne langue par-dessus, annulant le choix pour tout visiteur ayant des préférences sauvegardées.
