### PR TITLE
fix(securite): une seule page a la fois, et configuration rapide a part

### DIFF
--- a/apps/dashboard/messages/en.json
+++ b/apps/dashboard/messages/en.json
@@ -387,6 +387,7 @@
   "nav_group_security": "Security",
   "nav_group_config": "Configuration",
   "nav_security_overview": "Overview",
+  "nav_security_quick_setup": "Quick setup",
   "nav_security_antiraid": "Anti-raid",
   "nav_security_filters": "Filters",
   "nav_security_accounts": "Alt accounts",

--- a/apps/dashboard/messages/fr.json
+++ b/apps/dashboard/messages/fr.json
@@ -387,6 +387,7 @@
   "nav_group_security": "Sécurité",
   "nav_group_config": "Configuration",
   "nav_security_overview": "Vue d'ensemble",
+  "nav_security_quick_setup": "Configuration rapide",
   "nav_security_antiraid": "Anti-raid",
   "nav_security_filters": "Filtres",
   "nav_security_accounts": "Multi-comptes",

--- a/apps/dashboard/src/App.svelte
+++ b/apps/dashboard/src/App.svelte
@@ -85,6 +85,10 @@
     if (path.startsWith("/events")) return "events";
     if (path.startsWith("/members") || path.startsWith("/invitations"))
       return "members";
+    // Les niveaux de protection sont des prereglages AutoMod, meme s'ils
+    // deplacent aussi les seuils anti-raid : c'est le droit AutoMod qui ouvre
+    // la page, comme sur Securite > Filtres.
+    if (path.startsWith("/security/quick-setup")) return "automod";
     if (path.startsWith("/security/sanctions")) return "sanctions";
     if (path.startsWith("/security/filters")) return "automod";
     if (path.startsWith("/security/accounts")) return "double_accounts";
@@ -559,8 +563,12 @@
               path="/workflows"
               load={() => import("./pages/Workflows.svelte")}
             />
-            <!-- Securite : cinq pages, chacune decoupee en onglets.
+            <!-- Securite : six pages, la plupart decoupees en onglets.
                  Les anciennes URL sont redirigees plus bas. -->
+            <LazyRoute
+              path="/security/quick-setup"
+              load={() => import("./pages/security/QuickSetup.svelte")}
+            />
             <LazyRoute
               path="/security/anti-raid/*"
               load={() => import("./pages/security/AntiRaid.svelte")}
@@ -577,8 +585,14 @@
               path="/security/sanctions/*"
               load={() => import("./pages/security/Sanctions.svelte")}
             />
+            <!-- Sans etoile, et surtout pas apres les autres pages du groupe :
+                 les routes de Tinro ne s'excluent pas, `/security/*` captait
+                 aussi `/security/anti-raid` et consorts, et la vue d'ensemble
+                 se rajoutait sous chacune d'elles. La vue d'ensemble n'ayant
+                 pas d'onglets, une route exacte suffit ; lui en donner un jour
+                 demandera d'ajouter sa route ici, sous celles de ses voisines. -->
             <LazyRoute
-              path="/security/*"
+              path="/security"
               load={() => import("./pages/security/Overview.svelte")}
             />
             <LazyRoute

--- a/apps/dashboard/src/lib/components/AutomodPresetPicker.svelte
+++ b/apps/dashboard/src/lib/components/AutomodPresetPicker.svelte
@@ -169,7 +169,7 @@
         <p class="text-[13px] text-on-surface-variant/70 mt-3 leading-relaxed">{card.desc}</p>
 
         {#if detailed}
-          <div class="grid grid-cols-2 gap-2.5 mt-5">
+          <div class="grid grid-cols-2 gap-2.5 mt-5 mb-1">
             <div class="px-3 py-2 bg-surface-container-high/20 border border-outline-variant/5 rounded-lg">
               <p class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest">{m.am_presets_tile_filters()}</p>
               <p class="text-sm font-semibold text-on-surface">{automodActiveFilterCount(card.filters, card.raid)} / {AUTOMOD_FILTER_TOTAL}</p>
@@ -187,8 +187,15 @@
               <p class="text-sm font-semibold text-on-surface">{raidSummary(card.raid)}</p>
             </div>
           </div>
-        {:else}
-          <p class="flex items-center gap-1.5 mt-5 text-[13px] font-semibold text-primary/80">
+        {/if}
+
+        <!-- La seule action de la carte « Personnalise », donc toujours
+             affichee : elle disparaissait des que les reglages en place ne
+             collaient a aucun prereglage - le cas ou l'on va justement les
+             regler en detail - et la carte devenait un pave qui navigue sans
+             prevenir. -->
+        {#if !card.preset}
+          <p class="flex items-center gap-1.5 mt-4 text-[13px] font-semibold text-primary/80">
             {m.am_presets_open_advanced()}
             <Papicon icon="ArrowRight" size={14} />
           </p>

--- a/apps/dashboard/src/lib/config/pages.ts
+++ b/apps/dashboard/src/lib/config/pages.ts
@@ -48,6 +48,7 @@ export const moderationItems: PageConfig[] = [
  */
 export const securityItems: PageConfig[] = [
   { name: m.nav_security_overview(),  icon: "shieldcheck",   href: "/security",           featureKey: "raid_protection", beta: false, wip: false },
+  { name: m.nav_security_quick_setup(), icon: "sparkles",    href: "/security/quick-setup", featureKey: "automod", beta: false, wip: false },
   { name: m.nav_security_antiraid(),  icon: "shieldwarning", href: "/security/anti-raid", featureKey: "raid_protection", beta: false, wip: false },
   { name: m.nav_security_filters(),   icon: "shield-alert",  href: "/security/filters",   featureKey: "automod", beta: false, wip: false },
   { name: m.nav_security_accounts(),  icon: "shield",        href: "/security/accounts",  featureKey: "double_accounts", beta: false, wip: false },

--- a/apps/dashboard/src/lib/stores/navigation.svelte.ts
+++ b/apps/dashboard/src/lib/stores/navigation.svelte.ts
@@ -1,6 +1,7 @@
 import { canonicalModuleKey, getModuleDefinition, getModuleForPath } from '@kotbo/contracts';
 import { updateSidebarFavorites } from '../api';
 import {
+  allPages,
   generalItems,
   moderationItems,
   securityItems,
@@ -322,10 +323,27 @@ function matchScore(haystack: string, needle: string): number {
 
 export const navigationStore = new NavigationStore();
 
-/** Shared active-route test so sidebar and sheet always agree on highlighting. */
+/** Adresses du menu, sans leur eventuelle requete. Fixes : calculees une fois. */
+const NAV_BASE_PATHS = allPages.map((page) => page.href.split('?')[0]);
+
+/**
+ * Shared active-route test so sidebar and sheet always agree on highlighting.
+ *
+ * L'entree la plus precise gagne : sans cela `/security` restait allume sur
+ * `/security/anti-raid` et deux entrees du meme groupe s'eclairaient ensemble.
+ * Une entree sans voisine plus longue garde son prefixe, et les sous-pages
+ * absentes du menu - `/admin/servers`, un onglet - continuent d'allumer leur
+ * entree parente.
+ */
 export function isActiveNavItem(href: string, path: string, url: string): boolean {
   if (href === '/') return path === '/';
   const [base, query] = href.split('?');
   if (query) return path === base && url.includes(query);
-  return path === base || path.startsWith(`${base}/`);
+  if (path === base) return true;
+  if (!path.startsWith(`${base}/`)) return false;
+
+  return !NAV_BASE_PATHS.some(
+    (candidate) => candidate.length > base.length
+      && (path === candidate || path.startsWith(`${candidate}/`)),
+  );
 }

--- a/apps/dashboard/src/pages/SecurityAudit.svelte
+++ b/apps/dashboard/src/pages/SecurityAudit.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import type { Snippet } from 'svelte';
   import { authStore } from '../lib/stores/auth.svelte';
   import { fetchSecurityAudit, applySecurityFix } from '../lib/api';
   import { toast } from '../lib/stores/toast.svelte';
@@ -15,14 +14,6 @@
   type Category =
     | 'DISCORD' | 'PERMISSIONS' | 'BOTS' | 'WEBHOOKS'
     | 'INVITES' | 'MODULES' | 'BOT_PERMS' | 'HYGIENE';
-
-  /**
-   * `intro` s'insere en tete du corps de page, sous l'en-tete. Le hub Securite
-   * y place sa configuration rapide : rendue a cote de cette page plutot que
-   * dedans, elle passerait au-dessus du titre, et echapperait au grisage
-   * applique quand le module est desactive.
-   */
-  const { intro = undefined }: { intro?: Snippet } = $props();
 
   type AuditEntity = { id: string; name: string; type: string; detail?: string };
   type AuditFix = { action: string; label: string; risky?: boolean };
@@ -194,7 +185,7 @@
 </script>
 
 <ModulePage
-  title="Audit de sécurité"
+  title="Vue d'ensemble"
   description="Analyse complète de la configuration du serveur, catégorie par catégorie"
   icon="ShieldCheck"
   featureKey="raid_protection"
@@ -202,8 +193,6 @@
   {#snippet actions()}
     <RefreshButton onclick={() => load(true)} loading={loading} />
   {/snippet}
-
-  {#if intro}{@render intro()}{/if}
 
   {#if loading && !report}
     <LoadingHint context="config" />

--- a/apps/dashboard/src/pages/security/Overview.svelte
+++ b/apps/dashboard/src/pages/security/Overview.svelte
@@ -2,14 +2,8 @@
   /**
    * Securite > Vue d'ensemble : le hub du groupe.
    *
-   * En tete du corps de page, « Configuration rapide » : les niveaux de
-   * protection reglent d'un coup les filtres et les seuils anti-raid, ils
-   * relevent donc du hub et non d'une page thematique. C'est aussi la premiere
-   * entree du menu Securite, donc le chemin le plus court pour qui veut se
-   * proteger sans rien regler en detail.
-   *
-   * Passee en `intro` plutot que rendue a cote : SecurityAudit porte l'en-tete
-   * de page et le grisage du module desactive, dont la section doit heriter.
+   * La configuration rapide a quitte cette page pour son propre onglet : elle
+   * passait derriere le score d'audit, alors que c'est par elle qu'on commence.
    *
    * Cible du lot 7 : onglets « Etat » (score d'audit + constats, ce que fait
    * deja SecurityAudit), « Alertes », « Exceptions » (vue agregee des listes
@@ -17,12 +11,7 @@
    * (statistiques des mots, hygiene des bans, retention des logs - les trois
    * reglages a enjeu vie privee, aujourd'hui disperses).
    */
-  import SecurityQuickSetup from '../../lib/components/security/SecurityQuickSetup.svelte';
   import SecurityAudit from '../SecurityAudit.svelte';
 </script>
 
-<SecurityAudit>
-  {#snippet intro()}
-    <SecurityQuickSetup />
-  {/snippet}
-</SecurityAudit>
+<SecurityAudit />

--- a/apps/dashboard/src/pages/security/QuickSetup.svelte
+++ b/apps/dashboard/src/pages/security/QuickSetup.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  /**
+   * Securite > Configuration rapide : les niveaux de protection, seuls.
+   *
+   * Ils reglent d'un coup les filtres AutoMod et les seuils anti-raid, donc ils
+   * ne relevent d'aucune page thematique. Ils vivaient en tete de la vue
+   * d'ensemble, ou ils passaient derriere le score d'audit ; leur propre entree
+   * de menu en fait le chemin le plus court pour qui veut se proteger sans rien
+   * regler en detail.
+   */
+  import ModulePage from '../../lib/components/ModulePage.svelte';
+  import SecurityQuickSetup from '../../lib/components/security/SecurityQuickSetup.svelte';
+</script>
+
+<ModulePage
+  title="Configuration rapide"
+  description="Un niveau de protection règle d'un coup les filtres et l'anti-raid"
+  icon="Sparkles"
+  featureKey="automod"
+>
+  <SecurityQuickSetup />
+</ModulePage>


### PR DESCRIPTION
La configuration rapide quitte la vue d'ensemble pour sa propre entrée de menu : elle passait derrière le score d'audit alors que c'est par elle qu'on commence.

Sur la carte Personnalise, le lien vers la configuration détaillée n'apparaissait que si les réglages en place collaient a un préréglage, soit l'inverse du cas ou l'on veut régler en détail ; la carte naviguait alors sans rien annoncer. Il est toujours affiche.

L'audit de sécurité prend le titre Vue d'ensemble, celui que son entrée de menu portait déjà.