### PR TITLE
fix(salons): fils en double sur le sticky et page Salons ingerable module eteint

### DIFF
--- a/apps/bot/src/modules/autoThread.module.ts
+++ b/apps/bot/src/modules/autoThread.module.ts
@@ -9,6 +9,7 @@
 import type { Client, TextChannel, NewsChannel } from 'discord.js';
 import { MessageFlags, PermissionFlagsBits } from 'discord.js';
 import { subscribeForModule } from '../services/core/moduleScope.js';
+import { isStickyMessage } from '../services/features/stickyMessageService.js';
 import { getCachedGuild } from '../utils/cache.js';
 import { logger } from '../utils/logger.js';
 
@@ -35,7 +36,7 @@ export function registerAutoThreadBusSubscribers(client: Client): void {
     const config = await getAutoThreadConfig(payload.guildId);
     if (!config.enabled || !config.channels.includes(payload.channelId)) return;
 
-    if (payload.isBot && payload.authorId !== client.user?.id && !config.botsEnabled) return;
+    if (payload.isBot && !config.botsEnabled) return;
 
     const channel = client.channels.cache.get(payload.channelId) as TextChannel | NewsChannel | undefined;
     if (!channel || !('guild' in channel)) return;
@@ -52,6 +53,11 @@ export function registerAutoThreadBusSubscribers(client: Client): void {
     const message = await channel.messages.fetch(payload.messageId).catch(() => null);
     if (!message) return;
     if (message.interaction || message.interactionMetadata || message.flags.has(MessageFlags.Ephemeral)) return;
+
+    // Le sticky remonte à chaque seuil : lui ouvrir un fil en laisserait un
+    // vide derrière chaque renvoi. Testé après le fetch, qui laisse le temps à
+    // l'envoi du sticky d'être enregistré si l'événement le devance.
+    if (isStickyMessage(payload.messageId)) return;
 
     let rawName = payload.content ? payload.content.replace(/[\n\r]+/g, ' ').trim() : '';
     let authorName = message.member?.displayName || message.author.displayName || message.author.username;

--- a/apps/bot/src/services/features/stickyMessageService.ts
+++ b/apps/bot/src/services/features/stickyMessageService.ts
@@ -30,6 +30,27 @@ const CONFIG_TTL_SECONDS = 300;
 const pendingCounts = new Map<string, number>();
 /** Salons dont un renvoi est en cours : évite les doublons sur les rafales. */
 const reposting = new Set<string>();
+/**
+ * Ids des envois sticky encore en place, pour que l'autothread ne leur ouvre
+ * pas de fil : le sticky remonte à chaque seuil, chaque renvoi laisserait
+ * sinon un fil vide derrière lui.
+ */
+const stickyMessageIds = new Set<string>();
+
+export function isStickyMessage(messageId: string): boolean {
+  return stickyMessageIds.has(messageId);
+}
+
+function trackStickyMessage(previousId: string | null, nextId: string | null): void {
+  if (previousId) stickyMessageIds.delete(previousId);
+  if (nextId) stickyMessageIds.add(nextId);
+}
+
+/** Après un redémarrage, les envois déjà en place ne sont connus que d'ici. */
+function trackKnownStickyMessages(rows: StickyMessage[]): StickyMessage[] {
+  for (const row of rows) trackStickyMessage(null, row.lastMessageId);
+  return rows;
+}
 
 function cacheKey(guildId: string): string {
   return `guild:${guildId}:sticky`;
@@ -38,7 +59,7 @@ function cacheKey(guildId: string): string {
 /** Configurations sticky d'une guilde, indexées par salon. */
 async function getGuildStickies(guildId: string): Promise<StickyMessage[]> {
   const cached = await cache.get<StickyMessage[]>(cacheKey(guildId));
-  if (cached) return cached;
+  if (cached) return trackKnownStickyMessages(cached);
 
   const rows = await prisma.stickyMessage.findMany({ where: { guildId } }).catch((err) => {
     logger.error('Sticky', `Lecture des sticky de ${guildId} impossible`, err);
@@ -47,7 +68,7 @@ async function getGuildStickies(guildId: string): Promise<StickyMessage[]> {
   if (!rows) return [];
 
   await cache.set(cacheKey(guildId), rows, CONFIG_TTL_SECONDS);
-  return rows;
+  return trackKnownStickyMessages(rows);
 }
 
 /** À appeler après toute écriture depuis le dashboard ou une commande. */
@@ -127,6 +148,7 @@ export async function repostSticky(
       return null;
     });
     if (!sent) return null;
+    trackStickyMessage(sticky.lastMessageId, sent.id);
 
     await prisma.stickyMessage.update({
       where: { id: sticky.id },
@@ -174,6 +196,7 @@ export async function handleStickyMessage(
 export async function clearStickyMessage(client: Client, sticky: StickyMessage): Promise<void> {
   resetStickyCounter(sticky.channelId);
   if (!sticky.lastMessageId) return;
+  trackStickyMessage(sticky.lastMessageId, null);
 
   const channel = resolveChannel(client, sticky.channelId);
   if (!channel) return;

--- a/apps/dashboard/src/lib/stores/unsavedChanges.svelte.ts
+++ b/apps/dashboard/src/lib/stores/unsavedChanges.svelte.ts
@@ -83,7 +83,10 @@ class UnsavedChangesStore {
     try {
       const result = await this._onSave();
       // If the page callback returns false explicitly, keep dirty
-      if (result === false) return false;
+      if (result === false) {
+        this.saving = false;
+        return false;
+      }
       this.clear();
       return true;
     } catch {

--- a/apps/dashboard/src/pages/ChannelsManagement.svelte
+++ b/apps/dashboard/src/pages/ChannelsManagement.svelte
@@ -413,10 +413,17 @@
     }
   });
 
-  // Keep toggle state in sync with module header in ModulePage
+  // Keep toggle state in sync with module header in ModulePage.
+  // L'interrupteur du module ecrit deja son etat cote serveur : le repercuter
+  // sur la seule copie locale ferait apparaitre une modification a enregistrer,
+  // et l'enregistrement serait refuse par la garde des modules.
   $effect(() => {
     const activeModule = (dashboardStore.state.modules as any[]).find(m => m.id === 'auto_thread');
-    config.autoThreadEnabled = activeModule?.status === 'active';
+    const enabled = activeModule?.status === 'active';
+    untrack(() => {
+      config.autoThreadEnabled = enabled;
+      savedConfig.autoThreadEnabled = enabled;
+    });
   });
 
   async function handleSave(): Promise<boolean> {

--- a/packages/contracts/src/types/modules.ts
+++ b/packages/contracts/src/types/modules.ts
@@ -643,7 +643,7 @@ export const MODULE_REGISTRY: ModuleDefinition[] = [
     guildFields: ['autoThreadEnabled'],
     legacyField: 'autoThreadEnabled',
     apiSegments: ['auto-thread', 'channels-management'],
-    paths: ['/auto-thread', '/channels-management'],
+    paths: ['/channels-management'],
   },
   {
     key: 'news',


### PR DESCRIPTION
Autothread et sticky message configures sur le meme salon ouvraient deux fils par message : celui du message d'origine et celui du sticky republie. Les messages emis par Kotbo echappaient en effet au reglage "fils pour les bots". Le bot est desormais traite comme n'importe quel bot, et les envois sticky sont suivis en memoire pour ne jamais recevoir de fil, meme quand l'option bots est activee.

Cote dashboard, eteindre le module depuis la page Salons repercutait son etat sur la seule copie locale de la configuration : une fausse modification en attente apparaissait, et son enregistrement etait refuse par la garde des modules, d'ou le message d'erreur rouge juste apres une action reussie. Le snapshot de reference suit maintenant l'interrupteur, la barre ne s'ouvre plus.

La barre "modifications non sauvegardees" arrete par ailleurs son indicateur de chargement quand la page signale un echec sans lever d'erreur : il tournait jusqu'au rechargement de la page.

Enfin, le lien de reglages du module Auto-thread pointait sur /auto-thread, une route qui n'existe pas ; il mene desormais a /channels-management.

Closes #312
Closes #313