### PR TITLE
fix(dashboard): refuse l'acces quand aucune guilde n'est resolue

### DIFF
--- a/apps/dashboard/messages/en.json
+++ b/apps/dashboard/messages/en.json
@@ -8876,5 +8876,9 @@
   "prestige_public_search_placeholder": "Search a member…",
   "prestige_public_no_result": "No member found",
   "prestige_public_clear_search": "Clear the search",
-  "prestige_public_streak": "{days}-day streak"
+  "prestige_public_streak": "{days}-day streak",
+  "no_guild_access_title": "No server available",
+  "no_guild_access_desc": "Your Discord account has no permissions on any server where Kotbo is installed. Ask an administrator to grant you a role, or invite the bot to your server, then try again.",
+  "no_feature_access_title": "Page not available",
+  "no_feature_access_desc": "Your role on this server does not grant access to this page. Contact a server administrator if you think this is a mistake."
 }

--- a/apps/dashboard/messages/fr.json
+++ b/apps/dashboard/messages/fr.json
@@ -8876,5 +8876,9 @@
   "prestige_public_search_placeholder": "Rechercher un membre…",
   "prestige_public_no_result": "Aucun membre trouvé",
   "prestige_public_clear_search": "Effacer la recherche",
-  "prestige_public_streak": "Série de {days} jours"
+  "prestige_public_streak": "Série de {days} jours",
+  "no_guild_access_title": "Aucun serveur accessible",
+  "no_guild_access_desc": "Votre compte Discord n'a de droits sur aucun serveur où Kotbo est installé. Demandez à un administrateur de vous attribuer un rôle, ou invitez le bot sur votre serveur, puis réessayez.",
+  "no_feature_access_title": "Page non accessible",
+  "no_feature_access_desc": "Votre rôle sur ce serveur ne donne pas accès à cette page. Contactez un administrateur du serveur si vous pensez que c'est une erreur."
 }

--- a/apps/dashboard/src/App.svelte
+++ b/apps/dashboard/src/App.svelte
@@ -82,10 +82,13 @@
   });
 
   function canViewFeature(featureKey: string) {
+    // Meme ordre que navigationStore.canViewFeature : l'acces a la guilde
+    // prime sur `featureAccess`, qui decrit la derniere guilde chargee.
+    if (!fallbackCanView) return false;
     if (!featureKey) return true;
     const feature = (featureAccess as Record<string, any>)?.[featureKey];
     if (feature?.canView !== undefined) return feature.canView;
-    return fallbackCanView;
+    return true;
   }
 
   function resolveRouteFeatureKey(path: string): string | null {
@@ -521,15 +524,15 @@
           <Route path="/*">
             <Activation />
           </Route>
+        {:else if noGuildAccess || routeFeatureDenied}
+          <MainLayout>
+            <NoAccessNotice reason={noGuildAccess ? "guild" : "feature"} />
+          </MainLayout>
         {:else if $router.path === "/dailyalgo/ide"}
           <LazyRoute
             path="/dailyalgo/ide"
             load={() => import("./pages/DailyAlgoIDE.svelte")}
           />
-        {:else if noGuildAccess || routeFeatureDenied}
-          <MainLayout>
-            <NoAccessNotice reason={noGuildAccess ? "guild" : "feature"} />
-          </MainLayout>
         {:else if disabledModuleForRoute}
           <MainLayout>
             <ModuleDisabledNotice moduleKey={disabledModuleForRoute} />

--- a/apps/dashboard/src/App.svelte
+++ b/apps/dashboard/src/App.svelte
@@ -18,6 +18,8 @@
   import GlobalErrorOverlay from "./lib/components/GlobalErrorOverlay.svelte";
   import LazyRoute from "./lib/components/LazyRoute.svelte";
   import ModuleDisabledNotice from "./lib/components/ModuleDisabledNotice.svelte";
+  import NoAccessNotice from "./lib/components/NoAccessNotice.svelte";
+  import { navigationStore } from "./lib/stores/navigation.svelte";
   import { getModuleForPath } from "@kotbo/contracts";
   import {
     SECURITY_LEGACY_REDIRECTS,
@@ -66,10 +68,18 @@
   }
 
   const featureAccess = $derived(dashboardStore.state.featureAccess || {});
-  const fallbackCanView = $derived(
-    authStore.guilds.find((guild) => guild.id === authStore.selectedGuildId)
-      ?.accessLevel !== "none",
+  const fallbackCanView = $derived(authStore.hasGuildAccess);
+  const noGuildAccess = $derived(
+    authStore.initialized && !authStore.hasGuildAccess,
   );
+  // Une page dont la clef est refusee ne doit pas se rendre en attendant que la
+  // redirection s'applique - et quand il n'existe aucune page ouverte vers ou
+  // rediriger, c'est cet ecran qui reste affiche.
+  const routeFeatureDenied = $derived.by(() => {
+    if (!authStore.initialized || isPublicPage) return false;
+    const featureKey = resolveRouteFeatureKey($router.path);
+    return !!featureKey && !canViewFeature(featureKey);
+  });
 
   function canViewFeature(featureKey: string) {
     if (!featureKey) return true;
@@ -388,10 +398,20 @@
     }
 
     if (authStore.isAuthenticated && !isPublicPage) {
+      // Aucun serveur accessible : il n'y a nulle part ou rediriger, c'est
+      // NoAccessNotice qui prend la main.
+      if (noGuildAccess) return;
+
       const featureKey = resolveRouteFeatureKey($router.path);
       if (featureKey && !canViewFeature(featureKey)) {
-        if ($router.path !== "/") {
-          router.goto("/");
+        // `/` porte la clef `dashboard` : y renvoyer quelqu'un a qui cette
+        // clef est refusee ne faisait rien du tout, et l'accueil se rendait
+        // malgre le refus. On vise donc la premiere page reellement ouverte.
+        const target = canViewFeature("dashboard")
+          ? "/"
+          : navigationStore.allItems[0]?.href;
+        if (target && $router.path !== target) {
+          router.goto(target);
         }
       }
     }
@@ -506,6 +526,10 @@
             path="/dailyalgo/ide"
             load={() => import("./pages/DailyAlgoIDE.svelte")}
           />
+        {:else if noGuildAccess || routeFeatureDenied}
+          <MainLayout>
+            <NoAccessNotice reason={noGuildAccess ? "guild" : "feature"} />
+          </MainLayout>
         {:else if disabledModuleForRoute}
           <MainLayout>
             <ModuleDisabledNotice moduleKey={disabledModuleForRoute} />

--- a/apps/dashboard/src/lib/components/NoAccessNotice.svelte
+++ b/apps/dashboard/src/lib/components/NoAccessNotice.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  /**
+   * Ecran terminal pour une page que le compte connecte n'a pas le droit de voir.
+   *
+   * La garde de route renvoyait ces cas vers `/`, qui porte lui-meme la clef
+   * `dashboard` : quand c'est cette clef qui manque, la redirection ne faisait
+   * rien et l'accueil se rendait malgre le refus. Il faut donc un ecran, et pas
+   * seulement une redirection.
+   */
+  import { authStore } from '../stores/auth.svelte';
+  import { m } from '../i18n';
+  import Papicon from './Papicon.svelte';
+
+  const { reason = 'feature' }: { reason?: 'guild' | 'feature' } = $props();
+
+  let retrying = $state(false);
+
+  async function retry() {
+    if (retrying) return;
+    retrying = true;
+    try {
+      await authStore.fetchGuilds();
+    } finally {
+      retrying = false;
+    }
+  }
+</script>
+
+<div class="max-w-lg mx-auto px-4 py-24 text-center space-y-5">
+  <div class="w-14 h-14 mx-auto rounded-2xl bg-surface-container text-on-surface-variant/60 flex items-center justify-center">
+    <Papicon icon="Lock" size={26} />
+  </div>
+
+  <div class="space-y-2">
+    <h1 class="text-lg font-semibold text-on-surface">
+      {reason === 'guild' ? m.no_guild_access_title() : m.no_feature_access_title()}
+    </h1>
+    <p class="text-[13px] text-on-surface-variant leading-relaxed">
+      {reason === 'guild' ? m.no_guild_access_desc() : m.no_feature_access_desc()}
+    </p>
+  </div>
+
+  <div class="flex items-center justify-center gap-2">
+    <button
+      type="button"
+      onclick={retry}
+      disabled={retrying}
+      class="inline-flex items-center gap-1.5 h-10 px-4 rounded-lg bg-primary text-on-primary text-sm font-medium hover:bg-primary/90 transition-colors disabled:opacity-50"
+    >
+      {retrying ? m.common_loading() : m.common_retry()}
+    </button>
+    <button
+      type="button"
+      onclick={() => authStore.logout()}
+      class="inline-flex items-center gap-1.5 h-10 px-4 rounded-lg border border-outline-variant/40 text-sm font-medium text-on-surface hover:bg-surface-container transition-colors"
+    >
+      {m.navbar_logout()}
+    </button>
+  </div>
+</div>

--- a/apps/dashboard/src/lib/components/NoAccessNotice.svelte
+++ b/apps/dashboard/src/lib/components/NoAccessNotice.svelte
@@ -8,6 +8,7 @@
    * seulement une redirection.
    */
   import { authStore } from '../stores/auth.svelte';
+  import { dashboardStore } from '../stores/dashboard.svelte';
   import { m } from '../i18n';
   import Papicon from './Papicon.svelte';
 
@@ -15,11 +16,18 @@
 
   let retrying = $state(false);
 
+  /**
+   * Les deux refus se relisent a des endroits differents : la liste des
+   * serveurs pour `guild`, les droits par fonctionnalite du store pour
+   * `feature`. On relit les deux, un role fraichement attribue pouvant
+   * debloquer l'un comme l'autre.
+   */
   async function retry() {
     if (retrying) return;
     retrying = true;
     try {
       await authStore.fetchGuilds();
+      await dashboardStore.refresh({ full: true });
     } finally {
       retrying = false;
     }

--- a/apps/dashboard/src/lib/stores/auth.svelte.ts
+++ b/apps/dashboard/src/lib/stores/auth.svelte.ts
@@ -73,6 +73,19 @@ class AuthStore {
         this.user = null;
         this.member = null;
         this.guilds = [];
+        this.clearGuildSelection();
+    }
+
+    /**
+     * La guilde selectionnee est persistee, mais elle n'appartient qu'a la
+     * session qui l'a choisie. Sans cette purge, l'identifiant survivait a une
+     * deconnexion : le compte suivant sur le meme navigateur repartait sur le
+     * serveur du precedent, et `getGuildId` le reemettait tel quel tant que la
+     * liste des guildes n'etait pas encore chargee.
+     */
+    private clearGuildSelection() {
+        this.selectedGuildId = null;
+        localStorage.removeItem('kotbo_guild_id');
     }
 
     async fetchUser() {
@@ -99,10 +112,12 @@ class AuthStore {
             });
             if (res.ok) {
                 const data = await res.json();
-                this.guilds = data.guilds.filter((guild: any) => guild.botPresent);
-                if (!this.selectedGuildId && this.guilds.length > 0) {
-                    this.setGuild(this.guilds[0].id);
-                } else if (this.selectedGuildId && !this.guilds.some((guild) => guild.id === this.selectedGuildId) && this.guilds.length > 0) {
+                this.guilds = Array.isArray(data?.guilds)
+                    ? data.guilds.filter((guild: any) => guild.botPresent)
+                    : [];
+                if (this.guilds.length === 0) {
+                    this.clearGuildSelection();
+                } else if (!this.selectedGuildId || !this.guilds.some((guild) => guild.id === this.selectedGuildId)) {
                     this.setGuild(this.guilds[0].id);
                 }
             }
@@ -137,8 +152,28 @@ class AuthStore {
         return !!this.token;
     }
 
+    get currentGuild() {
+        return this.guilds.find((guild: any) => guild.id === this.selectedGuildId) ?? null;
+    }
+
+    /**
+     * Une guilde qu'on n'arrive pas a resoudre ne vaut pas autorisation.
+     * `find` rend `undefined` aussi bien pour un serveur interdit que pour un
+     * compte sans aucun serveur, et comparer ce `undefined` a `'none'` faisait
+     * repondre "autorise" a qui n'avait acces a rien.
+     *
+     * Tant que la session n'est pas chargee la reponse reste permissive :
+     * refuser pendant l'amorcage viderait la navigation a chaque
+     * rafraichissement, avant meme que la liste des serveurs soit connue.
+     */
+    get hasGuildAccess() {
+        if (!this.initialized) return true;
+        const guild = this.currentGuild;
+        return !!guild && guild.accessLevel !== 'none';
+    }
+
     get isAdmin() {
-        return this.guilds.find((g: any) => g.id === this.selectedGuildId)?.accessLevel === 'admin';
+        return this.currentGuild?.accessLevel === 'admin';
     }
 
     get isBotAdmin() {

--- a/apps/dashboard/src/lib/stores/dashboard.svelte.ts
+++ b/apps/dashboard/src/lib/stores/dashboard.svelte.ts
@@ -71,7 +71,7 @@ class DashboardStore {
     sidebarFavorites: [] as string[],
     commandCatalog: [] as any[],
     access: {
-      level: 'moderator',
+      level: 'none',
       canModerateContent: false,
       canModerateDailyAlgo: false,
       canManageSettings: false
@@ -287,7 +287,7 @@ class DashboardStore {
         this.state.sidebarFavorites = data.sidebarFavorites || [];
         this.state.commandCatalog = data.commandCatalog || [];
         this.state.access = data.access || {
-          level: 'moderator',
+          level: 'none',
           canModerateContent: false,
           canModerateDailyAlgo: false,
           canManageSettings: false

--- a/apps/dashboard/src/lib/stores/navigation.svelte.ts
+++ b/apps/dashboard/src/lib/stores/navigation.svelte.ts
@@ -102,7 +102,7 @@ class NavigationStore {
     if (!featureKey) return true;
     const feature = this.#featureAccess[featureKey];
     if (feature?.canView !== undefined) return feature.canView;
-    return this.#guild?.accessLevel !== 'none';
+    return authStore.hasGuildAccess;
   };
 
   /**

--- a/apps/dashboard/src/lib/stores/navigation.svelte.ts
+++ b/apps/dashboard/src/lib/stores/navigation.svelte.ts
@@ -99,10 +99,15 @@ class NavigationStore {
   );
 
   canViewFeature = (featureKey?: string): boolean => {
+    // L'acces a la guilde se verifie avant `featureAccess`, qui vient du store
+    // et decrit toujours la derniere guilde chargee : passe outre, un compte
+    // qui perd ses droits en cours de session continuerait de voir ses pages
+    // tant que le store n'a pas ete relu.
+    if (!authStore.hasGuildAccess) return false;
     if (!featureKey) return true;
     const feature = this.#featureAccess[featureKey];
     if (feature?.canView !== undefined) return feature.canView;
-    return authStore.hasGuildAccess;
+    return true;
   };
 
   /**


### PR DESCRIPTION
## Ce que corrige cette PR

**Fail-open des permissions**

`guilds.find(...)` rend `undefined` aussi bien pour un serveur interdit que pour un compte sans aucun serveur, et `undefined !== 'none'` vaut `true`. Trois endroits en déduisaient un accès : `App.svelte`, `navigationStore.canViewFeature`, et le defaut `access.level: 'moderator'` du store dashboard. Resultat, la navigation complete s'affichait pour un compte n'ayant accès a rien.

La décision passe désormais par `authStore.hasGuildAccess`, qui exige une guilde effectivement résolue. Elle reste volontairement permissive tant que `initialized` est faux : refuser pendant l’amorçage viderait la navigation a chaque rafraichissement, avant même que la liste des serveurs soit connue. L’état dangereux est l’état stabilise, c'est celui qui est ferme.

Le défaut `access.level` passe de `'moderator'` a `'none'`. Son seul lecteur compare a `'admin'`, le changement est sans effet ailleurs.

