### PR TITLE
fix(bot): convertit aussi les mises a jour venues d'un modal

### DIFF
--- a/apps/bot/src/utils/patchV2.ts
+++ b/apps/bot/src/utils/patchV2.ts
@@ -362,7 +362,9 @@ interface PatchItem {
 const patches: PatchItem[] = [
   { target: discord.CommandInteraction as unknown as { prototype: Record<string, unknown> }, methods: ['reply', 'editReply', 'followUp'] },
   { target: discord.MessageComponentInteraction as unknown as { prototype: Record<string, unknown> }, methods: ['reply', 'editReply', 'followUp', 'update'] },
-  { target: discord.ModalSubmitInteraction as unknown as { prototype: Record<string, unknown> }, methods: ['reply', 'editReply', 'followUp'] },
+  // `update` compris : un modal ouvert depuis un composant met a jour le message
+  // d'origine, qui est deja en Components V2 des qu'il portait un embed.
+  { target: discord.ModalSubmitInteraction as unknown as { prototype: Record<string, unknown> }, methods: ['reply', 'editReply', 'followUp', 'update'] },
   { target: discord.TextChannel as unknown as { prototype: Record<string, unknown> }, methods: ['send'] },
   { target: discord.DMChannel as unknown as { prototype: Record<string, unknown> }, methods: ['send'] },
   { target: discord.ThreadChannel as unknown as { prototype: Record<string, unknown> }, methods: ['send'] },


### PR DESCRIPTION
Un modal ouvert depuis un composant met a jour le message d'origine, lequel est deja en Components V2 puisque patchV2 convertit tout embed a l'envoi. La liste des methodes interceptees sur ModalSubmitInteraction omettait `update`: la charge partait telle quelle et Discord la rejetait avec MESSAGE_CANNOT_USE_LEGACY_FIELDS_WITH_COMPONENTS_V2, affichant "Une erreur est survenue" alors que le traitement avait abouti.

Visible sur le commentaire du sondage de satisfaction, mais la lacune touchait tous les modals qui finalisent leur message d'origine.
