### PR TITLE
fix(dashboard): restaurer le rendu Papicons pour les icônes du dashboard

### DIFF
--- a/apps/dashboard/src/lib/components/Papicon.svelte
+++ b/apps/dashboard/src/lib/components/Papicon.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { Papicons } from "@getpapillon/papicons";
+  import { availablePapicons, toPapiconsName } from "../icons/papicons";
   import { getLucideIcon } from "../icons/lucide";
 
   const {
@@ -20,10 +22,84 @@
     children?: import('svelte').Snippet;
   } = $props();
 
+  function unwrapReactComponent(node: any) {
+    if (!node) return null;
+    let current = node;
+    let depth = 0;
+
+    while (current && typeof current.type === "function" && depth < 5) {
+      current = current.type(current.props || {});
+      depth += 1;
+    }
+
+    return current;
+  }
+
+  function flattenChildren(children: any) {
+    if (children == null) return [];
+    const stack = Array.isArray(children) ? [...children] : [children];
+    const flattened: any[] = [];
+
+    while (stack.length > 0) {
+      const child = stack.shift();
+      if (Array.isArray(child)) {
+        stack.unshift(...child);
+      } else if (child != null && typeof child === "object") {
+        flattened.push(child);
+      }
+    }
+
+    return flattened;
+  }
+
   const requestedIcon = $derived(icon || name);
+  const mergedClassName = $derived(`${className} ${classNameAlias} ${legacyClassName}`.trim());
+  const iconName = $derived(toPapiconsName(requestedIcon));
+  const isPapiconAvailable = $derived(availablePapicons.has(iconName));
+
+  const reactIcon = $derived.by(() => {
+    if (!isPapiconAvailable || !iconName) return null;
+    try {
+      return unwrapReactComponent((Papicons as any)({ name: iconName, size, className: mergedClassName }));
+    } catch {
+      return null;
+    }
+  });
+  const svgProps = $derived(reactIcon?.props ?? {});
+  const svgChildren = $derived(flattenChildren(svgProps.children));
+
   const LucideComponent = $derived(getLucideIcon(requestedIcon));
 </script>
 
-{#key requestedIcon}
-  <LucideComponent size={size} class={`${className} ${classNameAlias} ${legacyClassName}`.trim()} {style} stroke-width={2.25} />
+{#key isPapiconAvailable ? iconName : requestedIcon}
+  {#if isPapiconAvailable && reactIcon}
+    <svg
+      width={svgProps.width ?? size}
+      height={svgProps.height ?? size}
+      viewBox={svgProps.viewBox ?? "0 0 24 24"}
+      fill={svgProps.fill ?? "none"}
+      xmlns="http://www.w3.org/2000/svg"
+      class={mergedClassName}
+      {style}
+    >
+      {#each svgChildren as child}
+        {#if child.type === 'path'}
+          <path
+            d={child.props?.d}
+            fill={child.props?.fill ?? "currentColor"}
+            fill-rule={child.props?.fillRule}
+            clip-rule={child.props?.clipRule}
+          />
+        {:else}
+          {@const Tag = child.type}
+          <Tag
+            {...child.props}
+            fill={child.props?.fill ?? (['line', 'polyline', 'polygon'].includes(child.type) ? 'none' : 'currentColor')}
+          />
+        {/if}
+      {/each}
+    </svg>
+  {:else}
+    <LucideComponent size={size} class={mergedClassName} {style} stroke-width={2.25} />
+  {/if}
 {/key}


### PR DESCRIPTION
Le refactor 6cbc19e avait retiré le chemin de rendu Papicons de Papicon.svelte pour ne garder que Lucide (bundle plus léger). Résultat sur recette (issue #158) : sur des pages comme Tutoring → RolePermissionSettings, les icônes des boutons VOIR/MODÉRER/CONFIGURER/ SUPPRIMER n'étaient plus les jolies icônes Papicons filled/arrondies d'origine et disparaissaient visuellement, cassant la mise en page.

Rétablit le chemin de rendu Papicons (unwrap du composant React, ré-émission en SVG Svelte) en priorité quand l'icône fait partie du set availablePapicons, en gardant Lucide en fallback pour tout le reste. Les props récents (name, className, class_, style) restent supportés.
