### PR TITLE
feat(dashboard): remet les pseudos dans la nav securite

### DIFF
--- a/apps/dashboard/src/lib/config/pages.ts
+++ b/apps/dashboard/src/lib/config/pages.ts
@@ -52,6 +52,7 @@ export const securityItems: PageConfig[] = [
   { name: m.nav_security_quick_setup(), icon: "sparkles",    href: "/security/quick-setup", featureKey: "automod", beta: false, wip: false },
   { name: m.nav_security_antiraid(),  icon: "shieldwarning", href: "/security/anti-raid", featureKey: "raid_protection", beta: false, wip: false },
   { name: m.nav_security_filters(),   icon: "shield-alert",  href: "/security/filters",   featureKey: "automod", beta: false, wip: false },
+  { name: m.nav_nicknames(),          icon: "user",          href: "/security/filters/nicknames", featureKey: "nickname_moderation", beta: false, wip: false },
   { name: m.nav_security_accounts(),  icon: "shield",        href: "/security/accounts",  featureKey: "double_accounts", beta: false, wip: false },
   { name: m.nav_security_sanctions(), icon: "alert-triangle",href: "/security/sanctions", featureKey: "sanctions", beta: false, wip: false },
 ];

--- a/packages/contracts/src/types/modules.ts
+++ b/packages/contracts/src/types/modules.ts
@@ -263,7 +263,7 @@ export const MODULE_REGISTRY: ModuleDefinition[] = [
     guildFields: ['autoNicknameModerationEnabled'],
     legacyField: 'autoNicknameModerationEnabled',
     apiSegments: ['nickname-moderation'],
-    paths: ['/nickname-moderation'],
+    paths: ['/security/filters/nicknames', '/nickname-moderation'],
   },
   {
     key: 'double_accounts',


### PR DESCRIPTION
La page de moderation des pseudos n'etait plus accessible que par l'URL directe ou la redirection de /nickname-moderation : la refonte de la section Securite avait supprime son entree de menu.

Ajoute l'entree "Pseudos" sous "Filtres" et declare la nouvelle route sur le module nickname_moderation, sans quoi arriver sur la page avec le module eteint n'affichait pas l'ecran de reactivation.