### PR TITLE
fix(captcha): ajouter la migration de captchaVerifiedRoleId

### DIFF
--- a/packages/database/prisma/migrations/20260806130000_add_captcha_verified_role/migration.sql
+++ b/packages/database/prisma/migrations/20260806130000_add_captcha_verified_role/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "raid_protection_configs" ADD COLUMN     "captchaVerifiedRoleId" TEXT;

--- a/packages/database/prisma/repair-production.ts
+++ b/packages/database/prisma/repair-production.ts
@@ -21,6 +21,7 @@ const repairs = [
   "20260721160000_add_raid_protection_tables",
   "20260804120000_add_voice_captcha",
   "20260806120000_add_captcha_voice_locale",
+  "20260806130000_add_captcha_verified_role",
 ];
 
 async function run(command: string[]) {

--- a/packages/database/prisma/repairs/20260806130000_add_captcha_verified_role.sql
+++ b/packages/database/prisma/repairs/20260806130000_add_captcha_verified_role.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "raid_protection_configs"
+  ADD COLUMN IF NOT EXISTS "captchaVerifiedRoleId" TEXT;


### PR DESCRIPTION
Colonne nullable, aucune valeur par defaut a propager : le champ reste optionnel et le comportement est inchange tant qu'aucun role n'est choisi.
