### PR TITLE
feat(leveling): personnaliser la carte de rang depuis le dashboard

### DIFF
--- a/apps/bot/src/api/routes/user.ts
+++ b/apps/bot/src/api/routes/user.ts
@@ -4,6 +4,7 @@ import { logger } from '../../utils/logger.js';
 import { isGuildActivated } from '../../utils/activation.js';
 import {
   json,
+  readJsonBody,
   verifyAuth,
   resolveAdminAccess,
   resolveDashboardAccess,
@@ -13,6 +14,20 @@ import {
 import { getCurrentInstance, isWhiteLabelInstance } from '../../utils/instanceContext.js';
 import prisma from '../../utils/db.js';
 import { fetchExternal } from '../../utils/http.js';
+import {
+  normalizeRankCardCustomization,
+  RANK_CARD_BACKGROUNDS,
+  RANK_CARD_EMOJIS,
+  RANK_CARD_MAX_EMOJIS,
+} from '@kotbo/shared';
+import { getRankCardCustomization, saveRankCardCustomization } from '../../services/progression/rankCardService.js';
+import { renderRankCard } from '../../services/progression/levelingService.js';
+
+// Valeurs d'exemple de l'aperçu : la vraie progression dépend du serveur, la
+// personnalisation elle est globale.
+const PREVIEW_LEVEL = 12;
+const PREVIEW_XP = 16_800;
+const PREVIEW_RANK = 7;
 
 async function mapWithConcurrency<T, R>(
   values: T[],
@@ -86,6 +101,63 @@ export async function handleUserRoutes(
   if (parts[2] === 'me' && method === 'GET') {
     const isBotAdmin = await resolveAdminAccess(client, user.userId);
     json(res, 200, { id: user.userId, username: user.username, avatar: user.avatar, isBotAdmin });
+    return true;
+  }
+
+  // GET /api/user/rank-card
+  if (parts[2] === 'rank-card' && parts.length === 3 && method === 'GET') {
+    const customization = await getRankCardCustomization(user.userId);
+    json(res, 200, {
+      customization,
+      backgrounds: RANK_CARD_BACKGROUNDS,
+      emojis: RANK_CARD_EMOJIS.map((emoji) => emoji.value),
+      maxEmojis: RANK_CARD_MAX_EMOJIS,
+    });
+    return true;
+  }
+
+  // PUT /api/user/rank-card
+  if (parts[2] === 'rank-card' && parts.length === 3 && method === 'PUT') {
+    try {
+      const body = await readJsonBody(req);
+      const customization = await saveRankCardCustomization(user.userId, body);
+      json(res, 200, { customization });
+    } catch (err) {
+      logger.error('API', `Erreur de sauvegarde de la carte de rang pour ${user.userId}:`, err);
+      json(res, 500, { error: 'Une erreur interne est survenue' });
+    }
+    return true;
+  }
+
+  // POST /api/user/rank-card/preview — rendu réel, pour éviter de réimplémenter
+  // le dessin de la carte côté dashboard.
+  if (parts[2] === 'rank-card' && parts[3] === 'preview' && parts.length === 4 && method === 'POST') {
+    try {
+      const body = await readJsonBody(req);
+      const customization = normalizeRankCardCustomization(body);
+      const buffer = await renderRankCard(
+        {
+          userId: user.userId,
+          displayName: user.username ?? 'Membre',
+          username: user.username ?? 'membre',
+          discriminator: '0',
+          avatarUrl: user.avatar
+            ? `https://cdn.discordapp.com/avatars/${user.userId}/${user.avatar}.png?size=256`
+            : 'https://cdn.discordapp.com/embed/avatars/0.png',
+          status: 'online',
+        },
+        PREVIEW_LEVEL,
+        PREVIEW_XP,
+        PREVIEW_RANK,
+        customization,
+      );
+
+      res.writeHead(200, { 'Content-Type': 'image/png', 'Cache-Control': 'no-store' });
+      res.end(buffer);
+    } catch (err) {
+      logger.error('API', `Erreur d'aperçu de la carte de rang pour ${user.userId}:`, err);
+      json(res, 500, { error: 'Une erreur interne est survenue' });
+    }
     return true;
   }
 

--- a/apps/bot/src/services/progression/levelingService.ts
+++ b/apps/bot/src/services/progression/levelingService.ts
@@ -1,6 +1,14 @@
 import { Client, GuildMember } from 'discord.js';
-import { createCanvas, loadImage, type SKRSContext2D } from '@napi-rs/canvas';
+import { createCanvas, loadImage, type Image, type SKRSContext2D } from '@napi-rs/canvas';
 import type { LevelConfig } from '@prisma/client';
+import {
+  getRankCardBackground,
+  rankCardEmojiImageUrl,
+  RANK_CARD_HEIGHT,
+  RANK_CARD_WIDTH,
+  type RankCardCustomization,
+} from '@kotbo/shared';
+import { getRankCardCustomization } from './rankCardService.js';
 import prisma from '../../utils/db.js';
 import { logger } from '../../utils/logger.js';
 import { cache, getCachedGuild } from '../../utils/cache.js';
@@ -560,47 +568,84 @@ export async function getMemberRankData(guildId: string, userId: string) {
   };
 }
 
-export async function generateRankCard(member: GuildMember, level: number, xp: number, rank: number): Promise<Buffer> {
-  const W = 934, H = 282;
+export type RankCardSubject = {
+  userId: string;
+  displayName: string;
+  username: string;
+  discriminator: string;
+  avatarUrl: string;
+  status: string;
+};
+
+export async function generateRankCard(
+  member: GuildMember,
+  level: number,
+  xp: number,
+  rank: number,
+  customization?: RankCardCustomization,
+): Promise<Buffer> {
+  return renderRankCard(
+    {
+      userId: member.id,
+      displayName: member.displayName,
+      username: member.user.username,
+      discriminator: member.user.discriminator,
+      avatarUrl: member.user.displayAvatarURL({ extension: 'png', size: 256 }),
+      status: member.presence?.status ?? 'offline',
+    },
+    level,
+    xp,
+    rank,
+    customization,
+  );
+}
+
+/**
+ * Rendu détaché de discord.js : le dashboard prévisualise la même carte sans
+ * qu'un `GuildMember` soit disponible.
+ */
+export async function renderRankCard(
+  subject: RankCardSubject,
+  level: number,
+  xp: number,
+  rank: number,
+  customization?: RankCardCustomization,
+): Promise<Buffer> {
+  const W = RANK_CARD_WIDTH, H = RANK_CARD_HEIGHT;
+  const custom = customization ?? await getRankCardCustomization(subject.userId);
+  const preset = getRankCardBackground(custom.backgroundId);
   const canvas = createCanvas(W, H);
   const ctx = canvas.getContext('2d');
 
   // Background
   const bg = ctx.createLinearGradient(0, 0, W, H);
-  bg.addColorStop(0, '#0a0d13');
-  bg.addColorStop(0.5, '#0f1219');
-  bg.addColorStop(1, '#0a0d13');
+  for (const stop of preset.gradient) bg.addColorStop(stop.offset, stop.color);
   roundRect(ctx, 0, 0, W, H, 22, bg);
 
   // Accent bar (top)
   const topBar = ctx.createLinearGradient(0, 0, W, 0);
-  topBar.addColorStop(0, '#5865f2');
-  topBar.addColorStop(0.5, '#7b68ee');
-  topBar.addColorStop(1, '#57f287');
+  for (const stop of preset.accentBar) topBar.addColorStop(stop.offset, stop.color);
   ctx.fillStyle = topBar;
   ctx.fillRect(0, 0, W, 3);
 
   // Glows
-  const glow1 = ctx.createRadialGradient(W * 0.75, H * 0.4, 0, W * 0.75, H * 0.4, 300);
-  glow1.addColorStop(0, 'rgba(88, 101, 242, 0.1)');
-  glow1.addColorStop(1, 'rgba(0,0,0,0)');
-  ctx.fillStyle = glow1;
-  ctx.fillRect(0, 0, W, H);
-
-  const glow2 = ctx.createRadialGradient(150, 140, 0, 150, 140, 200);
-  glow2.addColorStop(0, 'rgba(87, 242, 135, 0.06)');
-  glow2.addColorStop(1, 'rgba(0,0,0,0)');
-  ctx.fillStyle = glow2;
-  ctx.fillRect(0, 0, W, H);
+  for (const glow of preset.glows) {
+    const cx = W * glow.x, cy = H * glow.y;
+    const gradient = ctx.createRadialGradient(cx, cy, 0, cx, cy, glow.radius);
+    gradient.addColorStop(0, glow.color);
+    gradient.addColorStop(1, 'rgba(0,0,0,0)');
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, W, H);
+  }
 
   // Avatar
-  const avatarUrl = member.user.displayAvatarURL({ extension: 'png', size: 256 });
+  const avatarUrl = subject.avatarUrl;
   const avatarCX = 115, avatarCY = 130, avatarR = 62;
 
   // Avatar ring
   const ringGrad = ctx.createLinearGradient(avatarCX - avatarR, avatarCY - avatarR, avatarCX + avatarR, avatarCY + avatarR);
-  ringGrad.addColorStop(0, '#5865f2');
-  ringGrad.addColorStop(1, '#57f287');
+  ringGrad.addColorStop(0, preset.accentBar[0].color);
+  ringGrad.addColorStop(1, preset.accentBar[preset.accentBar.length - 1].color);
   ctx.beginPath();
   ctx.arc(avatarCX, avatarCY, avatarR + 4, 0, Math.PI * 2);
   ctx.fillStyle = ringGrad;
@@ -608,7 +653,7 @@ export async function generateRankCard(member: GuildMember, level: number, xp: n
 
   ctx.beginPath();
   ctx.arc(avatarCX, avatarCY, avatarR + 1, 0, Math.PI * 2);
-  ctx.fillStyle = '#0a0d13';
+  ctx.fillStyle = preset.avatarBackdrop;
   ctx.fill();
 
   try {
@@ -628,11 +673,11 @@ export async function generateRankCard(member: GuildMember, level: number, xp: n
   }
 
   // Status indicator
-  const status = member.presence?.status || 'offline';
+  const status = subject.status;
   const statusColor = status === 'online' ? '#3ba55d' : status === 'idle' ? '#faa81a' : status === 'dnd' ? '#ed4245' : '#747f8d';
   ctx.beginPath();
   ctx.arc(avatarCX + 45, avatarCY + 45, 14, 0, Math.PI * 2);
-  ctx.fillStyle = '#0a0d13';
+  ctx.fillStyle = preset.avatarBackdrop;
   ctx.fill();
   ctx.beginPath();
   ctx.arc(avatarCX + 45, avatarCY + 45, 10, 0, Math.PI * 2);
@@ -643,13 +688,16 @@ export async function generateRankCard(member: GuildMember, level: number, xp: n
   const nameX = 210;
   ctx.fillStyle = '#ffffff';
   ctx.font = 'bold 30px sans-serif';
-  const truncatedName = member.displayName.length > 18 ? member.displayName.slice(0, 15) + '…' : member.displayName;
+  const truncatedName = subject.displayName.length > 18 ? subject.displayName.slice(0, 15) + '…' : subject.displayName;
   ctx.fillText(truncatedName, nameX, 80);
 
-  const tagText = member.user.discriminator !== '0' ? `#${member.user.discriminator}` : `@${member.user.username}`;
+  const tagText = subject.discriminator !== '0' ? `#${subject.discriminator}` : `@${subject.username}`;
   ctx.fillStyle = '#6e7681';
   ctx.font = '17px sans-serif';
   ctx.fillText(tagText, nameX, 106);
+  const tagWidth = ctx.measureText(tagText).width;
+
+  await drawRankCardEmojis(ctx, custom.emojis, nameX + tagWidth + 16, 99);
 
   // Rank & Level (right side)
   ctx.textAlign = 'right';
@@ -716,14 +764,46 @@ export async function generateRankCard(member: GuildMember, level: number, xp: n
 
   // Bottom accent bar
   const bottomBar = ctx.createLinearGradient(0, 0, W, 0);
-  bottomBar.addColorStop(0, 'rgba(88, 101, 242, 0)');
-  bottomBar.addColorStop(0.3, 'rgba(88, 101, 242, 0.3)');
-  bottomBar.addColorStop(0.7, 'rgba(87, 242, 135, 0.3)');
-  bottomBar.addColorStop(1, 'rgba(87, 242, 135, 0)');
+  for (const stop of preset.accentBar) bottomBar.addColorStop(stop.offset, stop.color);
+  ctx.save();
+  // Le liseré du bas s'estompe sur les bords : on reprend le dégradé du haut
+  // avec un masque d'opacité plutôt que de dupliquer les couleurs en rgba.
+  ctx.globalAlpha = 0.35;
   ctx.fillStyle = bottomBar;
   ctx.fillRect(0, H - 2, W, 2);
+  ctx.restore();
 
   return canvas.toBuffer('image/png');
+}
+
+const emojiImageCache = new Map<string, Image>();
+
+async function drawRankCardEmojis(
+  ctx: SKRSContext2D,
+  emojis: string[],
+  startX: number,
+  centerY: number,
+): Promise<void> {
+  const size = 26, gap = 8;
+  let x = startX;
+
+  for (const emoji of emojis) {
+    const url = rankCardEmojiImageUrl(emoji);
+    if (!url) continue;
+
+    let image = emojiImageCache.get(url);
+    if (!image) {
+      try {
+        image = await loadImage(url);
+        emojiImageCache.set(url, image);
+      } catch {
+        continue;
+      }
+    }
+
+    ctx.drawImage(image, x, centerY - size / 2, size, size);
+    x += size + gap;
+  }
 }
 
 // Helper pour dessiner des rectangles arrondis

--- a/apps/bot/src/services/progression/rankCardService.ts
+++ b/apps/bot/src/services/progression/rankCardService.ts
@@ -1,0 +1,53 @@
+import {
+  DEFAULT_RANK_CARD_CUSTOMIZATION,
+  normalizeRankCardCustomization,
+  type RankCardCustomization,
+} from '@kotbo/shared';
+import prisma from '../../utils/db.js';
+import { cache } from '../../utils/cache.js';
+import { logger } from '../../utils/logger.js';
+
+// TTL court : l'ecriture rafraichit le cache du processus qui enregistre, mais
+// un autre shard garde sa copie L1 jusqu'a expiration. Une minute borne le
+// decalage entre l'enregistrement sur le dashboard et le prochain `/rank`.
+const CACHE_TTL_SECONDS = 60;
+
+function cacheKey(userId: string): string {
+  return `user:${userId}:rank_card`;
+}
+
+/**
+ * La préférence est volontairement hors guilde : la même carte suit
+ * l'utilisateur sur tous les serveurs où il lance `/rank`.
+ */
+export async function getRankCardCustomization(userId: string): Promise<RankCardCustomization> {
+  const key = cacheKey(userId);
+  const cached = await cache.get<RankCardCustomization>(key);
+  if (cached) return cached;
+
+  try {
+    const preference = await prisma.rankCardPreference.findUnique({ where: { userId } });
+    const customization = preference
+      ? normalizeRankCardCustomization({ backgroundId: preference.backgroundId, emojis: preference.emojis })
+      : DEFAULT_RANK_CARD_CUSTOMIZATION;
+
+    await cache.set(key, customization, CACHE_TTL_SECONDS);
+    return customization;
+  } catch (error) {
+    logger.warn('RankCard', `Lecture de la personnalisation impossible pour ${userId}:`, error);
+    return DEFAULT_RANK_CARD_CUSTOMIZATION;
+  }
+}
+
+export async function saveRankCardCustomization(userId: string, raw: unknown): Promise<RankCardCustomization> {
+  const customization = normalizeRankCardCustomization(raw);
+
+  await prisma.rankCardPreference.upsert({
+    where: { userId },
+    update: { backgroundId: customization.backgroundId, emojis: customization.emojis },
+    create: { userId, backgroundId: customization.backgroundId, emojis: customization.emojis },
+  });
+
+  await cache.set(cacheKey(userId), customization, CACHE_TTL_SECONDS);
+  return customization;
+}

--- a/apps/dashboard/messages/en.json
+++ b/apps/dashboard/messages/en.json
@@ -7542,5 +7542,21 @@
   "sm_action_kick": "Kick",
   "sm_action_ban": "Ban",
   "sm_action_escalate": "Escalate",
-  "sm_action_reply": "Reply"
+  "sm_action_reply": "Reply",
+  "rc_title": "My rank card",
+  "rc_subtitle": "This card follows you across every server. The level, XP and rank shown on it stay specific to each server.",
+  "rc_preview_alt": "Rank card preview",
+  "rc_preview_loading": "Rendering…",
+  "rc_preview_note": "Preview uses sample values: your actual progress depends on the server.",
+  "rc_background_title": "Background",
+  "rc_emojis_title": "Emojis",
+  "rc_emoji_limit": "You can pick at most {count} emojis.",
+  "rc_save": "Save card",
+  "rc_saving": "Saving…",
+  "rc_saved": "Rank card updated.",
+  "rc_save_error": "Could not save the card.",
+  "rc_load_error": "Could not load the customization options.",
+  "rc_unsaved": "Unsaved changes",
+  "pf_tab_rank_card": "My rank card",
+  "rc_preview_error": "Preview unavailable right now."
 }

--- a/apps/dashboard/messages/fr.json
+++ b/apps/dashboard/messages/fr.json
@@ -7542,5 +7542,21 @@
   "sm_action_kick": "Expulser",
   "sm_action_ban": "Bannir",
   "sm_action_escalate": "Escalader",
-  "sm_action_reply": "Répondre"
+  "sm_action_reply": "Répondre",
+  "rc_title": "Ma carte de rang",
+  "rc_subtitle": "Cette carte vous suit sur tous les serveurs. Le niveau, l'XP et le rang affichés dessus restent propres à chaque serveur.",
+  "rc_preview_alt": "Aperçu de la carte de rang",
+  "rc_preview_loading": "Rendu…",
+  "rc_preview_note": "Aperçu avec des valeurs d'exemple : votre progression réelle dépend du serveur.",
+  "rc_background_title": "Fond",
+  "rc_emojis_title": "Emojis",
+  "rc_emoji_limit": "Vous pouvez choisir {count} emojis au maximum.",
+  "rc_save": "Enregistrer la carte",
+  "rc_saving": "Enregistrement…",
+  "rc_saved": "Carte de rang mise à jour.",
+  "rc_save_error": "Impossible d'enregistrer la carte.",
+  "rc_load_error": "Impossible de charger les options de personnalisation.",
+  "rc_unsaved": "Modifications non enregistrées",
+  "pf_tab_rank_card": "Ma carte de rang",
+  "rc_preview_error": "Aperçu indisponible pour le moment."
 }

--- a/apps/dashboard/src/lib/api/index.ts
+++ b/apps/dashboard/src/lib/api/index.ts
@@ -42,3 +42,4 @@ export * from './clans';
 export * from './ghostMembers';
 export * from './auditEvents';
 export * from './workflows';
+export * from './rankCard';

--- a/apps/dashboard/src/lib/api/rankCard.ts
+++ b/apps/dashboard/src/lib/api/rankCard.ts
@@ -1,0 +1,44 @@
+/** Personnalisation de la carte `/rank` : globale a l utilisateur, hors guilde. */
+import type { RankCardBackgroundPreset, RankCardCustomization } from '@kotbo/shared';
+import { API_BASE_URL, authorizedFetch } from './client';
+
+const RANK_CARD_URL = `${API_BASE_URL}/api/user/rank-card`;
+
+export type RankCardOptions = {
+  customization: RankCardCustomization;
+  backgrounds: RankCardBackgroundPreset[];
+  emojis: string[];
+  maxEmojis: number;
+};
+
+export async function fetchRankCardOptions(): Promise<RankCardOptions | null> {
+  const response = await authorizedFetch(RANK_CARD_URL);
+  if (!response.ok) return null;
+  return response.json();
+}
+
+export async function saveRankCard(customization: RankCardCustomization): Promise<RankCardCustomization | null> {
+  const response = await authorizedFetch(RANK_CARD_URL, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(customization),
+  });
+  if (!response.ok) return null;
+  const data = await response.json();
+  return data?.customization ?? null;
+}
+
+/**
+ * L apercu est rendu par le bot avec le meme code que `/rank` : pas de canvas
+ * a maintenir en double cote dashboard.
+ */
+export async function fetchRankCardPreview(customization: RankCardCustomization): Promise<string | null> {
+  const response = await authorizedFetch(`${RANK_CARD_URL}/preview`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(customization),
+  });
+  if (!response.ok) return null;
+  const blob = await response.blob();
+  return URL.createObjectURL(blob);
+}

--- a/apps/dashboard/src/lib/components/RankCardCustomizer.svelte
+++ b/apps/dashboard/src/lib/components/RankCardCustomizer.svelte
@@ -1,0 +1,236 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import { rankCardEmojiImageUrl, type RankCardBackgroundPreset, type RankCardCustomization } from '@kotbo/shared';
+  import { fetchRankCardOptions, fetchRankCardPreview, saveRankCard } from '../api/rankCard';
+  import { toast } from '../stores/toast.svelte';
+  import { m, getLocale } from '../i18n';
+  import Papicon from './Papicon.svelte';
+
+  let loading = $state(true);
+  let saving = $state(false);
+  let backgrounds = $state<RankCardBackgroundPreset[]>([]);
+  let availableEmojis = $state<string[]>([]);
+  let maxEmojis = $state(3);
+
+  let backgroundId = $state('default');
+  let emojis = $state<string[]>([]);
+  let savedSignature = $state('');
+
+  let previewUrl = $state<string | null>(null);
+  let previewLoading = $state(false);
+  let previewFailed = $state(false);
+  let previewTimer: ReturnType<typeof setTimeout> | null = null;
+  let previewToken = 0;
+
+  const draft = $derived<RankCardCustomization>({ backgroundId, emojis: [...emojis] });
+  const dirty = $derived(signatureOf(draft) !== savedSignature);
+
+  /** Signature canonique : ne pas dependre de l ordre des cles renvoyees par l API. */
+  function signatureOf(customization: RankCardCustomization): string {
+    return JSON.stringify([customization.backgroundId, customization.emojis]);
+  }
+
+  /** Reconstruit la vignette d un fond a partir de la meme recette que le canvas serveur. */
+  function swatchStyle(preset: RankCardBackgroundPreset): string {
+    const base = preset.gradient
+      .map((stop) => `${stop.color} ${Math.round(stop.offset * 100)}%`)
+      .join(', ');
+    const glows = preset.glows
+      .map((glow) => `radial-gradient(circle at ${Math.round(glow.x * 100)}% ${Math.round(glow.y * 100)}%, ${glow.color}, transparent 60%)`)
+      .join(', ');
+    const layers = glows ? `${glows}, linear-gradient(135deg, ${base})` : `linear-gradient(135deg, ${base})`;
+    return `background: ${layers};`;
+  }
+
+  function accentStyle(preset: RankCardBackgroundPreset): string {
+    const stops = preset.accentBar
+      .map((stop) => `${stop.color} ${Math.round(stop.offset * 100)}%`)
+      .join(', ');
+    return `background: linear-gradient(90deg, ${stops});`;
+  }
+
+  function releasePreview() {
+    if (previewUrl) URL.revokeObjectURL(previewUrl);
+    previewUrl = null;
+  }
+
+  async function refreshPreview(customization: RankCardCustomization) {
+    const token = ++previewToken;
+    previewLoading = true;
+    try {
+      const url = await fetchRankCardPreview(customization);
+      if (token !== previewToken) {
+        if (url) URL.revokeObjectURL(url);
+        return;
+      }
+      if (url) {
+        releasePreview();
+        previewUrl = url;
+        previewFailed = false;
+      } else {
+        previewFailed = true;
+      }
+    } catch {
+      if (token === previewToken) previewFailed = true;
+    } finally {
+      if (token === previewToken) previewLoading = false;
+    }
+  }
+
+  function toggleEmoji(emoji: string) {
+    if (emojis.includes(emoji)) {
+      emojis = emojis.filter((entry) => entry !== emoji);
+      return;
+    }
+    if (emojis.length >= maxEmojis) {
+      toast.warning(m.rc_emoji_limit({ count: maxEmojis }));
+      return;
+    }
+    emojis = [...emojis, emoji];
+  }
+
+  async function save() {
+    saving = true;
+    try {
+      const result = await saveRankCard(draft);
+      if (!result) {
+        toast.error(m.rc_save_error());
+        return;
+      }
+      backgroundId = result.backgroundId;
+      emojis = result.emojis;
+      savedSignature = signatureOf(result);
+      toast.success(m.rc_saved());
+    } catch {
+      toast.error(m.rc_save_error());
+    } finally {
+      saving = false;
+    }
+  }
+
+  $effect(() => {
+    // Le rendu passe par le bot : on attend une pause dans les clics pour ne
+    // pas enchainer un aller-retour par vignette survolee.
+    const customization = draft;
+    if (loading) return;
+    if (previewTimer) clearTimeout(previewTimer);
+    previewTimer = setTimeout(() => refreshPreview(customization), 250);
+  });
+
+  $effect(() => {
+    void (async () => {
+      try {
+        const options = await fetchRankCardOptions();
+        if (options) {
+          backgrounds = options.backgrounds;
+          availableEmojis = options.emojis;
+          maxEmojis = options.maxEmojis;
+          backgroundId = options.customization.backgroundId;
+          emojis = options.customization.emojis;
+          savedSignature = signatureOf(options.customization);
+        } else {
+          toast.error(m.rc_load_error());
+        }
+      } catch {
+        toast.error(m.rc_load_error());
+      } finally {
+        loading = false;
+      }
+    })();
+  });
+
+  onDestroy(() => {
+    if (previewTimer) clearTimeout(previewTimer);
+    releasePreview();
+  });
+</script>
+
+<div class="space-y-6">
+  <div>
+    <h3 class="text-[15px] font-semibold text-on-surface">{m.rc_title()}</h3>
+    <p class="mt-1 text-[13px] text-on-surface-variant">{m.rc_subtitle()}</p>
+  </div>
+
+  {#if loading}
+    <div class="h-[180px] animate-pulse rounded-xl bg-surface-container-low"></div>
+  {:else if backgrounds.length === 0}
+    <p class="text-[13px] text-on-surface-variant">{m.rc_load_error()}</p>
+  {:else}
+    <div class="relative overflow-hidden rounded-xl border border-outline-variant bg-surface-container-low">
+      {#if previewUrl}
+        <img src={previewUrl} alt={m.rc_preview_alt()} class="w-full" />
+      {:else if previewFailed}
+        <div class="flex aspect-[934/282] w-full items-center justify-center px-4 text-center text-[13px] text-on-surface-variant">
+          {m.rc_preview_error()}
+        </div>
+      {:else}
+        <div class="aspect-[934/282] w-full animate-pulse bg-surface-container-high"></div>
+      {/if}
+      {#if previewLoading}
+        <div class="absolute right-3 top-3 rounded-full bg-black/60 px-2.5 py-1 text-[11px] text-white">
+          {m.rc_preview_loading()}
+        </div>
+      {/if}
+    </div>
+    <p class="text-[12px] text-on-surface-variant">{m.rc_preview_note()}</p>
+
+    <div>
+      <h4 class="mb-2 text-[13px] font-medium text-on-surface">{m.rc_background_title()}</h4>
+      <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+        {#each backgrounds as preset (preset.id)}
+          <button
+            type="button"
+            onclick={() => (backgroundId = preset.id)}
+            aria-pressed={backgroundId === preset.id}
+            class="group overflow-hidden rounded-lg border text-left transition-all {backgroundId === preset.id ? 'border-primary ring-2 ring-primary/40' : 'border-outline-variant hover:border-primary/50'}"
+          >
+            <div class="h-14 w-full" style={swatchStyle(preset)}>
+              <div class="h-[3px] w-full" style={accentStyle(preset)}></div>
+            </div>
+            <div class="flex items-center justify-between px-2 py-1.5">
+              <span class="text-[12px] text-on-surface">{getLocale() === 'fr' ? preset.label.fr : preset.label.en}</span>
+              {#if backgroundId === preset.id}
+                <Papicon icon="Check" size={13} class="text-primary" />
+              {/if}
+            </div>
+          </button>
+        {/each}
+      </div>
+    </div>
+
+    <div>
+      <h4 class="mb-2 text-[13px] font-medium text-on-surface">
+        {m.rc_emojis_title()}
+        <span class="ml-1 font-normal text-on-surface-variant">{emojis.length}/{maxEmojis}</span>
+      </h4>
+      <div class="flex flex-wrap gap-2">
+        {#each availableEmojis as emoji (emoji)}
+          <button
+            type="button"
+            onclick={() => toggleEmoji(emoji)}
+            aria-pressed={emojis.includes(emoji)}
+            class="flex h-10 w-10 items-center justify-center rounded-lg border transition-all {emojis.includes(emoji) ? 'border-primary bg-primary/10' : 'border-outline-variant hover:border-primary/50'}"
+          >
+            <!-- Meme asset que le canvas serveur : la police emoji du systeme
+                 ne ressemble pas au rendu de la carte. -->
+            <img src={rankCardEmojiImageUrl(emoji)} alt={emoji} class="h-5 w-5" />
+          </button>
+        {/each}
+      </div>
+    </div>
+
+    <div class="flex items-center gap-3">
+      <button
+        type="button"
+        onclick={save}
+        disabled={saving || !dirty}
+        class="rounded-lg bg-primary px-4 py-2 text-[13px] font-medium text-on-primary transition-all hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {saving ? m.rc_saving() : m.rc_save()}
+      </button>
+      {#if dirty}
+        <span class="text-[12px] text-on-surface-variant">{m.rc_unsaved()}</span>
+      {/if}
+    </div>
+  {/if}
+</div>

--- a/apps/dashboard/src/pages/Profile.svelte
+++ b/apps/dashboard/src/pages/Profile.svelte
@@ -19,6 +19,7 @@
   import MetricCard from '../lib/components/MetricCard.svelte';
   import FormInput from '../lib/components/FormInput.svelte';
   import Papicon from '../lib/components/Papicon.svelte';
+  import RankCardCustomizer from '../lib/components/RankCardCustomizer.svelte';
   import Chart from '../lib/components/charts/Chart.svelte';
   import { toast } from '../lib/stores/toast.svelte';
   import { confirmDialog } from '../lib/stores/confirmDialog.svelte';
@@ -50,7 +51,7 @@
   
   let loading = $state(true);
   let error = $state('');
-  const profileTabs = ['staff_overview', 'staff_activity', 'community_overview', 'api_keys'] as const;
+  const profileTabs = ['staff_overview', 'staff_activity', 'community_overview', 'rank_card', 'api_keys'] as const;
   let activeTab = $state('staff_overview');
 
   const profileBase = $derived(userId ? `/profile/${userId}` : '/profile');
@@ -89,6 +90,9 @@
     ...(publicProfile ? [
       { id: 'community_overview', label: m.pf_tab_community(), icon: 'User' }
     ] : []),
+    ...(isOwnProfile ? [
+      { id: 'rank_card', label: m.pf_tab_rank_card(), icon: 'Sparkles' }
+    ] : []),
     ...(staffMember && isOwnProfile ? [
       { id: 'api_keys', label: m.pf_tab_api_keys(), icon: 'Lock' }
     ] : [])
@@ -100,6 +104,12 @@
       loadProfile(targetUserId);
     }
   });
+
+  // L onglet choisi dans l URL prime sur le defaut deduit du type de profil,
+  // sinon un lien direct vers un onglet serait ecrase a la fin du chargement.
+  function applyDefaultTab(fallback: string) {
+    activeTab = resolveTabFromUrl(profileBase, profileTabs, fallback);
+  }
 
   async function loadProfile(id: string) {
     loading = true;
@@ -138,10 +148,10 @@
         
         // Default active tab
         if (staffMember) {
-          activeTab = 'staff_overview';
+          applyDefaultTab('staff_overview');
           await loadScorecard(staffMember.guildId, id);
         } else {
-          activeTab = 'community_overview';
+          applyDefaultTab('community_overview');
         }
 
         // Load pending resignation if own profile
@@ -157,14 +167,23 @@
         if (pubRes.ok) {
           publicProfile = await pubRes.json();
           staffMember = null;
-          activeTab = 'community_overview';
+          applyDefaultTab('community_overview');
         } else {
           throw new Error(m.pf_load_error());
         }
       }
     } catch (err: any) {
       console.error('Erreur lors du chargement du profil:', err);
-      error = err.message || 'Erreur lors du chargement du profil';
+      // Un membre sans fiche staff ni profil de serveur n'a rien a afficher ici,
+      // mais sa carte de rang ne depend d'aucun des deux : sur son propre profil
+      // on garde la page accessible au lieu de la remplacer par une erreur.
+      if (isOwnProfile) {
+        staffMember = null;
+        publicProfile = null;
+        applyDefaultTab('rank_card');
+      } else {
+        error = err.message || 'Erreur lors du chargement du profil';
+      }
     } finally {
       loading = false;
     }
@@ -193,6 +212,9 @@
   const getUserAvatar = () => {
     if (staffMember?.avatarUrl) return staffMember.avatarUrl;
     if (publicProfile?.avatar) return publicProfile.avatar;
+    if (isOwnProfile && authStore.user?.avatar) {
+      return `https://cdn.discordapp.com/avatars/${authStore.user.id}/${authStore.user.avatar}.png`;
+    }
     return 'https://cdn.discordapp.com/embed/avatars/0.png';
   };
 
@@ -1124,6 +1146,11 @@
               </div>
             </div>
           </div>
+        </div>
+
+      {:else if activeTab === 'rank_card' && isOwnProfile}
+        <div class="rounded-xl bg-surface-container-low/30 p-10 border border-outline-variant/10 shadow-sm">
+          <RankCardCustomizer />
         </div>
 
       {:else if activeTab === 'api_keys' && staffMember && isOwnProfile}

--- a/packages/database/prisma/rank-card.prisma
+++ b/packages/database/prisma/rank-card.prisma
@@ -1,0 +1,14 @@
+/// Personnalisation de la carte `/rank`, volontairement hors de toute guilde :
+/// elle appartient à l'utilisateur et le suit sur tous les serveurs, alors que
+/// le niveau et l'XP affichés dessus restent propres à chaque serveur.
+model RankCardPreference {
+  userId String @id
+
+  backgroundId String @default("default")
+  emojis       Json   @default("[]")
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("rank_card_preferences")
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,3 +10,6 @@ export * from './workflow/types.js';
 export * from './workflow/catalog.js';
 export * from './workflow/validate.js';
 export * from './simulation/types.js';
+export * from './rankCard/types.js';
+export * from './rankCard/presets.js';
+export * from './rankCard/normalize.js';

--- a/packages/shared/src/rankCard/normalize.ts
+++ b/packages/shared/src/rankCard/normalize.ts
@@ -1,0 +1,79 @@
+import { DEFAULT_RANK_CARD_BACKGROUND_ID, RANK_CARD_BACKGROUNDS } from './presets.js';
+import type { RankCardCustomization } from './types.js';
+
+export const RANK_CARD_MAX_EMOJIS = 3;
+
+/** Dimensions de référence de la carte. */
+export const RANK_CARD_WIDTH = 934;
+export const RANK_CARD_HEIGHT = 282;
+
+/**
+ * Catalogue fermé : le canvas serveur n'a pas de police couleur, chaque emoji
+ * doit donc correspondre à un asset Twemoji connu. Les points de code sont
+ * figés ici plutôt que dérivés du caractère, pour éviter les surprises des
+ * sélecteurs de variante et des séquences ZWJ.
+ */
+export const RANK_CARD_EMOJIS: Array<{ value: string; codePoint: string }> = [
+  { value: '🔥', codePoint: '1f525' },
+  { value: '⭐', codePoint: '2b50' },
+  { value: '⚡', codePoint: '26a1' },
+  { value: '✨', codePoint: '2728' },
+  { value: '💎', codePoint: '1f48e' },
+  { value: '👑', codePoint: '1f451' },
+  { value: '🏆', codePoint: '1f3c6' },
+  { value: '🚀', codePoint: '1f680' },
+  { value: '🎯', codePoint: '1f3af' },
+  { value: '🎮', codePoint: '1f3ae' },
+  { value: '🎧', codePoint: '1f3a7' },
+  { value: '🌙', codePoint: '1f319' },
+  { value: '🪐', codePoint: '1fa90' },
+  { value: '🌊', codePoint: '1f30a' },
+  { value: '🍀', codePoint: '1f340' },
+  { value: '🌸', codePoint: '1f338' },
+  { value: '🐺', codePoint: '1f43a' },
+  { value: '🦊', codePoint: '1f98a' },
+  { value: '🧊', codePoint: '1f9ca' },
+  { value: '💀', codePoint: '1f480' },
+];
+
+const EMOJI_CODE_POINTS = new Map(RANK_CARD_EMOJIS.map((emoji) => [emoji.value, emoji.codePoint]));
+
+export const DEFAULT_RANK_CARD_CUSTOMIZATION: RankCardCustomization = {
+  backgroundId: DEFAULT_RANK_CARD_BACKGROUND_ID,
+  emojis: [],
+};
+
+/**
+ * Ramène une entrée quelconque (corps de requête, colonne Json) à une
+ * personnalisation sûre à dessiner. Toute valeur inconnue est écartée au lieu
+ * de faire échouer le rendu : une carte par défaut vaut mieux qu'un `/rank`
+ * cassé.
+ */
+export function normalizeRankCardCustomization(raw: unknown): RankCardCustomization {
+  const candidate = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+
+  const backgroundId = typeof candidate.backgroundId === 'string'
+    && RANK_CARD_BACKGROUNDS.some((preset) => preset.id === candidate.backgroundId)
+    ? candidate.backgroundId
+    : DEFAULT_RANK_CARD_BACKGROUND_ID;
+
+  const seen = new Set<string>();
+  const emojis: string[] = [];
+  if (Array.isArray(candidate.emojis)) {
+    for (const entry of candidate.emojis) {
+      if (typeof entry !== 'string' || !EMOJI_CODE_POINTS.has(entry) || seen.has(entry)) continue;
+      seen.add(entry);
+      emojis.push(entry);
+      if (emojis.length >= RANK_CARD_MAX_EMOJIS) break;
+    }
+  }
+
+  return { backgroundId, emojis };
+}
+
+/** URL de l'asset Twemoji correspondant, ou `null` si l'emoji n'est pas au catalogue. */
+export function rankCardEmojiImageUrl(value: string): string | null {
+  const codePoint = EMOJI_CODE_POINTS.get(value);
+  if (!codePoint) return null;
+  return `https://cdn.jsdelivr.net/gh/jdecked/twemoji@16.0.1/assets/72x72/${codePoint}.png`;
+}

--- a/packages/shared/src/rankCard/presets.ts
+++ b/packages/shared/src/rankCard/presets.ts
@@ -1,0 +1,190 @@
+import type { RankCardBackgroundPreset } from './types.js';
+
+/**
+ * Les fonds sont décrits comme des recettes de peinture (dégradés + halos)
+ * plutôt que comme des images : rien à héberger, rien à modérer, et le rendu
+ * reste net quelle que soit la taille de la carte.
+ */
+export const RANK_CARD_BACKGROUNDS: RankCardBackgroundPreset[] = [
+  {
+    id: 'default',
+    label: { fr: 'Kotbo', en: 'Kotbo' },
+    gradient: [
+      { offset: 0, color: '#0a0d13' },
+      { offset: 0.5, color: '#0f1219' },
+      { offset: 1, color: '#0a0d13' },
+    ],
+    glows: [
+      { x: 0.75, y: 0.4, radius: 300, color: 'rgba(88, 101, 242, 0.1)' },
+      { x: 0.16, y: 0.5, radius: 200, color: 'rgba(87, 242, 135, 0.06)' },
+    ],
+    accentBar: [
+      { offset: 0, color: '#5865f2' },
+      { offset: 0.5, color: '#7b68ee' },
+      { offset: 1, color: '#57f287' },
+    ],
+    avatarBackdrop: '#0a0d13',
+  },
+  {
+    id: 'midnight',
+    label: { fr: 'Minuit', en: 'Midnight' },
+    gradient: [
+      { offset: 0, color: '#05070f' },
+      { offset: 1, color: '#101a33' },
+    ],
+    glows: [
+      { x: 0.8, y: 0.2, radius: 340, color: 'rgba(59, 130, 246, 0.16)' },
+      { x: 0.1, y: 0.9, radius: 260, color: 'rgba(129, 140, 248, 0.1)' },
+    ],
+    accentBar: [
+      { offset: 0, color: '#1d4ed8' },
+      { offset: 1, color: '#60a5fa' },
+    ],
+    avatarBackdrop: '#05070f',
+  },
+  {
+    id: 'sunset',
+    label: { fr: 'Coucher de soleil', en: 'Sunset' },
+    gradient: [
+      { offset: 0, color: '#1b0b12' },
+      { offset: 1, color: '#3a1220' },
+    ],
+    glows: [
+      { x: 0.78, y: 0.75, radius: 320, color: 'rgba(249, 115, 22, 0.2)' },
+      { x: 0.2, y: 0.2, radius: 240, color: 'rgba(236, 72, 153, 0.14)' },
+    ],
+    accentBar: [
+      { offset: 0, color: '#f97316' },
+      { offset: 1, color: '#ec4899' },
+    ],
+    avatarBackdrop: '#1b0b12',
+  },
+  {
+    id: 'forest',
+    label: { fr: 'Forêt', en: 'Forest' },
+    gradient: [
+      { offset: 0, color: '#06120c' },
+      { offset: 1, color: '#0d2418' },
+    ],
+    glows: [
+      { x: 0.72, y: 0.35, radius: 300, color: 'rgba(34, 197, 94, 0.16)' },
+      { x: 0.15, y: 0.8, radius: 220, color: 'rgba(163, 230, 53, 0.08)' },
+    ],
+    accentBar: [
+      { offset: 0, color: '#16a34a' },
+      { offset: 1, color: '#a3e635' },
+    ],
+    avatarBackdrop: '#06120c',
+  },
+  {
+    id: 'crimson',
+    label: { fr: 'Cramoisi', en: 'Crimson' },
+    gradient: [
+      { offset: 0, color: '#140506' },
+      { offset: 1, color: '#2e0a10' },
+    ],
+    glows: [
+      { x: 0.75, y: 0.5, radius: 320, color: 'rgba(239, 68, 68, 0.18)' },
+      { x: 0.12, y: 0.25, radius: 230, color: 'rgba(251, 146, 60, 0.08)' },
+    ],
+    accentBar: [
+      { offset: 0, color: '#b91c1c' },
+      { offset: 1, color: '#f87171' },
+    ],
+    avatarBackdrop: '#140506',
+  },
+  {
+    id: 'aurora',
+    label: { fr: 'Aurore', en: 'Aurora' },
+    gradient: [
+      { offset: 0, color: '#050b14' },
+      { offset: 0.5, color: '#0a1a24' },
+      { offset: 1, color: '#0b1020' },
+    ],
+    glows: [
+      { x: 0.3, y: 0.1, radius: 300, color: 'rgba(45, 212, 191, 0.18)' },
+      { x: 0.85, y: 0.85, radius: 300, color: 'rgba(167, 139, 250, 0.16)' },
+    ],
+    accentBar: [
+      { offset: 0, color: '#2dd4bf' },
+      { offset: 1, color: '#a78bfa' },
+    ],
+    avatarBackdrop: '#050b14',
+  },
+  {
+    id: 'gold',
+    label: { fr: 'Or', en: 'Gold' },
+    gradient: [
+      { offset: 0, color: '#12100a' },
+      { offset: 1, color: '#241d0c' },
+    ],
+    glows: [
+      { x: 0.76, y: 0.45, radius: 320, color: 'rgba(234, 179, 8, 0.18)' },
+      { x: 0.14, y: 0.7, radius: 220, color: 'rgba(253, 224, 71, 0.08)' },
+    ],
+    accentBar: [
+      { offset: 0, color: '#b45309' },
+      { offset: 1, color: '#fde047' },
+    ],
+    avatarBackdrop: '#12100a',
+  },
+  {
+    id: 'mono',
+    label: { fr: 'Monochrome', en: 'Monochrome' },
+    gradient: [
+      { offset: 0, color: '#0b0b0c' },
+      { offset: 1, color: '#1a1a1d' },
+    ],
+    glows: [
+      { x: 0.7, y: 0.3, radius: 300, color: 'rgba(255, 255, 255, 0.06)' },
+    ],
+    accentBar: [
+      { offset: 0, color: '#52525b' },
+      { offset: 1, color: '#e4e4e7' },
+    ],
+    avatarBackdrop: '#0b0b0c',
+  },
+  {
+    id: 'ocean',
+    label: { fr: 'Océan', en: 'Ocean' },
+    gradient: [
+      { offset: 0, color: '#04121a' },
+      { offset: 1, color: '#07293a' },
+    ],
+    glows: [
+      { x: 0.8, y: 0.6, radius: 320, color: 'rgba(14, 165, 233, 0.18)' },
+      { x: 0.18, y: 0.2, radius: 240, color: 'rgba(34, 211, 238, 0.1)' },
+    ],
+    accentBar: [
+      { offset: 0, color: '#0284c7' },
+      { offset: 1, color: '#22d3ee' },
+    ],
+    avatarBackdrop: '#04121a',
+  },
+  {
+    id: 'candy',
+    label: { fr: 'Bonbon', en: 'Candy' },
+    gradient: [
+      { offset: 0, color: '#160b1f' },
+      { offset: 1, color: '#2a0f33' },
+    ],
+    glows: [
+      { x: 0.75, y: 0.3, radius: 320, color: 'rgba(217, 70, 239, 0.18)' },
+      { x: 0.2, y: 0.8, radius: 250, color: 'rgba(56, 189, 248, 0.12)' },
+    ],
+    accentBar: [
+      { offset: 0, color: '#d946ef' },
+      { offset: 1, color: '#38bdf8' },
+    ],
+    avatarBackdrop: '#160b1f',
+  },
+];
+
+export const DEFAULT_RANK_CARD_BACKGROUND_ID = 'default';
+
+export function getRankCardBackground(id: string | null | undefined): RankCardBackgroundPreset {
+  return (
+    RANK_CARD_BACKGROUNDS.find((preset) => preset.id === id)
+    ?? RANK_CARD_BACKGROUNDS[0]
+  );
+}

--- a/packages/shared/src/rankCard/types.ts
+++ b/packages/shared/src/rankCard/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Personnalisation de la carte `/rank`.
+ *
+ * La préférence est globale à l'utilisateur (elle le suit d'un serveur à
+ * l'autre) : seules les données de progression affichées dessus (niveau, XP,
+ * rang) restent propres au serveur où la commande est lancée.
+ */
+
+export type RankCardStopColor = { offset: number; color: string };
+
+export type RankCardGlow = {
+  /** Position du centre, en fraction de la largeur / hauteur de la carte. */
+  x: number;
+  y: number;
+  /** Rayon en pixels sur la carte de référence (934x282). */
+  radius: number;
+  color: string;
+};
+
+export type RankCardBackgroundPreset = {
+  id: string;
+  /** Libellé affiché dans le dashboard, en français puis en anglais. */
+  label: { fr: string; en: string };
+  /** Dégradé de fond, tracé en diagonale du coin haut-gauche au coin bas-droit. */
+  gradient: RankCardStopColor[];
+  /** Halos radiaux dessinés par-dessus le dégradé. */
+  glows: RankCardGlow[];
+  /** Dégradé horizontal des liserés haut et bas. */
+  accentBar: RankCardStopColor[];
+  /** Couleur de remplissage du disque derrière l'avatar. */
+  avatarBackdrop: string;
+};
+
+/**
+ * Les emojis ne sont pas positionnables : le rendu les aligne lui-même dans la
+ * bande décorative sous le pseudo. L'utilisateur choisit seulement lesquels et
+ * dans quel ordre.
+ */
+export type RankCardCustomization = {
+  backgroundId: string;
+  emojis: string[];
+};


### PR DESCRIPTION
La carte de `/rank` était entièrement en dur : fond, halos, liserés et anneau d'avatar étaient écrits dans `generateRankCard`, sans aucun réglage possible côté membre. maintenant il y a le rajout d'une carte profile personnalisable, les options vont arrivées progressivement. La carte profile de l'utilisateur fonctionne sur tous les serveurs il faut juste que les levels soient activer

La personnalisation se trouve sur « Mon Profil ». 

Le TTL de cache est court, une minute. L'écriture rafraîchit le cache du processus qui enregistre, mais un autre shard garde sa copie L1 jusqu'à expiration.