### PR TITLE
fix(dashboard): afficher les pseudos dans l'onglet reputation

### DIFF
--- a/apps/bot/src/api/routes/dashboard/reputation.ts
+++ b/apps/bot/src/api/routes/dashboard/reputation.ts
@@ -3,6 +3,7 @@ import { Client } from 'discord.js';
 import { logger } from '../../../utils/logger.js';
 import { json, type AuthClaims, type DashboardAccess } from '../../shared.js';
 import { getReputationDashboardData } from '../../../services/community/reputationService.js';
+import { getMemberIdentities } from '../../../services/moderation/memberIdentityService.js';
 
 export async function handleReputationRoutes(
   req: IncomingMessage,
@@ -21,7 +22,34 @@ export async function handleReputationRoutes(
   if (parts.length === 5 && method === 'GET') {
     try {
       const data = await getReputationDashboardData(guildId);
-      json(res, 200, data);
+
+      // La réputation ne stocke que des identifiants : sans cette résolution, le
+      // classement et le flux des votes affichent des suites de chiffres.
+      const identities = await getMemberIdentities(client, guildId, [
+        ...data.leaderboard.entries.map((entry) => entry.userId),
+        ...data.recentVotes.flatMap((vote) => [vote.giverId, vote.receiverId]),
+      ]);
+      const nameOf = (userId: string) => identities.get(userId)?.displayName ?? null;
+      const avatarOf = (userId: string) => identities.get(userId)?.avatarUrl || null;
+
+      json(res, 200, {
+        ...data,
+        leaderboard: {
+          ...data.leaderboard,
+          entries: data.leaderboard.entries.map((entry) => ({
+            ...entry,
+            displayName: nameOf(entry.userId),
+            avatarUrl: avatarOf(entry.userId),
+          })),
+        },
+        recentVotes: data.recentVotes.map((vote) => ({
+          ...vote,
+          giverName: nameOf(vote.giverId),
+          giverAvatarUrl: avatarOf(vote.giverId),
+          receiverName: nameOf(vote.receiverId),
+          receiverAvatarUrl: avatarOf(vote.receiverId),
+        })),
+      });
     } catch (err) {
       logger.error('ReputationAPI', 'Error fetching reputation data:', err);
       json(res, 500, { error: 'Erreur lors de la récupération des données' });

--- a/apps/bot/src/services/moderation/memberIdentityService.ts
+++ b/apps/bot/src/services/moderation/memberIdentityService.ts
@@ -53,6 +53,52 @@ function withTimeout<T>(promise: Promise<T>): Promise<T | null> {
  * La réécriture en base est volontairement restreinte aux lignes dont le pseudo
  * est absent : une identité déjà connue n'est jamais écrasée.
  */
+/**
+ * Identités affichables pour une liste d'identifiants.
+ *
+ * Le profil en base répond pour la plupart des membres sans solliciter Discord ;
+ * seuls ceux qu'il ne nomme pas encore passent par la résolution Discord, qui
+ * réécrit au passage le profil. Sans ça, les vues qui n'affichent qu'un
+ * identifiant brut - le classement de réputation notamment - restent
+ * illisibles.
+ */
+export async function getMemberIdentities(
+  client: Client,
+  guildId: string,
+  userIds: string[],
+): Promise<Map<string, MemberIdentity>> {
+  const identities = new Map<string, MemberIdentity>();
+  const unique = [...new Set(userIds)].filter((id): id is string => Boolean(id));
+  if (unique.length === 0) return identities;
+
+  const profiles = await prisma.memberProfile
+    .findMany({
+      where: { guildId, userId: { in: unique } },
+      select: { userId: true, username: true, displayName: true, globalName: true, avatarUrl: true },
+    })
+    .catch(() => []);
+
+  for (const profile of profiles) {
+    const displayName = profile.displayName ?? profile.globalName ?? profile.username;
+    // Un profil cree a partir du seul identifiant n'a pas de pseudo : on le
+    // laisse a la resolution Discord plutot que d'afficher un vide.
+    if (!displayName) continue;
+    identities.set(profile.userId, {
+      username: profile.username ?? displayName,
+      displayName,
+      avatarUrl: profile.avatarUrl ?? '',
+    });
+  }
+
+  const missing = unique.filter((id) => !identities.has(id));
+  if (missing.length > 0) {
+    const resolved = await resolveMissingMemberIdentities(client, guildId, missing).catch(() => new Map());
+    for (const [userId, identity] of resolved) identities.set(userId, identity);
+  }
+
+  return identities;
+}
+
 export async function resolveMissingMemberIdentities(
   client: Client,
   guildId: string,

--- a/apps/dashboard/src/pages/Reputation.svelte
+++ b/apps/dashboard/src/pages/Reputation.svelte
@@ -96,7 +96,14 @@
             <div class="reputation-leaderboard-row grid items-center gap-2 px-2.5 py-2 rounded-lg text-sm transition-colors hover:bg-surface-container-high/20 {i < 3 ? 'bg-surface-container-high/10' : ''}">
               <span class="text-base leading-none">{getMedal(i)}</span>
               <span class="font-semibold text-on-surface-variant/60 text-xs">#{entry.rank}</span>
-              <span class="font-mono text-xs text-on-surface-variant/60 truncate">{entry.userId}</span>
+              <div class="flex items-center gap-2 min-w-0">
+                {#if entry.avatarUrl}
+                  <img src={entry.avatarUrl} alt="" loading="lazy" class="w-5 h-5 rounded-full shrink-0 object-cover" />
+                {/if}
+                <span class="text-xs text-on-surface truncate" title={entry.userId}>
+                  {entry.displayName ?? entry.userId}
+                </span>
+              </div>
               <div class="h-2 bg-surface-container-high rounded-full overflow-hidden">
                 <div
                   class="h-2 rounded-full transition-all duration-500 bg-emerald-500"
@@ -126,14 +133,14 @@
               <div class="flex items-center gap-2 flex-wrap">
                 <div class="flex items-center gap-1.5 text-on-surface-variant/60">
                   <Papicon icon="User" size={13} />
-                  <span class="font-mono text-xs">{vote.giverId}</span>
+                  <span class="text-xs truncate max-w-[10rem]" title={vote.giverId}>{vote.giverName ?? vote.giverId}</span>
                 </div>
                 <div class="text-primary flex items-center">
                   <Papicon icon="ArrowRight" size={14} />
                 </div>
                 <div class="flex items-center gap-1.5">
                   <Papicon icon="Star" size={13} />
-                  <span class="font-mono text-xs font-medium text-emerald-500">{vote.receiverId}</span>
+                  <span class="text-xs font-medium text-emerald-500 truncate max-w-[10rem]" title={vote.receiverId}>{vote.receiverName ?? vote.receiverId}</span>
                 </div>
               </div>
               {#if vote.reason}


### PR DESCRIPTION
Corrige #179.

Le service de reputation ne renvoyait que les identifiants Discord, et la page les affichait tels quels : le classement et le flux des votes n'etaient qu'une suite de chiffres.
La route resout desormais les identites avant de repondre, via un helper ajoute a memberIdentityService : le profil en base repond pour la plupart des membres sans solliciter Discord, et seuls ceux qu'il ne nomme pas encore passent par la resolution Discord existante, qui gere le cache, le chunk des membres presents, le repli sur l'API utilisateur pour ceux qui ont quitte le serveur, et la reecriture du profil au passage.
Le classement affiche l'avatar et le pseudo, le flux des votes le pseudo. L'identifiant reste accessible en infobulle. L'avatar est place dans la cellule du pseudo et non a cote : le style local de la ligne fixe cinq colonnes et cible ses enfants par position, un frere supplementaire aurait decale la barre de progression et le score.
