### PR TITLE
feat(nickname): traduire le pseudo de remplacement et durcir ses garde-fous

### DIFF
--- a/apps/bot/messages/en.json
+++ b/apps/bot/messages/en.json
@@ -1777,5 +1777,14 @@
   "rpg_inventory_field_materials": "🧱 Materials (crafting)",
   "rpg_shop_type_accessory": "💍 Accessories",
   "rpg_shop_stat_spd": " · 💨 +{v} SPD",
-  "rpg_shop_stat_maxhp": " · ❤️ +{v} max HP"
+  "rpg_shop_stat_maxhp": " · ❤️ +{v} max HP",
+  "nickmod_safe_nickname": "non-compliant nickname | automod",
+  "nickmod_rename_reason": "Automod: non-compliant nickname - original: \"{original}\"",
+  "nickmod_log_title_auto": "Non-compliant nickname | Automod",
+  "nickmod_log_title_rescan": "Non-compliant nickname | Rescan",
+  "nickmod_log_member": "Member",
+  "nickmod_log_original": "Original nickname",
+  "nickmod_log_applied": "Applied nickname",
+  "nickmod_log_footer_auto": "Automod | Nickname moderation",
+  "nickmod_log_footer_rescan": "Automod | Nickname rescan"
 }

--- a/apps/bot/messages/fr.json
+++ b/apps/bot/messages/fr.json
@@ -1777,5 +1777,14 @@
   "rpg_inventory_field_materials": "🧱 Matériaux (artisanat)",
   "rpg_shop_type_accessory": "💍 Accessoires",
   "rpg_shop_stat_spd": " · 💨 +{v} VIT",
-  "rpg_shop_stat_maxhp": " · ❤️ +{v} PV max"
+  "rpg_shop_stat_maxhp": " · ❤️ +{v} PV max",
+  "nickmod_safe_nickname": "pseudo non conforme | automod",
+  "nickmod_rename_reason": "Automod : pseudo non conforme - original : \"{original}\"",
+  "nickmod_log_title_auto": "Pseudo non conforme | Automod",
+  "nickmod_log_title_rescan": "Pseudo non conforme | Rescan",
+  "nickmod_log_member": "Membre",
+  "nickmod_log_original": "Pseudo original",
+  "nickmod_log_applied": "Pseudo appliqué",
+  "nickmod_log_footer_auto": "Automod | Modération des pseudos",
+  "nickmod_log_footer_rescan": "Automod | Rescan des pseudos"
 }

--- a/apps/bot/src/api/routes/admin.ts
+++ b/apps/bot/src/api/routes/admin.ts
@@ -8,6 +8,7 @@ import { logger } from '../../utils/logger.js';
 import { activateGuild, deactivateGuild, reconcileStaffGuildActivation } from '../../utils/activation.js';
 import { announceAccessRevoked, announceTrialStart, extendAccess, formatDuration, normalizeAccessGrant, MAX_ACCESS_DURATION_MINUTES } from '../../services/system/accessService.js';
 import { E, resolveEmojiShortcodes, resolveEmojiShortcodesToUnicode, UNICODE_FALLBACKS } from '../../utils/emojis.js';
+import { isReservedByNicknameModeration } from '../../services/moderation/nicknameModerationService.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -521,7 +522,7 @@ export async function handleAdminRoutes(
           const word = normalizeGlobalBannedWord(entry?.word);
           if (!word) continue;
 
-          if (word.includes('automod') || word.includes('pseudo non conforme')) {
+          if (isReservedByNicknameModeration(word)) {
             continue;
           }
 
@@ -623,7 +624,7 @@ export async function handleAdminRoutes(
             return true;
           }
 
-          if (nextWord.includes('automod') || nextWord.includes('pseudo non conforme')) {
+          if (isReservedByNicknameModeration(nextWord)) {
             json(res, 400, { error: 'Ce mot ne peut pas être banni (réservé par le système de modération)' });
             return true;
           }

--- a/apps/bot/src/api/routes/dashboard/modules/banned-words.ts
+++ b/apps/bot/src/api/routes/dashboard/modules/banned-words.ts
@@ -1,5 +1,6 @@
 /** Routes dashboard du module `banned-words`. */
 import { invalidateBannedWordsCache } from '../../../../services/moderation/bannedWordsService.js';
+import { isReservedByNicknameModeration } from '../../../../services/moderation/nicknameModerationService.js';
 import prisma from '../../../../utils/db.js';
 import { errorCode } from '../../../../utils/errors.js';
 import { logger } from '../../../../utils/logger.js';
@@ -43,7 +44,7 @@ export async function handleBannedWordsRoutes(ctx: ModuleRouteContext): Promise<
 
         const cleanWord = body.word.trim().toLowerCase().slice(0, 100);
 
-        if (cleanWord.includes('automod') || cleanWord.includes('pseudo non conforme')) {
+        if (isReservedByNicknameModeration(cleanWord)) {
           json(res, 400, { error: 'Ce mot ne peut pas être banni (réservé par le système de modération)' });
           return true;
         }

--- a/apps/bot/src/events/nicknameModeration.ts
+++ b/apps/bot/src/events/nicknameModeration.ts
@@ -1,7 +1,9 @@
 import { EmbedBuilder, Events, PermissionFlagsBits, type Client, type GuildMember } from 'discord.js';
-import { isNicknameProblematic, SAFE_NICKNAME, buildRenameReason, loadBannedWords } from '../services/moderation/nicknameModerationService.js';
+import { isNicknameProblematic, isSafeNickname, safeNickname, buildRenameReason, loadBannedWords } from '../services/moderation/nicknameModerationService.js';
 import { invalidateBannedWordsCache, loadGlobalWords, loadCustomWords } from '../services/moderation/bannedWordsService.js';
 import { logger } from '../utils/logger.js';
+import { resolveGuildLocale } from '../utils/i18n.js';
+import * as m from '../lib/paraglide/messages.js';
 
 import { getCachedGuild, cache } from '../utils/cache.js';
 
@@ -67,15 +69,15 @@ async function checkAndRename(member: GuildMember): Promise<void> {
   if (!botMember) return;
   if (!botMember.permissions.has(PermissionFlagsBits.ManageNicknames)) return;
 
-  // Le bot ne peut pas renommer le propriétaire du serveur ou des membres avec des rôles supérieurs ou égaux au sien
-  if (member.guild.ownerId === member.id) return;
-  if (botMember.roles.highest.comparePositionTo(member.roles.highest) <= 0) return;
+  // `manageable` couvre d'un coup le proprietaire du serveur, la hierarchie des
+  // roles et les membres que le bot ne peut pas toucher.
+  if (!member.manageable) return;
 
   // Pseudo effectif : nickname > globalName > username
   const effectiveName = member.nickname ?? member.user.globalName ?? member.user.username;
   if (!effectiveName) return;
 
-  if (effectiveName.toLowerCase().trim() === SAFE_NICKNAME.toLowerCase().trim()) return;
+  if (isSafeNickname(effectiveName)) return;
 
   // Chargement des mots bannis selon les toggles actifs
   let bannedWords: string[] = [];
@@ -98,12 +100,15 @@ async function checkAndRename(member: GuildMember): Promise<void> {
     return;
   }
 
+  const locale = await resolveGuildLocale(guildId, member.guild.preferredLocale);
+  const safe = safeNickname(locale);
+
   try {
-    await member.setNickname(SAFE_NICKNAME, buildRenameReason(effectiveName));
+    await member.setNickname(safe, buildRenameReason(effectiveName, locale));
 
     logger.warn(
       'NicknameAutomod',
-      `Pseudo renommé pour ${member.user.tag} dans "${member.guild.name}": "${effectiveName}" → "${SAFE_NICKNAME}"`,
+      `Pseudo renommé pour ${member.user.tag} dans "${member.guild.name}": "${effectiveName}" → "${safe}"`,
     );
 
     // Log dans le channel de logs du serveur
@@ -118,14 +123,14 @@ async function checkAndRename(member: GuildMember): Promise<void> {
       if (logChannel?.isTextBased()) {
         const embed = new EmbedBuilder()
           .setColor(0xf4a261)
-          .setTitle('Pseudo non conforme | Automod')
+          .setTitle(m.nickmod_log_title_auto({}, { locale }))
           .addFields(
-            { name: 'Membre', value: `<@${member.id}> \`${member.user.tag}\``, inline: false },
-            { name: 'Pseudo original', value: `\`${effectiveName}\``, inline: true },
-            { name: 'Pseudo appliqué', value: `\`${SAFE_NICKNAME}\``, inline: true },
+            { name: m.nickmod_log_member({}, { locale }), value: `<@${member.id}> \`${member.user.tag}\``, inline: false },
+            { name: m.nickmod_log_original({}, { locale }), value: `\`${effectiveName}\``, inline: true },
+            { name: m.nickmod_log_applied({}, { locale }), value: `\`${safe}\``, inline: true },
           )
           .setThumbnail(member.displayAvatarURL())
-          .setFooter({ text: 'Automod | Modération des pseudos' })
+          .setFooter({ text: m.nickmod_log_footer_auto({}, { locale }) })
           .setTimestamp();
 
         await logChannel.send({ embeds: [embed], allowedMentions: { parse: [] } }).catch(() => null);
@@ -142,7 +147,7 @@ async function checkAndRename(member: GuildMember): Promise<void> {
         context: member.guild.name,
         module: 'Modération des pseudos',
         eventType: 'Automatique',
-        details: `Pseudo "${effectiveName}" remplacé par "${SAFE_NICKNAME}" pour ${member.user.tag}`,
+        details: `Pseudo "${effectiveName}" remplacé par "${safe}" pour ${member.user.tag}`,
         dateIso: new Date(),
       },
     }).catch(() => null);
@@ -173,7 +178,7 @@ export function registerNicknameModerationListener(client: Client): void {
     const newName = newMember.nickname ?? newMember.user.globalName ?? newMember.user.username;
 
     if (oldName === newName) return;
-    if (newName.toLowerCase().trim() === SAFE_NICKNAME.toLowerCase().trim()) return;
+    if (isSafeNickname(newName)) return;
 
     try {
       const config = await getNicknameModerationConfig(newMember.guild.id);

--- a/apps/bot/src/services/moderation/autoModService.ts
+++ b/apps/bot/src/services/moderation/autoModService.ts
@@ -4,6 +4,7 @@ import prisma from '../../utils/db.js';
 import { logger } from '../../utils/logger.js';
 import { registerWarnSanction, registerTimeoutSanction } from './sanctionService.js';
 import { loadBannedWords, loadGlobalWords, loadCustomWords } from './bannedWordsService.js';
+import { isReservedByNicknameModeration } from './nicknameModerationService.js';
 import { mirrorModlogToStaffServer } from '../staff/staffServerService.js';
 import { getUppercasePercentage } from './capsDetection.js';
 
@@ -545,7 +546,7 @@ export async function syncDiscordAutoModProfileRule(client: Client, guildId: str
     // Limites de Discord: mots clés <= 60 caractères, max 1000 mots
     const keywords = bannedWords
       .map(w => w.trim().toLowerCase())
-      .filter(w => w.length > 0 && w.length <= 60 && !w.includes('automod') && !w.includes('pseudo non conforme'))
+      .filter(w => w.length > 0 && w.length <= 60 && !isReservedByNicknameModeration(w))
       .slice(0, 1000);
 
     if (keywords.length === 0) {

--- a/apps/bot/src/services/moderation/nicknameModerationService.ts
+++ b/apps/bot/src/services/moderation/nicknameModerationService.ts
@@ -7,11 +7,65 @@ import { EmbedBuilder, PermissionFlagsBits, type Guild } from 'discord.js';
 import { containsBannedWord, INVISIBLE_ONLY_REGEX, loadBannedWords, loadGlobalWords, loadCustomWords } from './bannedWordsService.js';
 import { logger } from '../../utils/logger.js';
 import { fetchAllMembers } from '../../utils/discord.js';
+import type { BotLocale } from '../../utils/i18n.js';
+import * as m from '../../lib/paraglide/messages.js';
 
 export { loadBannedWords, invalidateBannedWordsCache } from './bannedWordsService.js';
 
-/** Pseudo de remplacement appliqué automatiquement. */
-export const SAFE_NICKNAME = 'pseudo non conforme | automod';
+/** Limite Discord : un pseudo au-dela est refuse par l'API. */
+const NICKNAME_MAX_LENGTH = 32;
+
+function clampNickname(value: string): string {
+  return value.trim().slice(0, NICKNAME_MAX_LENGTH);
+}
+
+// `Record<BotLocale, …>` : ajouter une langue sans la declarer ici casse le
+// typecheck. Sans cette exhaustivite, les pseudos deja remplaces dans la langue
+// oubliee redeviendraient « non conformes » et seraient renommes en masse.
+const SAFE_NICKNAMES: Record<BotLocale, string> = {
+  fr: clampNickname(m.nickmod_safe_nickname({}, { locale: 'fr' })),
+  en: clampNickname(m.nickmod_safe_nickname({}, { locale: 'en' })),
+};
+
+/** Pseudo de remplacement applique automatiquement, dans la langue du serveur. */
+export function safeNickname(locale: BotLocale): string {
+  return SAFE_NICKNAMES[locale];
+}
+
+// Toutes les langues, pas seulement celle du serveur : sans ca, changer la
+// langue rendrait « non conformes » tous les pseudos deja remplaces et
+// declencherait une vague de renommages au premier evenement venu.
+const KNOWN_SAFE_NICKNAMES: ReadonlySet<string> = new Set(
+  Object.values(SAFE_NICKNAMES).map((nickname) => nickname.toLowerCase()),
+);
+
+/** Un pseudo deja pose par la moderation, quelle que soit la langue du serveur. */
+export function isSafeNickname(name: string): boolean {
+  return KNOWN_SAFE_NICKNAMES.has(name.toLowerCase().trim());
+}
+
+// Fragments du pseudo de remplacement, dans toutes les langues : « pseudo non
+// conforme », « non-compliant nickname » et « automod ». Les decouper sur la
+// barre verticale evite de lister ces morceaux a la main, donc d'en oublier un
+// en ajoutant une langue.
+const RESERVED_FRAGMENTS: readonly string[] = [
+  ...new Set(
+    Object.values(SAFE_NICKNAMES)
+      .flatMap((nickname) => nickname.split('|'))
+      .map((fragment) => fragment.trim().toLowerCase())
+      .filter(Boolean),
+  ),
+];
+
+/**
+ * Un mot banni recouvrant le pseudo de remplacement retournerait la moderation
+ * contre elle-meme : le pseudo pose serait a son tour signale.
+ */
+export function isReservedByNicknameModeration(word: string): boolean {
+  const normalized = word.trim().toLowerCase();
+  if (!normalized) return false;
+  return RESERVED_FRAGMENTS.some((fragment) => normalized.includes(fragment));
+}
 
 /**
  * Vérifie si un pseudo est non conforme.
@@ -35,8 +89,8 @@ export function isNicknameProblematic(
 
   const normalized = name.toLowerCase().trim();
 
-  // Protection anti-boucle : Ignorer uniquement le pseudo de remplacement exact
-  if (normalized === SAFE_NICKNAME.toLowerCase().trim()) {
+  // Protection anti-boucle : ignorer uniquement les pseudos de remplacement exacts
+  if (isSafeNickname(normalized)) {
     return false;
   }
 
@@ -57,10 +111,10 @@ export function isNicknameProblematic(
 }
 
 /**
- * Retourne une raison de renommage lisible pour les logs Discord.
+ * Retourne une raison de renommage lisible dans les logs d'audit Discord.
  */
-export function buildRenameReason(originalName: string): string {
-  return `Automod: pseudo non conforme — original: "${originalName}"`;
+export function buildRenameReason(originalName: string, locale: BotLocale): string {
+  return m.nickmod_rename_reason({ original: originalName }, { locale });
 }
 
 // ---------------------------------------------------------------------------
@@ -136,11 +190,18 @@ export async function scanAndModeratePseudos(guild: Guild): Promise<PseudoScanRe
 
   const whitelist = guildData?.nicknameModerationWhitelist ?? [];
   const bypass = guildData?.nicknameModerationBypass ?? [];
+  // Import differe comme celui de Prisma juste au-dessus : `utils/i18n` tire le
+  // cache Redis et la base, dont ce module n'a pas besoin pour ses fonctions
+  // pures (celles que couvrent les tests unitaires).
+  const { resolveGuildLocale } = await import('../../utils/i18n.js');
+  const locale = await resolveGuildLocale(guild.id, guild.preferredLocale);
+  const safe = safeNickname(locale);
 
   for (const [, member] of members) {
     if (member.user.bot) { result.skippedCount++; continue; }
-    if (guild.ownerId === member.id) { result.skippedCount++; continue; }
-    if (botMember.roles.highest.comparePositionTo(member.roles.highest) <= 0) { result.skippedCount++; continue; }
+    // `manageable` couvre d'un coup le proprietaire, la hierarchie des roles et
+    // les membres que le bot ne peut pas toucher.
+    if (!member.manageable) { result.skippedCount++; continue; }
 
     result.scannedCount++;
 
@@ -148,12 +209,12 @@ export async function scanAndModeratePseudos(guild: Guild): Promise<PseudoScanRe
     if (!effectiveName) { result.skippedCount++; continue; }
 
     // Déjà au pseudo de sécurité → skip
-    if (effectiveName.toLowerCase().trim() === SAFE_NICKNAME.toLowerCase().trim()) continue;
+    if (isSafeNickname(effectiveName)) continue;
 
     if (!isNicknameProblematic(effectiveName, bannedWords, { whitelist, userId: member.id, bypassUserIds: bypass, checkInvisible })) continue;
 
     try {
-      await member.setNickname(SAFE_NICKNAME, buildRenameReason(effectiveName));
+      await member.setNickname(safe, buildRenameReason(effectiveName, locale));
       result.renamedCount++;
       result.renamed.push({ userId: member.id, original: effectiveName });
 
@@ -162,21 +223,21 @@ export async function scanAndModeratePseudos(guild: Guild): Promise<PseudoScanRe
 
       logger.warn(
         'NicknameRescan',
-        `Pseudo renommé: ${member.user.tag} — "${effectiveName}" → "${SAFE_NICKNAME}"`,
+        `Pseudo renommé: ${member.user.tag} — "${effectiveName}" → "${safe}"`,
       );
 
       // Log embed dans le channel de logs
       if (logChannel?.isTextBased()) {
         const embed = new EmbedBuilder()
           .setColor(0xf4a261)
-          .setTitle('Pseudo non conforme | Rescan')
+          .setTitle(m.nickmod_log_title_rescan({}, { locale }))
           .addFields(
-            { name: 'Membre', value: `<@${member.id}> \`${member.user.tag}\``, inline: false },
-            { name: 'Pseudo original', value: `\`${effectiveName}\``, inline: true },
-            { name: 'Pseudo appliqué', value: `\`${SAFE_NICKNAME}\``, inline: true },
+            { name: m.nickmod_log_member({}, { locale }), value: `<@${member.id}> \`${member.user.tag}\``, inline: false },
+            { name: m.nickmod_log_original({}, { locale }), value: `\`${effectiveName}\``, inline: true },
+            { name: m.nickmod_log_applied({}, { locale }), value: `\`${safe}\``, inline: true },
           )
           .setThumbnail(member.displayAvatarURL())
-          .setFooter({ text: 'Automod | Rescan des pseudos' })
+          .setFooter({ text: m.nickmod_log_footer_rescan({}, { locale }) })
           .setTimestamp();
 
         await logChannel.send({ embeds: [embed], allowedMentions: { parse: [] } }).catch(() => null);
@@ -192,7 +253,7 @@ export async function scanAndModeratePseudos(guild: Guild): Promise<PseudoScanRe
           context: guild.name,
           module: 'Modération des pseudos',
           eventType: 'Manuel',
-          details: `Pseudo "${effectiveName}" remplacé par "${SAFE_NICKNAME}" pour ${member.user.tag}`,
+          details: `Pseudo "${effectiveName}" remplacé par "${safe}" pour ${member.user.tag}`,
           dateIso: new Date(),
         },
       }).catch(() => null);

--- a/apps/dashboard/messages/en.json
+++ b/apps/dashboard/messages/en.json
@@ -4236,6 +4236,7 @@
   "nm_bypass_removed": "Exemption for member {id} removed.",
   "nm_bypass_restored": "Exemption for member {id} restored.",
   "nm_activation": "Activation",
+  "nm_safe_nickname": "non-compliant nickname | automod",
   "nm_activation_desc_1": "When enabled, the bot checks nicknames on join and on change. A non-compliant nickname is replaced with",
   "nm_activation_desc_2": "Discord check command:",
   "nm_watches": "What the bot watches",

--- a/apps/dashboard/messages/fr.json
+++ b/apps/dashboard/messages/fr.json
@@ -4236,6 +4236,7 @@
   "nm_bypass_removed": "Exemption pour le membre {id} retirée.",
   "nm_bypass_restored": "Exemption pour le membre {id} rétablie.",
   "nm_activation": "Activation",
+  "nm_safe_nickname": "pseudo non conforme | automod",
   "nm_activation_desc_1": "Lorsqu'activé, le bot vérifie les pseudos à l'arrivée et lors des modifications. Un pseudo non conforme est remplacé par",
   "nm_activation_desc_2": "Commande Discord de vérification :",
   "nm_watches": "Ce que le bot surveille",

--- a/apps/dashboard/src/pages/NicknameModeration.svelte
+++ b/apps/dashboard/src/pages/NicknameModeration.svelte
@@ -7,7 +7,7 @@
   import InlineFeedback from '../lib/components/InlineFeedback.svelte';
   import Papicon from '../lib/components/Papicon.svelte';
   import LoadingHint from '../lib/components/LoadingHint.svelte';
-  import { m } from '../lib/i18n';
+  import { m, getLocale } from '../lib/i18n';
   import { createAsyncActionState } from '../lib/asyncAction.svelte';
   import { authStore } from '../lib/stores/auth.svelte';
   import { toast } from '../lib/stores/toast.svelte';
@@ -18,9 +18,15 @@
     addBannedWord,
     deleteBannedWord,
     toggleBannedWord,
+    fetchGuildLanguage,
   } from '../lib/api';
 
   let wsListener: ((e: CustomEvent) => void) | null = null;
+
+  // Le pseudo de remplacement suit la langue du bot sur ce serveur, pas celle du
+  // dashboard : afficher la version francaise a qui administre un serveur en
+  // anglais annoncerait un pseudo qui ne sera jamais applique.
+  let botLocale = $state<'fr' | 'en'>(getLocale() as 'fr' | 'en');
 
   // ---------------------------------------------------------------------------
   // Types
@@ -125,6 +131,9 @@
 
   onMount(async () => {
     await loadData(true);
+
+    const language = await fetchGuildLanguage();
+    if (language?.locale) botLocale = language.locale;
 
     wsListener = (e: CustomEvent) => {
       const payload = e.detail;
@@ -418,7 +427,7 @@
           <h2 class="text-base font-semibold tracking-tight text-on-surface">{m.nm_activation()}</h2>
           <p class="text-sm text-on-surface-variant/70">
             {m.nm_activation_desc_1()}
-            <code class="font-mono text-primary dark:text-blue-300 bg-primary/10 dark:bg-blue-500/15 px-1.5 py-0.5 rounded-lg text-xs">pseudo non conforme | automod</code>.
+            <code class="font-mono text-primary dark:text-blue-300 bg-primary/10 dark:bg-blue-500/15 px-1.5 py-0.5 rounded-lg text-xs">{m.nm_safe_nickname({}, { locale: botLocale })}</code>.
             <br />
             {m.nm_activation_desc_2()} <code class="font-mono text-primary bg-primary/10 px-1.5 py-0.5 rounded-lg text-xs">/rescan pseudo rescan</code>
           </p>


### PR DESCRIPTION
Le pseudo pose sur un membre non conforme, la raison inscrite dans l'audit Discord et les embeds de log étaient en francais en dur, sur les deux chemins de renommage : l'automatique et le rescan massif. Ils suivent desormais la langue du serveur.

Traduire ce pseudo demande trois protections :

- un pseudo deja pose est reconnu dans toutes les langues, sans quoi changer la langue du serveur les rendrait tous "non conformes" et declencherait une vague de renommages
- la table des pseudos est un Record par langue : en ajouter une sans la declarer casse le typecheck au lieu de passer inapercu
- le pseudo est tronque a 32 caracteres, la limite Discord, dont la version anglaise est deja a la limite exacte

Les quatre controles qui empechent de bannir un mot reserve dupliquaient les memes litteraux francais et ignoraient donc l'anglais. Ils partagent une seule fonction, dont les fragments sont dérives des pseudos de remplacement.

Les deux verifications manuelles du renommage, proprietaire du serveur puis hierarchie des roles, laissent place a `member.manageable`, deja utilise ailleurs dans le bot pour cette question.

Cote dashboard, la page annoncait le pseudo francais a qui administre un serveur en anglais : elle lit maintenant la langue du bot.