### PR TITLE
fix(dashboard): conserver le theme choisi lors de la bascule clair/sombre

### DIFF
--- a/apps/dashboard/src/lib/stores/theme.svelte.ts
+++ b/apps/dashboard/src/lib/stores/theme.svelte.ts
@@ -466,6 +466,12 @@ export function buildCustomSurfaceVars(colors: CustomThemeColors): Record<string
 
 const THEME_KEY = 'kotbo_theme';
 const CUSTOM_COLORS_KEY = 'kotbo_custom_theme';
+/**
+ * Dernier thème retenu pour chaque mode. Le bouton clair/sombre y revient au
+ * lieu de retomber sur les presets nus : sans ça, basculer depuis Midnight
+ * effaçait le choix de l'utilisateur, qui devait le refaire à chaque aller-retour.
+ */
+const PREFERRED_KEY = 'kotbo_theme_preferred';
 
 function createThemeStore() {
   const savedId = (typeof localStorage !== 'undefined' ? localStorage.getItem(THEME_KEY) : null) as ThemeId | null;
@@ -475,6 +481,50 @@ function createThemeStore() {
   );
   let customColors = $state<CustomThemeColors>(loadCustomColors());
   let currentAccent = $state<AccentColorId>('violet');
+  let preferredByMode = $state<Record<ThemeMode, ThemeId>>(loadPreferred());
+
+  function loadPreferred(): Record<ThemeMode, ThemeId> {
+    const fallback: Record<ThemeMode, ThemeId> = { light: 'light', dark: 'dark' };
+    try {
+      if (typeof localStorage === 'undefined') return fallback;
+      const raw = localStorage.getItem(PREFERRED_KEY);
+      if (raw) return { ...fallback, ...JSON.parse(raw) };
+    } catch { /* ignore */ }
+    return fallback;
+  }
+
+  function modeOf(id: ThemeId): ThemeMode {
+    if (id === 'custom') return customColors.mode;
+    return THEME_PRESETS.find(p => p.id === id)?.mode ?? 'dark';
+  }
+
+  /** Retient un thème comme choix de l'utilisateur pour le mode auquel il appartient. */
+  function rememberPreferred(id: ThemeId) {
+    const next: Record<ThemeMode, ThemeId> = { ...preferredByMode };
+    next[modeOf(id)] = id;
+    preferredByMode = next;
+    try {
+      localStorage.setItem(PREFERRED_KEY, JSON.stringify(preferredByMode));
+    } catch { /* ignore */ }
+  }
+
+  function themeForMode(mode: ThemeMode): ThemeId {
+    const candidate = preferredByMode[mode];
+    // Le thème « custom » peut avoir changé de mode depuis qu'il a été retenu :
+    // on ne le ressort que s'il correspond toujours au mode demandé.
+    if (candidate && modeOf(candidate) === mode) return candidate;
+    return mode === 'dark' ? 'dark' : 'light';
+  }
+
+  function applyThemeId(id: ThemeId) {
+    themeId = id;
+    rememberPreferred(id);
+    try {
+      localStorage.setItem(THEME_KEY, id);
+    } catch { /* ignore */ }
+    applyAll();
+    syncThemeToDb(id, customColors);
+  }
 
   function loadCustomColors(): CustomThemeColors {
     try {
@@ -486,9 +536,7 @@ function createThemeStore() {
   }
 
   function getMode(): ThemeMode {
-    if (themeId === 'custom') return customColors.mode;
-    const preset = THEME_PRESETS.find(p => p.id === themeId);
-    return preset?.mode ?? 'dark';
+    return modeOf(themeId);
   }
 
   function clearInlineVars() {
@@ -566,6 +614,7 @@ function createThemeStore() {
     }
   }
 
+  rememberPreferred(themeId);
   applyAll();
 
   return {
@@ -574,10 +623,7 @@ function createThemeStore() {
     },
 
     set dark(value: boolean) {
-      themeId = value ? 'dark' : 'light';
-      localStorage.setItem(THEME_KEY, themeId);
-      applyAll();
-      syncThemeToDb(themeId, customColors);
+      applyThemeId(themeForMode(value ? 'dark' : 'light'));
     },
 
     get themeId() {
@@ -585,10 +631,7 @@ function createThemeStore() {
     },
 
     set themeId(id: ThemeId) {
-      themeId = id;
-      localStorage.setItem(THEME_KEY, id);
-      applyAll();
-      syncThemeToDb(id, customColors);
+      applyThemeId(id);
     },
 
     get mode(): ThemeMode {
@@ -602,7 +645,9 @@ function createThemeStore() {
     setCustomColors(colors: CustomThemeColors) {
       customColors = { ...colors };
       localStorage.setItem(CUSTOM_COLORS_KEY, JSON.stringify(customColors));
-      if (themeId === 'custom') applyAll();
+      // Le mode du thème custom vient de changer : il doit être retenu pour le
+      // bon mode, sinon la bascule le proposerait encore pour l'ancien.
+      if (themeId === 'custom') { rememberPreferred('custom'); applyAll(); }
       syncThemeToDb(themeId, customColors);
     },
 
@@ -613,11 +658,7 @@ function createThemeStore() {
     },
 
     toggle() {
-      const mode = getMode();
-      themeId = mode === 'dark' ? 'light' : 'dark';
-      localStorage.setItem(THEME_KEY, themeId);
-      applyAll();
-      syncThemeToDb(themeId, customColors);
+      applyThemeId(themeForMode(getMode() === 'dark' ? 'light' : 'dark'));
     },
   };
 }

--- a/apps/dashboard/src/lib/stores/userPreferences.svelte.ts
+++ b/apps/dashboard/src/lib/stores/userPreferences.svelte.ts
@@ -178,7 +178,10 @@ class UserPreferencesStore {
     try {
       const { updateUserSettings } = await import('../api');
       await updateUserSettings({
-        themeId: this.prefs.theme,
+        // Lu depuis le magasin et non depuis `prefs` : le bouton clair/sombre
+        // change le thème sans passer par ici, et une valeur périmée renvoyée à
+        // la base ressuscitait l'ancien thème au chargement suivant.
+        themeId: themeStore.themeId,
         customTheme: themeStore.themeId === 'custom' ? themeStore.customColors : null,
         accentColor: this.prefs.accentColor,
         sidebarBehavior: this.prefs.sidebarBehavior,

--- a/apps/dashboard/src/pages/UserSettings.svelte
+++ b/apps/dashboard/src/pages/UserSettings.svelte
@@ -153,7 +153,7 @@
   }
 
   const activeThemeLabel = $derived(
-    THEME_PRESETS.find(p => p.id === userPrefs.prefs.theme)?.label ?? 'Custom'
+    THEME_PRESETS.find(p => p.id === themeStore.themeId)?.label ?? 'Custom'
   );
   const activeSummary = $derived([
     { label: m.us_summary_theme(), value: activeThemeLabel },
@@ -311,7 +311,7 @@
             <button
               onclick={() => handleToggle('theme', preset.id)}
               class="group relative flex flex-col items-center gap-2 p-3 rounded-lg border-2 transition-all duration-200 text-xs font-bold
- {userPrefs.prefs.theme === preset.id
+ {themeStore.themeId === preset.id
                   ? 'border-primary bg-primary/10 text-primary shadow-sm shadow-primary/20'
                   : 'border-outline-variant/20 bg-surface-container-high/20 text-on-surface-variant hover:border-primary/30 hover:bg-primary/5'}"
             >
@@ -327,7 +327,7 @@
           <button
             onclick={() => { handleToggle('theme', 'custom'); showCustomEditor = true; }}
             class="group relative flex flex-col items-center gap-2 p-3 rounded-lg border-2 transition-all duration-200 text-xs font-bold
- {userPrefs.prefs.theme === 'custom'
+ {themeStore.themeId === 'custom'
                 ? 'border-primary bg-primary/10 text-primary shadow-sm shadow-primary/20'
                 : 'border-outline-variant/20 bg-surface-container-high/20 text-on-surface-variant hover:border-primary/30 hover:bg-primary/5'}"
           >
@@ -340,7 +340,7 @@
       </div>
 
       <!-- Custom Theme Editor -->
-      {#if userPrefs.prefs.theme === 'custom' || showCustomEditor}
+      {#if themeStore.themeId === 'custom' || showCustomEditor}
         <div class="space-y-4 p-4 rounded-lg border border-primary/20 bg-primary/5 animate-in fade-in duration-200">
           <div class="flex items-center justify-between">
             <p class="text-xs font-bold text-primary">{m.us_custom_theme()}</p>
@@ -607,7 +607,7 @@
       {m.us_reset_desc()}
     </p>
     <button
-      onclick={() => { userPrefs.reset(); themeStore.dark = userPrefs.prefs.theme === 'dark'; showSavedFeedback(); toast.success(m.us_reset_done()); }}
+      onclick={() => { userPrefs.reset(); themeStore.themeId = userPrefs.prefs.theme; showSavedFeedback(); toast.success(m.us_reset_done()); }}
       class="px-6 py-2.5 rounded-xl border-2 border-rose-500/40 text-rose-500 font-bold text-sm hover:bg-rose-500/10 transition-all duration-200 hover:border-rose-500/60"
     >
       {m.us_reset_button()}


### PR DESCRIPTION
Corrige #176.

Le bouton clair/sombre remplacait l'identifiant du theme par le preset nu 'light' ou 'dark'. Un membre ayant choisi Midnight, Nord ou un theme personnalise le perdait donc au premier clic, et devait le reselectionner dans les parametres a chaque aller-retour.