### PR TITLE
Feat/leveling preset detail link

### DIFF
--- a/apps/dashboard/messages/en.json
+++ b/apps/dashboard/messages/en.json
@@ -3027,7 +3027,7 @@
   "lv_presets_recommended": "Recommended",
   "lv_presets_save": "Save",
   "lv_presets_save_hint": "Nothing is applied until you save.",
-  "lv_presets_already_saved": "This preset is already the saved one.",
+  "lv_presets_already_saved": "This is already the saved configuration.",
   "lv_presets_module_off": "The module is disabled: turn it on at the top of the page for XP to be handed out.",
   "lv_presets_tile_level_10": "Level 10",
   "lv_presets_max_level": "Maximum level: {level}",

--- a/apps/dashboard/messages/fr.json
+++ b/apps/dashboard/messages/fr.json
@@ -3027,7 +3027,7 @@
   "lv_presets_recommended": "Recommandé",
   "lv_presets_save": "Enregistrer",
   "lv_presets_save_hint": "Rien n'est appliqué tant que vous n'avez pas enregistré.",
-  "lv_presets_already_saved": "Ce préréglage est déjà celui enregistré.",
+  "lv_presets_already_saved": "C'est déjà la configuration enregistrée.",
   "lv_presets_module_off": "Le module est désactivé : activez-le en haut de la page pour que l'XP soit distribuée.",
   "lv_presets_tile_level_10": "Niveau 10",
   "lv_presets_max_level": "Niveau maximum : {level}",

--- a/apps/dashboard/src/lib/components/LevelingPresetPicker.svelte
+++ b/apps/dashboard/src/lib/components/LevelingPresetPicker.svelte
@@ -85,6 +85,45 @@
       preset: null,
     },
   ]);
+
+  // Les six courbes partagent une echelle commune, sinon leurs silhouettes se
+  // ressemblent toutes. Cette echelle est logarithmique : en lineaire, Marathon
+  // (127 000 XP au niveau 10) ecrase les autres courbes sur la ligne du bas.
+  const CURVE_LEVELS = 20;
+
+  function curveScale(values: LevelingPresetValues): number[] {
+    return Array.from({ length: CURVE_LEVELS }, (_, index) =>
+      Math.log10(1 + levelingValuesXpForLevel(values, index + 1)));
+  }
+
+  // L'echelle est bornee par les seuls prereglages : une configuration
+  // personnalisee extreme deformerait sinon les cinq autres courbes. La sienne
+  // est donc ramenee dans le cadre.
+  const CURVE_BOUNDS = (() => {
+    const points = LEVELING_PRESETS.flatMap((preset) => curveScale(levelingPresetValues(preset)));
+    return { min: Math.min(...points), max: Math.max(...points) };
+  })();
+
+  function curvePoints(values: LevelingPresetValues): string {
+    const span = Math.max(0.001, CURVE_BOUNDS.max - CURVE_BOUNDS.min);
+    return curveScale(values)
+      .map((point, index) => {
+        const x = (index / (CURVE_LEVELS - 1)) * 100;
+        const ratio = Math.min(1, Math.max(0, (point - CURVE_BOUNDS.min) / span));
+        return `${x.toFixed(2)},${(32 - ratio * 30).toFixed(2)}`;
+      })
+      .join(' ');
+  }
+
+  // La carte enregistree garde un contour, la carte choisie un fond plein :
+  // l'ecart entre « ce qui tourne » et « ce qui remplacera » reste lisible.
+  function cardTone(card: PresetCard, selected: boolean, active: boolean): string {
+    const outline = card.preset ? '' : ' border-dashed';
+    if (selected) return 'bg-primary/8 border-primary/50 shadow-lg shadow-primary/10' + outline;
+    if (active) return 'bg-surface-container-low/30 border-tertiary/40 hover:border-tertiary/60 hover:bg-surface-container-high/20' + outline;
+    if (card.preset) return 'bg-surface-container-low/30 border-outline-variant/10 hover:border-outline-variant/30 hover:bg-surface-container-high/20';
+    return 'bg-surface-container-low/20 border-outline-variant/25 hover:border-outline-variant/40 hover:bg-surface-container-high/20' + outline;
+  }
 </script>
 
 <div class="space-y-8 animate-in fade-in duration-300">
@@ -104,6 +143,9 @@
       {@const values = card.values}
       {@const selected = card.preset ? selectedId === card.preset.id : selectedId === null}
       {@const active = card.preset ? activeId === card.preset.id : activeId === null}
+      <!-- La carte « Personnalise » inactive n'a pas de valeurs a montrer :
+           elle repeterait celles du prereglage en cours. -->
+      {@const detailed = !!card.preset || active}
       <!-- Le liseré et la teinte ne marquent que le préréglage choisi. Le
            recommandé se signale par son seul badge : deux cartes colorées se
            disputeraient le regard. -->
@@ -112,62 +154,85 @@
         onclick={() => (card.preset ? onselect(card.preset) : ondetail())}
         {disabled}
         aria-pressed={card.preset ? selected : undefined}
-        class="relative overflow-hidden text-left p-6 rounded-xl border transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed {selected
-          ? 'bg-primary/8 border-primary/50 shadow-lg shadow-primary/10'
-          : card.preset
-            ? 'bg-surface-container-low/30 border-outline-variant/10 hover:border-outline-variant/30 hover:bg-surface-container-high/20'
-            : 'bg-surface-container-low/20 border-dashed border-outline-variant/25 hover:border-outline-variant/40 hover:bg-surface-container-high/20'}"
+        class="relative overflow-hidden text-left p-6 rounded-xl border transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed {cardTone(card, selected, active)}"
       >
         {#if selected}
           <span class="absolute inset-x-0 top-0 h-[3px] bg-primary" aria-hidden="true"></span>
         {/if}
 
-        <div class="flex items-start justify-between gap-3">
-          <div class="flex items-center gap-3 min-w-0">
-            <div class="w-9 h-9 shrink-0 rounded-lg flex items-center justify-center {selected ? 'bg-primary/15' : 'bg-surface-container-high/40'}">
-              <Papicon icon={card.icon} size={18} class={selected ? 'text-primary' : 'text-on-surface-variant/70'} />
+        {#if detailed}
+          <svg
+            class="absolute inset-x-0 bottom-0 w-full h-20 {selected ? 'text-primary/30' : 'text-on-surface-variant/15'}"
+            viewBox="0 0 100 32"
+            preserveAspectRatio="none"
+            aria-hidden="true"
+          >
+            <polyline
+              points={curvePoints(values)}
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linejoin="round"
+              vector-effect="non-scaling-stroke"
+            />
+          </svg>
+        {/if}
+
+        <div class="relative">
+          <div class="flex items-start justify-between gap-3">
+            <div class="flex items-center gap-3 min-w-0">
+              <div class="w-9 h-9 shrink-0 rounded-lg flex items-center justify-center {selected ? 'bg-primary/15' : 'bg-surface-container-high/40'}">
+                <Papicon icon={card.icon} size={18} class={selected ? 'text-primary' : 'text-on-surface-variant/70'} />
+              </div>
+              <h3 class="text-base font-semibold text-on-surface truncate">{card.name}</h3>
             </div>
-            <h3 class="text-base font-semibold text-on-surface truncate">{card.name}</h3>
+            {#if active}
+              <span class="shrink-0 text-[10px] font-bold uppercase tracking-widest px-2 py-1 rounded-lg bg-tertiary/15 text-tertiary">
+                {m.lv_presets_active()}
+              </span>
+            {:else if selected}
+              <span class="shrink-0 text-[10px] font-bold uppercase tracking-widest px-2 py-1 rounded-lg bg-primary/15 text-primary">
+                {m.lv_presets_selected()}
+              </span>
+            {:else if card.recommended}
+              <span class="shrink-0 text-[10px] font-bold uppercase tracking-widest px-2 py-1 rounded-lg border border-primary/30 text-primary/80">
+                {m.lv_presets_recommended()}
+              </span>
+            {/if}
           </div>
-          {#if active}
-            <span class="shrink-0 text-[10px] font-bold uppercase tracking-widest px-2 py-1 rounded-lg bg-tertiary/15 text-tertiary">
-              {m.lv_presets_active()}
-            </span>
-          {:else if selected}
-            <span class="shrink-0 text-[10px] font-bold uppercase tracking-widest px-2 py-1 rounded-lg bg-primary/15 text-primary">
-              {m.lv_presets_selected()}
-            </span>
-          {:else if card.recommended}
-            <span class="shrink-0 text-[10px] font-bold uppercase tracking-widest px-2 py-1 rounded-lg border border-primary/30 text-primary/80">
-              {m.lv_presets_recommended()}
-            </span>
+
+          <p class="text-[13px] text-on-surface-variant/70 mt-3 leading-relaxed">{card.desc}</p>
+
+          {#if detailed}
+            <div class="grid grid-cols-2 gap-2.5 mt-5">
+              <div class="px-3 py-2 bg-surface-container-high/20 border border-outline-variant/5 rounded-lg">
+                <p class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest">{m.lv_gains_tile_message()}</p>
+                <p class="text-sm font-semibold text-on-surface">{values.xpMin} – {values.xpMax}</p>
+              </div>
+              <div class="px-3 py-2 bg-surface-container-high/20 border border-outline-variant/5 rounded-lg">
+                <p class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest">{m.lv_gains_tile_cooldown()}</p>
+                <p class="text-sm font-semibold text-on-surface">{values.cooldownSeconds} s</p>
+              </div>
+              <div class="px-3 py-2 bg-surface-container-high/20 border border-outline-variant/5 rounded-lg">
+                <p class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest">{m.lv_gains_tile_hourly()}</p>
+                <p class="text-sm font-semibold text-on-surface">≈ {levelingValuesHourlyXp(values).toLocaleString()}</p>
+              </div>
+              <div class="px-3 py-2 bg-surface-container-high/20 border border-outline-variant/5 rounded-lg">
+                <p class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest">{m.lv_presets_tile_level_10()}</p>
+                <p class="text-sm font-semibold text-on-surface">{levelingValuesXpForLevel(values, 10).toLocaleString()} XP</p>
+              </div>
+            </div>
+
+            <p class="text-[11px] text-on-surface-variant/50 mt-3">
+              {values.maxLevel > 0 ? m.lv_presets_max_level({ level: values.maxLevel }) : m.lv_presets_no_max_level()}
+            </p>
+          {:else}
+            <p class="flex items-center gap-1.5 mt-5 text-[13px] font-semibold text-primary/80">
+              {m.lv_presets_open_advanced()}
+              <Papicon icon="ArrowRight" size={14} />
+            </p>
           {/if}
         </div>
-
-        <p class="text-[13px] text-on-surface-variant/70 mt-3 leading-relaxed">{card.desc}</p>
-
-        <div class="grid grid-cols-2 gap-2.5 mt-5">
-          <div class="px-3 py-2 bg-surface-container-high/20 border border-outline-variant/5 rounded-lg">
-            <p class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest">{m.lv_gains_tile_message()}</p>
-            <p class="text-sm font-semibold text-on-surface">{values.xpMin} – {values.xpMax}</p>
-          </div>
-          <div class="px-3 py-2 bg-surface-container-high/20 border border-outline-variant/5 rounded-lg">
-            <p class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest">{m.lv_gains_tile_cooldown()}</p>
-            <p class="text-sm font-semibold text-on-surface">{values.cooldownSeconds} s</p>
-          </div>
-          <div class="px-3 py-2 bg-surface-container-high/20 border border-outline-variant/5 rounded-lg">
-            <p class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest">{m.lv_gains_tile_hourly()}</p>
-            <p class="text-sm font-semibold text-on-surface">≈ {levelingValuesHourlyXp(values).toLocaleString()}</p>
-          </div>
-          <div class="px-3 py-2 bg-surface-container-high/20 border border-outline-variant/5 rounded-lg">
-            <p class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest">{m.lv_presets_tile_level_10()}</p>
-            <p class="text-sm font-semibold text-on-surface">{levelingValuesXpForLevel(values, 10).toLocaleString()} XP</p>
-          </div>
-        </div>
-
-        <p class="text-[11px] text-on-surface-variant/50 mt-3">
-          {values.maxLevel > 0 ? m.lv_presets_max_level({ level: values.maxLevel }) : m.lv_presets_no_max_level()}
-        </p>
       </button>
     {/each}
   </div>

--- a/apps/dashboard/src/lib/components/LevelingPresetPicker.svelte
+++ b/apps/dashboard/src/lib/components/LevelingPresetPicker.svelte
@@ -104,10 +104,9 @@
       {@const values = card.values}
       {@const selected = card.preset ? selectedId === card.preset.id : selectedId === null}
       {@const active = card.preset ? activeId === card.preset.id : activeId === null}
-      <!-- Le liseré et la teinte ne servent qu'à deux états : le préréglage
-           recommandé, et celui qu'on vient de choisir. Colorer les six cartes
-           les rendrait indistinctes. -->
-      {@const accented = selected || card.recommended}
+      <!-- Le liseré et la teinte ne marquent que le préréglage choisi. Le
+           recommandé se signale par son seul badge : deux cartes colorées se
+           disputeraient le regard. -->
       <button
         type="button"
         onclick={() => (card.preset ? onselect(card.preset) : ondetail())}
@@ -115,20 +114,18 @@
         aria-pressed={card.preset ? selected : undefined}
         class="relative overflow-hidden text-left p-6 rounded-xl border transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed {selected
           ? 'bg-primary/8 border-primary/50 shadow-lg shadow-primary/10'
-          : card.recommended
-            ? 'bg-primary/3 border-primary/25 hover:border-primary/40 hover:bg-primary/6'
-            : card.preset
-              ? 'bg-surface-container-low/30 border-outline-variant/10 hover:border-outline-variant/30 hover:bg-surface-container-high/20'
-              : 'bg-surface-container-low/20 border-dashed border-outline-variant/25 hover:border-outline-variant/40 hover:bg-surface-container-high/20'}"
+          : card.preset
+            ? 'bg-surface-container-low/30 border-outline-variant/10 hover:border-outline-variant/30 hover:bg-surface-container-high/20'
+            : 'bg-surface-container-low/20 border-dashed border-outline-variant/25 hover:border-outline-variant/40 hover:bg-surface-container-high/20'}"
       >
-        {#if accented}
-          <span class="absolute inset-x-0 top-0 h-[3px] bg-primary {selected ? '' : 'opacity-50'}" aria-hidden="true"></span>
+        {#if selected}
+          <span class="absolute inset-x-0 top-0 h-[3px] bg-primary" aria-hidden="true"></span>
         {/if}
 
         <div class="flex items-start justify-between gap-3">
           <div class="flex items-center gap-3 min-w-0">
-            <div class="w-9 h-9 shrink-0 rounded-lg flex items-center justify-center {accented ? 'bg-primary/15' : 'bg-surface-container-high/40'}">
-              <Papicon icon={card.icon} size={18} class={accented ? 'text-primary' : 'text-on-surface-variant/70'} />
+            <div class="w-9 h-9 shrink-0 rounded-lg flex items-center justify-center {selected ? 'bg-primary/15' : 'bg-surface-container-high/40'}">
+              <Papicon icon={card.icon} size={18} class={selected ? 'text-primary' : 'text-on-surface-variant/70'} />
             </div>
             <h3 class="text-base font-semibold text-on-surface truncate">{card.name}</h3>
           </div>

--- a/apps/dashboard/src/lib/components/LevelingPresetPicker.svelte
+++ b/apps/dashboard/src/lib/components/LevelingPresetPicker.svelte
@@ -24,7 +24,7 @@
   }: {
     selectedId?: string | null;
     activeId?: string | null;
-    /** Valeurs actuelles de la guilde, affichees par la carte « Personnalise ». */
+    /** Valeurs hors prereglage a montrer sur la carte « Personnalise ». */
     customValues: LevelingPresetValues;
     disabled?: boolean;
     dirty?: boolean;
@@ -146,13 +146,18 @@
       <!-- La carte « Personnalise » inactive n'a pas de valeurs a montrer :
            elle repeterait celles du prereglage en cours. -->
       {@const detailed = !!card.preset || active}
+      <!-- La carte « Personnalise » choisie montre les valeurs en attente, pas
+           celles qui tournent : elle ne peut pas se dire « active » tant qu'un
+           enregistrement reste a faire. -->
+      {@const running = active && !(!card.preset && selected && dirty)}
       <!-- Le liseré et la teinte ne marquent que le préréglage choisi. Le
            recommandé se signale par son seul badge : deux cartes colorées se
-           disputeraient le regard. -->
+           disputeraient le regard. La carte « Personnalise » reste cliquable
+           sans droit de modification : elle ne fait que naviguer. -->
       <button
         type="button"
         onclick={() => (card.preset ? onselect(card.preset) : ondetail())}
-        {disabled}
+        disabled={!!card.preset && disabled}
         aria-pressed={card.preset ? selected : undefined}
         class="relative overflow-hidden text-left p-6 rounded-xl border transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed {cardTone(card, selected, active)}"
       >
@@ -186,7 +191,7 @@
               </div>
               <h3 class="text-base font-semibold text-on-surface truncate">{card.name}</h3>
             </div>
-            {#if active}
+            {#if running}
               <span class="shrink-0 text-[10px] font-bold uppercase tracking-widest px-2 py-1 rounded-lg bg-tertiary/15 text-tertiary">
                 {m.lv_presets_active()}
               </span>

--- a/apps/dashboard/src/pages/Leveling.svelte
+++ b/apps/dashboard/src/pages/Leveling.svelte
@@ -595,16 +595,23 @@
     gotoTab('/leveling', 'gains', DEFAULT_TAB);
   }
 
-  const customPresetValues = $derived<LevelingPresetValues>({
-    xpMin: config.xpMin,
-    xpMax: config.xpMax,
-    cooldownSeconds: config.cooldownSeconds,
-    vocalXpPerMin: config.vocalXpPerMin,
-    curveBaseXp: config.curveBaseXp,
-    curveLinearXp: config.curveLinearXp,
-    curveExponent: config.curveExponent,
-    maxLevel: config.maxLevel,
-  });
+  function levelingValuesOf(source: typeof config): LevelingPresetValues {
+    return {
+      xpMin: source.xpMin,
+      xpMax: source.xpMax,
+      cooldownSeconds: source.cooldownSeconds,
+      vocalXpPerMin: source.vocalXpPerMin,
+      curveBaseXp: source.curveBaseXp,
+      curveLinearXp: source.curveLinearXp,
+      curveExponent: source.curveExponent,
+      maxLevel: source.maxLevel,
+    };
+  }
+
+  // Des qu'un prereglage est choisi, la configuration courante est la sienne :
+  // la carte « Personnalise » doit alors montrer la configuration enregistree,
+  // sans quoi elle devient le sosie de la carte qu'on vient de cliquer.
+  const customPresetValues = $derived(levelingValuesOf(selectedPreset ? savedConfig : config));
 
   // Estimation de duree : les curseurs repondent chacun a un fragment, aucun ne
   // dit combien de temps il faut pour atteindre un niveau. Le calcul combine le


### PR DESCRIPTION
La grille de prereglages passe de six choix figes a cinq prereglages plus une
carte "Personnalise" en bas a droite. Le prereglage "Rythme tranquille"
disparait et Prestige prend sa place.

La carte Personnalise reprend la configuration hors prereglage de la guilde
dans les memes tuiles que les autres (XP par message, delai, XP par heure,
niveau 10) et ouvre la configuration detaillee sans rien appliquer. Elle
n'affiche ses valeurs que lorsqu'elle correspond a l'etat en place, sinon elle
recopierait le prereglage en cours sur une carte jumelle. Elle reste cliquable
sans droit de modification, puisqu'elle ne fait que naviguer.

Une guilde reglee sur les anciennes valeurs de "Rythme tranquille" ne
correspond plus a aucun prereglage et se retrouve donc sur la carte
Personnalise, sans changement de donnees.

La lecture de la grille est revue : le prereglage recommande ne garde que son
badge, le fond plein marque la carte choisie, un contour tertiaire marque la
carte enregistree, et chaque carte trace en fond sa courbe de progression sur
vingt niveaux, a echelle commune et logarithmique, pour comparer les
silhouettes sans lire les chiffres.