### PR TITLE
Fix/relecture recette

### DIFF
--- a/apps/bot/src/api/routes/admin.ts
+++ b/apps/bot/src/api/routes/admin.ts
@@ -1942,7 +1942,7 @@ export async function handleAdminRoutes(
     try {
       const { deleteSatisfactionReviewMessages } = await import('../../services/features/ticketSatisfactionService.js');
       const result = await deleteSatisfactionReviewMessages(client, userId);
-      logger.info('AdminAPI', `Avis de satisfaction de ${userId} retirés de Discord (${result.deleted} supprimés, ${result.failed} en échec) par ${user.userId}`);
+      logger.info('AdminAPI', `Avis de satisfaction de ${userId} retirés de Discord (${result.deleted} supprimés, ${result.cleared} déjà absents, ${result.failed} en échec) par ${user.userId}`);
       json(res, 200, result);
     } catch (err) {
       logger.error('AdminAPI', 'GDPR satisfaction reviews deletion error:', err);

--- a/apps/bot/src/api/routes/dashboard/clans.ts
+++ b/apps/bot/src/api/routes/dashboard/clans.ts
@@ -674,6 +674,15 @@ export async function handleClansRoutes(
         if (guild.clanRewardLeaderRole && restoredSeason >= 1) {
           for (const clan of clans) {
             if (clan.leaderRoleId) {
+              // Même règle qu'à la clôture : un clan dont le score a été ramené
+              // à zéro ne sacre personne. Les lignes des membres survivent au
+              // retrait manuel, donc le seul total fait foi.
+              const totalXp = (await prisma.clanMemberContribution.aggregate({
+                where: { guildId, clanId: clan.id, season: restoredSeason },
+                _sum: { xp: true },
+              }))._sum.xp ?? 0;
+              if (totalXp <= 0) continue;
+
               const top = await prisma.clanMemberContribution.findFirst({
                 where: { guildId, clanId: clan.id, season: restoredSeason, userId: { not: CLAN_WIDE_USER_ID } },
                 orderBy: { xp: 'desc' }
@@ -855,9 +864,49 @@ export async function handleClansRoutes(
         allowNegativeBalance: isClanWide,
       });
 
-      // Journaliser le gain pour le flux public « derniers scores »
-      if (granted !== 0) {
-        await logClanContribution(guildId, resolvedClanId, targetUserId, granted, 'ADMIN', season);
+      let appliedAmount = granted;
+      let appliedContribution = contribution;
+
+      // 4. Le disponible a été lu avant l'écriture : deux retraits partis en
+      // même temps le lisent tous les deux et se cumulent, ce qui ferait passer
+      // le total du clan sous zéro. On relit donc après coup et on rend
+      // l'excédent.
+      //
+      // Chacun ne rend que ce qu'il a lui-même retiré : rendre tout l'excédent
+      // ferait rapporter un gain à qui venait de retirer, et l'audit mentirait.
+      // Le reste est réparé par les retraits concurrents, qui passent tous ici.
+      //
+      // Un retrait sur un membre n'a pas besoin de cette correction : son
+      // plancher est celui de sa propre ligne, que `creditClanContribution`
+      // applique après l'incrément, donc à l'abri de la concurrence.
+      if (isClanWide && granted < 0) {
+        const total = (await prisma.clanMemberContribution.aggregate({
+          where: { guildId, clanId: resolvedClanId, season },
+          _sum: { xp: true },
+        }))._sum.xp ?? 0;
+
+        const refund = Math.min(-total, -granted);
+        if (refund > 0) {
+          const corrected = await prisma.clanMemberContribution.update({
+            where: { guildId_clanId_userId_season: { guildId, clanId: resolvedClanId, userId: targetUserId, season } },
+            data: { xp: { increment: refund } },
+          }).catch(() => null);
+
+          if (corrected) {
+            appliedAmount = granted + refund;
+            appliedContribution = corrected;
+            logger.warn(
+              'ClansAPI',
+              `Retrait concurrent sur le clan ${resolvedClanId} : ${refund} XP rendus pour ne pas passer sous zéro.`,
+            );
+          }
+        }
+      }
+
+      // Journaliser le gain pour le flux public « derniers scores », après la
+      // correction : c'est le montant réellement appliqué qui doit s'y lire.
+      if (appliedAmount !== 0) {
+        await logClanContribution(guildId, resolvedClanId, targetUserId, appliedAmount, 'ADMIN', season);
       }
 
       const isRemoval = body.amount < 0;
@@ -867,15 +916,15 @@ export async function handleClansRoutes(
         context: getGuildName(client, guildId),
         module: 'Clans',
         eventType: 'Manuel',
-        details: `${isRemoval ? 'Retrait' : 'Ajout'} manuel de ${Math.abs(granted)} XP ${isRemoval ? 'sur le' : 'au'} clan "${resolvedClanName}"`
+        details: `${isRemoval ? 'Retrait' : 'Ajout'} manuel de ${Math.abs(appliedAmount)} XP ${isRemoval ? 'sur le' : 'au'} clan "${resolvedClanName}"`
           + (body.userId ? ` pour l'utilisateur ${body.userId}` : ' (global)')
-          + (granted !== body.amount ? ` (${Math.abs(body.amount)} demandés, borné par le total de la saison)` : ''),
+          + (appliedAmount !== body.amount ? ` (${Math.abs(body.amount)} demandés, borné par le total de la saison)` : ''),
         channelId: null,
       });
 
       broadcastDashboardStateChange(guildId, 'clans_updated');
 
-      json(res, 200, { success: true, granted, contribution });
+      json(res, 200, { success: true, granted: appliedAmount, contribution: appliedContribution });
     } catch (err) {
       logger.error('ClansAPI', 'Error adjusting manual points:', err);
       json(res, 500, { error: 'Erreur lors de l\'ajustement manuel de points.' });

--- a/apps/bot/src/commands/moderation/transcript.ts
+++ b/apps/bot/src/commands/moderation/transcript.ts
@@ -14,7 +14,7 @@ import { generateTranscriptFromMessages } from '../../services/features/transcri
 import { logger } from '../../utils/logger.js';
 import { getEffectiveLocale, getCommandMetadata } from '../../utils/i18n.js';
 import * as m from '../../lib/paraglide/messages.js';
-import { parseDateTimeInTimezone, zonedTimeToInstant } from '../../utils/timezone.js';
+import { parseDateTimeInTimezone, toWallClockUtcMs, zonedTimeToInstant } from '../../utils/timezone.js';
 
 const meta = getCommandMetadata('b4_transcript');
 const genererMeta = getCommandMetadata('b4_transcript_generer');
@@ -194,12 +194,16 @@ export function parseDateTimeOrDuration(
     // Sans `timezone`, la date est lue dans le fuseau du process - UTC en
     // conteneur. Les appelants qui planifient une action a venir doivent donc
     // passer celui du serveur, sous peine de decaler la saisie de l'admin.
-    const wallClock = Date.UTC(year, month, day, hour, minute, second);
-    if (!isNaN(wallClock)) {
-      return timezone
-        ? zonedTimeToInstant(wallClock, timezone).getTime()
-        : new Date(year, month, day, hour, minute, second).getTime();
-    }
+    //
+    // `toWallClockUtcMs` refuse une date qui n'existe pas au lieu de la reporter :
+    // « 31/02/2026 » devenait le 3 mars sans le moindre message. Le format etant
+    // reconnu, on rend `null` plutot que de laisser le repli plus bas retenter.
+    const wallClock = toWallClockUtcMs(year, month, day, hour, minute, second);
+    if (wallClock === null) return null;
+
+    return timezone
+      ? zonedTimeToInstant(wallClock, timezone).getTime()
+      : new Date(year, month, day, hour, minute, second).getTime();
   }
 
   // 4. Fallback JS parse. Avec un fuseau, il passe par le meme chemin que les

--- a/apps/bot/src/modules/autoThread.module.ts
+++ b/apps/bot/src/modules/autoThread.module.ts
@@ -59,7 +59,7 @@ export function registerAutoThreadBusSubscribers(client: Client): void {
     // laisserait un fil vide derrière chaque renvoi. Testé après le fetch, qui
     // laisse le temps à l'envoi du sticky d'être enregistré si l'événement le
     // devance.
-    if (isStickyMessage(payload.messageId)) return;
+    if (await isStickyMessage(payload.guildId, payload.channelId, payload.messageId)) return;
 
     let rawName = payload.content ? payload.content.replace(/[\n\r]+/g, ' ').trim() : '';
     let authorName = message.member?.displayName || message.author.displayName || message.author.username;

--- a/apps/bot/src/services/community/clanService.ts
+++ b/apps/bot/src/services/community/clanService.ts
@@ -1200,7 +1200,13 @@ export async function handleEndSeason(
     }
 
     // 4. Attribuer les rôles de chefs pour TOUS les ex æquo de chaque clan
-    for (const clan of clans) {
+    for (const { clan, totalXp } of clansWithXp) {
+      // Un clan dont le score a été ramené à zéro - retrait manuel décidé par
+      // un administrateur - ne sacre personne : les lignes des membres sont
+      // restées intactes, et sans ce garde-fou le clan sanctionné couronnait
+      // quand même son meilleur contributeur.
+      if (totalXp <= 0) continue;
+
       const topContrib = await prisma.clanMemberContribution.findFirst({
         where: { guildId, clanId: clan.id, season: currentSeason, userId: { not: 'system_manual_points' } },
         orderBy: { xp: 'desc' },

--- a/apps/bot/src/services/features/stickyMessageService.ts
+++ b/apps/bot/src/services/features/stickyMessageService.ts
@@ -31,25 +31,38 @@ const pendingCounts = new Map<string, number>();
 /** Salons dont un renvoi est en cours : évite les doublons sur les rafales. */
 const reposting = new Set<string>();
 /**
- * Ids des envois sticky encore en place, pour que l'autothread ne leur ouvre
- * pas de fil : le sticky remonte à chaque seuil, chaque renvoi laisserait
- * sinon un fil vide derrière lui.
+ * Envoi sticky en place, par salon, pour que l'autothread ne lui ouvre pas de
+ * fil : le sticky remonte à chaque seuil, chaque renvoi laisserait sinon un fil
+ * vide derrière lui.
+ *
+ * Indexé par salon et non par message : un salon n'a qu'un sticky à la fois, et
+ * un ensemble d'identifiants grossissait à chaque renvoi sans jamais se vider.
  */
-const stickyMessageIds = new Set<string>();
+const stickyMessageByChannel = new Map<string, string>();
 
-export function isStickyMessage(messageId: string): boolean {
-  return stickyMessageIds.has(messageId);
+function trackStickyMessage(channelId: string, messageId: string | null): void {
+  if (messageId) stickyMessageByChannel.set(channelId, messageId);
+  else stickyMessageByChannel.delete(channelId);
 }
 
-function trackStickyMessage(previousId: string | null, nextId: string | null): void {
-  if (previousId) stickyMessageIds.delete(previousId);
-  if (nextId) stickyMessageIds.add(nextId);
-}
+/**
+ * Ce message est-il le sticky actuellement affiché dans son salon ?
+ *
+ * La carte mémoire n'est celle que du processus qui a posté. En mode distribué
+ * l'autothread peut tourner ailleurs, d'où le repli sur la configuration
+ * persistée, qui porte `lastMessageId`. Ce repli a du retard le temps que
+ * l'écriture et l'invalidation du cache se propagent : c'est la même course que
+ * celle déjà admise entre l'envoi et l'événement `message:new`.
+ */
+export async function isStickyMessage(
+  guildId: string,
+  channelId: string,
+  messageId: string,
+): Promise<boolean> {
+  if (stickyMessageByChannel.get(channelId) === messageId) return true;
 
-/** Après un redémarrage, les envois déjà en place ne sont connus que d'ici. */
-function trackKnownStickyMessages(rows: StickyMessage[]): StickyMessage[] {
-  for (const row of rows) trackStickyMessage(null, row.lastMessageId);
-  return rows;
+  const stickies = await getGuildStickies(guildId);
+  return stickies.some((sticky) => sticky.channelId === channelId && sticky.lastMessageId === messageId);
 }
 
 function cacheKey(guildId: string): string {
@@ -59,7 +72,7 @@ function cacheKey(guildId: string): string {
 /** Configurations sticky d'une guilde, indexées par salon. */
 async function getGuildStickies(guildId: string): Promise<StickyMessage[]> {
   const cached = await cache.get<StickyMessage[]>(cacheKey(guildId));
-  if (cached) return trackKnownStickyMessages(cached);
+  if (cached) return cached;
 
   const rows = await prisma.stickyMessage.findMany({ where: { guildId } }).catch((err) => {
     logger.error('Sticky', `Lecture des sticky de ${guildId} impossible`, err);
@@ -68,7 +81,7 @@ async function getGuildStickies(guildId: string): Promise<StickyMessage[]> {
   if (!rows) return [];
 
   await cache.set(cacheKey(guildId), rows, CONFIG_TTL_SECONDS);
-  return trackKnownStickyMessages(rows);
+  return rows;
 }
 
 /** À appeler après toute écriture depuis le dashboard ou une commande. */
@@ -148,7 +161,7 @@ export async function repostSticky(
       return null;
     });
     if (!sent) return null;
-    trackStickyMessage(sticky.lastMessageId, sent.id);
+    trackStickyMessage(sticky.channelId, sent.id);
 
     await prisma.stickyMessage.update({
       where: { id: sticky.id },
@@ -195,8 +208,8 @@ export async function handleStickyMessage(
  */
 export async function clearStickyMessage(client: Client, sticky: StickyMessage): Promise<void> {
   resetStickyCounter(sticky.channelId);
+  trackStickyMessage(sticky.channelId, null);
   if (!sticky.lastMessageId) return;
-  trackStickyMessage(sticky.lastMessageId, null);
 
   const channel = resolveChannel(client, sticky.channelId);
   if (!channel) return;

--- a/apps/bot/src/services/features/ticketSatisfactionService.ts
+++ b/apps/bot/src/services/features/ticketSatisfactionService.ts
@@ -787,7 +787,7 @@ export async function deleteSatisfactionReviewMessages(
   client: Client,
   userId: string,
   guildId?: string,
-): Promise<{ deleted: number; failed: number }> {
+): Promise<{ deleted: number; cleared: number; failed: number }> {
   const rows = await prisma.ticketSatisfaction.findMany({
     where: {
       userId,
@@ -803,6 +803,7 @@ export async function deleteSatisfactionReviewMessages(
   });
 
   let deleted = 0;
+  let cleared = 0;
   let failed = 0;
 
   for (const row of rows) {
@@ -810,32 +811,45 @@ export async function deleteSatisfactionReviewMessages(
       ? await client.channels.fetch(row.reviewLogChannelId).catch(() => null)
       : null;
 
-    let gone = false;
+    // Trois issues distinctes : l'embed a été retiré, il avait déjà disparu, ou
+    // il est toujours là. Les deux premières libèrent la référence, mais seule
+    // la première est une suppression - les confondre faisait annoncer des
+    // embeds retirés que personne n'avait touchés.
+    let removed = false;
+    let alreadyGone = false;
+
     if (!channel?.isTextBased()) {
       // Salon supprimé ou devenu inaccessible : l'embed n'est plus atteignable,
       // garder la référence n'apporterait rien.
-      gone = true;
+      alreadyGone = true;
     } else {
       const message = await channel.messages.fetch(row.reviewLogMessageId!).catch(() => null);
-      gone = message
-        ? await message.delete().then(() => true).catch(() => false)
-        : true;
+      if (!message) {
+        alreadyGone = true;
+      } else {
+        removed = await message.delete().then(() => true).catch(() => false);
+      }
     }
 
-    if (!gone) {
+    if (!removed && !alreadyGone) {
       failed += 1;
       continue;
     }
 
-    deleted += 1;
+    if (removed) deleted += 1;
+    else cleared += 1;
+
     await prisma.ticketSatisfaction.updateMany({
       where: { guildId: row.guildId, ticketId: row.ticketId, userId },
       data: { reviewLogChannelId: null, reviewLogMessageId: null },
     });
   }
 
-  if (deleted > 0 || failed > 0) {
-    logger.info('TicketSatisfaction', `Effacement RGPD des avis de ${userId}: ${deleted} embed(s) retiré(s), ${failed} en échec`);
+  if (deleted > 0 || cleared > 0 || failed > 0) {
+    logger.info(
+      'TicketSatisfaction',
+      `Effacement RGPD des avis de ${userId}: ${deleted} embed(s) retiré(s), ${cleared} déjà absent(s), ${failed} en échec`,
+    );
   }
-  return { deleted, failed };
+  return { deleted, cleared, failed };
 }

--- a/apps/bot/src/services/features/workflow/engine.ts
+++ b/apps/bot/src/services/features/workflow/engine.ts
@@ -91,6 +91,13 @@ export interface ExecutionState {
    * s'entremêleraient avec les précédentes dans le détail d'exécution.
    */
   stepOrder: number;
+  /**
+   * Profondeur de cascade au départ de l'exécution. Le moteur ne s'en sert
+   * pas : il la transporte pour que `workflowService` la retrouve à la reprise.
+   * Sans elle, une chaîne d'automatisations coupée par un « Attendre »
+   * repartirait de zéro et sa borne ne l'arrêterait jamais.
+   */
+  cascadeDepth?: number;
 }
 
 export type ExecutionOutcome =

--- a/apps/bot/src/services/features/workflow/workflowService.ts
+++ b/apps/bot/src/services/features/workflow/workflowService.ts
@@ -1,8 +1,10 @@
-import { cronMatches, hasBlockingIssue, validateGraph, getNodeDef, type WorkflowGraph } from '@kotbo/shared';
+import { cronMatches, hasBlockingIssue, validateGraph, getNodeDef, wallClockMinuteKey, type WorkflowGraph } from '@kotbo/shared';
+import { currentCascadeDepth, runWithCascadeDepth } from '@kotbo/core';
 import type { Client, Guild } from 'discord.js';
 import prisma from '../../../utils/db.js';
 import { logger } from '../../../utils/logger.js';
 import { cache } from '../../../utils/cache.js';
+import { resolveGuildTimezone } from '../../../utils/timezone.js';
 import { isGuildActivated } from '../../../utils/activation.js';
 import { isModuleEnabled } from '../../core/moduleGate.js';
 import { createWorkflowEffects, toChannelValue, toMemberValue, toMessageValue, toRoleValue } from './effects.js';
@@ -15,6 +17,21 @@ import { runWorkflow, type ExecutionOutcome, type ExecutionState, type StepRecor
 
 /** Au-delà, on cesse de conserver le détail pas-à-pas d'une exécution. */
 const MAX_STEPS_PERSISTED = 200;
+
+/**
+ * Nombre d'automatisations qu'une seule action de départ peut enchaîner.
+ *
+ * Une action à effet de bord publie ses propres événements - exclure un membre
+ * publie `sanction:applied`, ouvrir un ticket publie `ticket:created` - et rien
+ * n'empêche le workflow déclenché de reproduire l'action qui l'a réveillé. Sans
+ * borne, « quand une sanction est appliquée, exclure le membre » se relance
+ * indéfiniment.
+ *
+ * Le chaînage reste permis parce qu'il est légitime : un workflow qui en
+ * déclenche un autre est une composition, pas une erreur. C'est sa répétition
+ * sans fin qu'on coupe.
+ */
+const MAX_CASCADE_DEPTH = 3;
 
 /**
  * Court volontairement : l'invalidation explicite ne touche que le cache
@@ -318,11 +335,20 @@ async function runAndPersist(
     // une erreur du workflow.
     if (!triggerOutputs) return;
 
-    const outcome = await runWorkflow({
+    // Les actions publient leurs propres événements : elles s'exécutent donc un
+    // cran plus loin dans la cascade, ce que `dispatchEvent` relit pour refuser
+    // de repartir au-delà de `MAX_CASCADE_DEPTH`.
+    const depth = currentCascadeDepth() + 1;
+    const outcome = await runWithCascadeDepth(depth, () => runWorkflow({
       graph: workflow.graph as WorkflowGraph,
       effects: createWorkflowEffects(guild),
       triggerOutputs,
-    });
+    }));
+
+    // Une exécution suspendue par un « Attendre » reprend dans un tout autre
+    // contexte : la profondeur voyage donc avec son état, sinon la reprise
+    // relancerait la cascade depuis zéro.
+    outcome.state.cascadeDepth = depth;
 
     await persistOutcome(workflow.id, guild.id, outcome, payload);
   } catch (error) {
@@ -347,6 +373,17 @@ export async function dispatchEvent(
   // Sortie immédiate et sans requête pour l'immense majorité des événements,
   // qui n'intéressent aucun workflow du serveur.
   if (!(await activeTriggerEvents(guildId)).includes(busEvent)) return;
+
+  // Testé ici plutôt qu'à l'entrée : au-dessus, l'avertissement partirait aussi
+  // pour les événements que personne n'écoute, donc à chaque message.
+  const depth = currentCascadeDepth();
+  if (depth >= MAX_CASCADE_DEPTH) {
+    logger.warn(
+      'Workflow',
+      `Cascade interrompue sur ${busEvent} pour ${guildId} : ${depth} automatisations déjà enchaînées.`,
+    );
+    return;
+  }
 
   const workflows = await prisma.workflow.findMany({
     where: { guildId, enabled: true, triggerEvent: busEvent },
@@ -380,9 +417,13 @@ function readSchedule(graph: WorkflowGraph): string | null {
  * tous les workflows planifiés du serveur à chaque tick, puisque le dispatch
  * sélectionne par événement et non par workflow.
  *
+ * Le motif est lu dans le fuseau du serveur, pas dans celui du process : le bot
+ * tourne en UTC, et « tous les jours à 9h00 » serait sinon parti à 11h à Paris.
+ *
  * `lastRunAt` sert de garde-fou : deux passages dans la même minute - tick qui
  * se chevauche, second processus en mode distribué - ne relancent pas le même
- * workflow.
+ * workflow. La minute est réservée par une écriture conditionnelle, la seule
+ * façon de trancher quand les deux passages lisent avant que l'un écrive.
  */
 export async function dispatchScheduledWorkflows(client: Client, now = new Date()): Promise<void> {
   const workflows = await prisma.workflow.findMany({
@@ -393,18 +434,52 @@ export async function dispatchScheduledWorkflows(client: Client, now = new Date(
   const minuteStart = new Date(now);
   minuteStart.setSeconds(0, 0);
 
+  /** Un fuseau par serveur : plusieurs planifications s'y partagent la lecture. */
+  const timezones = new Map<string, string>();
+
   for (const workflow of workflows) {
     try {
       if (!isGuildActivated(workflow.guildId)) continue;
       if (!(await isModuleEnabled(workflow.guildId, 'workflows'))) continue;
+      // Déjà parti cette minute d'après la copie qu'on vient de lire : inutile
+      // d'aller jusqu'à la réservation, qui coûte une écriture.
       if (workflow.lastRunAt && workflow.lastRunAt >= minuteStart) continue;
 
       const graph = workflow.graph as unknown as WorkflowGraph;
       const expression = readSchedule(graph);
-      if (!expression || !cronMatches(expression, now)) continue;
+      if (!expression) continue;
+
+      let timezone = timezones.get(workflow.guildId);
+      if (timezone === undefined) {
+        timezone = await resolveGuildTimezone(workflow.guildId);
+        timezones.set(workflow.guildId, timezone);
+      }
+      if (!cronMatches(expression, now, timezone)) continue;
 
       const guild = client.guilds.cache.get(workflow.guildId);
       if (!guild) continue;
+
+      // La nuit du retour à l'heure d'hiver, l'horloge repasse par la même
+      // heure : « tous les jours à 02h30 » y tombe deux fois, à une heure
+      // d'intervalle. Les deux instants sont distincts, donc la réservation
+      // ci-dessous les accepte tous les deux - seule la minute murale les
+      // confond, et c'est bien elle que l'admin a réglée.
+      if (workflow.lastRunAt
+        && wallClockMinuteKey(workflow.lastRunAt, timezone) === wallClockMinuteKey(now, timezone)) {
+        continue;
+      }
+
+      // Réservation de la minute avant d'exécuter. Le test ci-dessus porte sur
+      // une lecture déjà ancienne : deux balayages concurrents la passent tous
+      // les deux. Ici c'est la base qui départage, et le perdant s'abstient.
+      const { count } = await prisma.workflow.updateMany({
+        where: {
+          id: workflow.id,
+          OR: [{ lastRunAt: null }, { lastRunAt: { lt: minuteStart } }],
+        },
+        data: { lastRunAt: new Date() },
+      });
+      if (count === 0) continue;
 
       await runAndPersist(guild, workflow, { firedAt: minuteStart.toISOString(), cron: expression }, 'schedule');
     } catch (error) {
@@ -519,11 +594,21 @@ export async function resumePendingExecutions(client: Client): Promise<void> {
         data: { status: 'RUNNING', resumeAt: null },
       });
 
-      const outcome = await runWorkflow({
+      const state = execution.context as unknown as ExecutionState;
+      // Une exécution enregistrée avant l'introduction du compteur n'en porte
+      // pas : on la place à l'intérieur d'une automatisation plutôt qu'à la
+      // racine, ce qui lui laisse de quoi enchaîner sans repartir de zéro.
+      const depth = typeof state?.cascadeDepth === 'number' ? state.cascadeDepth : 1;
+
+      const outcome = await runWithCascadeDepth(depth, () => runWorkflow({
         graph: execution.workflow.graph as unknown as WorkflowGraph,
         effects: createWorkflowEffects(guild),
-        state: execution.context as unknown as ExecutionState,
-      });
+        state,
+      }));
+
+      // Un second « Attendre » repasse par ici : la profondeur doit survivre à
+      // chaque reprise, pas seulement à la première.
+      outcome.state.cascadeDepth = depth;
 
       await persistOutcome(
         execution.workflowId,

--- a/apps/bot/src/tests/unit/timezone.test.ts
+++ b/apps/bot/src/tests/unit/timezone.test.ts
@@ -35,6 +35,21 @@ describe('parseDateTimeInTimezone', () => {
     expect(parseDateTimeInTimezone('2026-08-20 21:00', 'Pas/UnFuseau')?.toISOString())
       .toBe('2026-08-20T19:00:00.000Z');
   });
+
+  test('une date qui n existe pas est refusee, pas reportee', () => {
+    // `Date.UTC` reporte sans rien dire : le 31 fevrier devient le 3 mars, le
+    // mois 13 devient janvier de l'annee suivante. Une saisie fautive doit etre
+    // rejetee pour que l'appelant affiche son message d'erreur.
+    expect(parseDateTimeInTimezone('2026-02-31 09:00', 'Europe/Paris')).toBeNull();
+    expect(parseDateTimeInTimezone('2026-13-01 09:00', 'Europe/Paris')).toBeNull();
+    expect(parseDateTimeInTimezone('2026-04-31', 'Europe/Paris')).toBeNull();
+  });
+
+  test('le 29 fevrier d une annee bissextile reste valide', () => {
+    expect(parseDateTimeInTimezone('2028-02-29 12:00', 'UTC')?.toISOString())
+      .toBe('2028-02-29T12:00:00.000Z');
+    expect(parseDateTimeInTimezone('2026-02-29 12:00', 'UTC')).toBeNull();
+  });
 });
 
 describe('changements d heure', () => {

--- a/apps/bot/src/tests/unit/transcript.command.test.ts
+++ b/apps/bot/src/tests/unit/transcript.command.test.ts
@@ -104,4 +104,18 @@ describe('parseDateTimeOrDuration avec options', () => {
     expect(parseDateTimeOrDuration('invalide', { timezone: 'Europe/Paris' })).toBeNull();
     expect(parseDateTimeOrDuration('', { timezone: 'Europe/Paris' })).toBeNull();
   });
+
+  test('une date francaise qui n existe pas est refusee', () => {
+    // Sans ce controle, « 31/02/2026 » planifiait au 3 mars sans avertir.
+    expect(parseDateTimeOrDuration('31/02/2026-09:00', { timezone: 'Europe/Paris' })).toBeNull();
+    expect(parseDateTimeOrDuration('31/04/2026', { timezone: 'UTC' })).toBeNull();
+    expect(parseDateTimeOrDuration('31/02/2026-09:00')).toBeNull();
+  });
+
+  test('une date francaise limite reste acceptee', () => {
+    expect(parseDateTimeOrDuration('29/02/2028-12:00', { timezone: 'UTC' }))
+      .toBe(Date.parse('2028-02-29T12:00:00.000Z'));
+    expect(parseDateTimeOrDuration('31/12/2026-23:59', { timezone: 'UTC' }))
+      .toBe(Date.parse('2026-12-31T23:59:00.000Z'));
+  });
 });

--- a/apps/bot/src/tests/unit/workflowCron.test.ts
+++ b/apps/bot/src/tests/unit/workflowCron.test.ts
@@ -5,10 +5,17 @@ import {
   isValidCron,
   parseCron,
   scheduleToCron,
+  wallClockMinuteKey,
 } from '@kotbo/shared';
 
-/** Raccourci lisible : l'heure locale, seule base du matcher. */
-const at = (iso: string) => new Date(iso);
+/**
+ * Instant absolu. Les motifs sont ensuite confrontes a un fuseau explicite :
+ * sans ca, le resultat des tests dependrait du fuseau de la machine.
+ */
+const at = (iso: string) => new Date(`${iso}Z`);
+
+/** Le fuseau neutre, sauf pour les tests qui verifient justement la conversion. */
+const UTC = 'UTC';
 
 describe('validation des motifs', () => {
   test('accepte les formes standard', () => {
@@ -25,53 +32,93 @@ describe('validation des motifs', () => {
 
   test('7 et 0 designent tous deux le dimanche', () => {
     const sunday = at('2026-08-16T12:00:00');
-    expect(sunday.getDay()).toBe(0);
-    expect(cronMatches('0 12 * * 7', sunday)).toBeTrue();
-    expect(cronMatches('0 12 * * 0', sunday)).toBeTrue();
+    expect(sunday.getUTCDay()).toBe(0);
+    expect(cronMatches('0 12 * * 7', sunday, UTC)).toBeTrue();
+    expect(cronMatches('0 12 * * 0', sunday, UTC)).toBeTrue();
   });
 });
 
 describe('correspondance a la minute', () => {
   test('tous les jours a 9h00', () => {
-    expect(cronMatches('0 9 * * *', at('2026-08-18T09:00:00'))).toBeTrue();
-    expect(cronMatches('0 9 * * *', at('2026-08-18T09:01:00'))).toBeFalse();
-    expect(cronMatches('0 9 * * *', at('2026-08-18T10:00:00'))).toBeFalse();
+    expect(cronMatches('0 9 * * *', at('2026-08-18T09:00:00'), UTC)).toBeTrue();
+    expect(cronMatches('0 9 * * *', at('2026-08-18T09:01:00'), UTC)).toBeFalse();
+    expect(cronMatches('0 9 * * *', at('2026-08-18T10:00:00'), UTC)).toBeFalse();
   });
 
   test('un pas couvre les minutes attendues', () => {
-    expect(cronMatches('*/15 * * * *', at('2026-08-18T10:00:00'))).toBeTrue();
-    expect(cronMatches('*/15 * * * *', at('2026-08-18T10:15:00'))).toBeTrue();
-    expect(cronMatches('*/15 * * * *', at('2026-08-18T10:30:00'))).toBeTrue();
-    expect(cronMatches('*/15 * * * *', at('2026-08-18T10:07:00'))).toBeFalse();
+    expect(cronMatches('*/15 * * * *', at('2026-08-18T10:00:00'), UTC)).toBeTrue();
+    expect(cronMatches('*/15 * * * *', at('2026-08-18T10:15:00'), UTC)).toBeTrue();
+    expect(cronMatches('*/15 * * * *', at('2026-08-18T10:30:00'), UTC)).toBeTrue();
+    expect(cronMatches('*/15 * * * *', at('2026-08-18T10:07:00'), UTC)).toBeFalse();
   });
 
   test('un intervalle de jours de semaine exclut le week-end', () => {
     // 2026-08-17 est un lundi, 2026-08-22 un samedi.
-    expect(cronMatches('0 8 * * 1-5', at('2026-08-17T08:00:00'))).toBeTrue();
-    expect(cronMatches('0 8 * * 1-5', at('2026-08-22T08:00:00'))).toBeFalse();
+    expect(cronMatches('0 8 * * 1-5', at('2026-08-17T08:00:00'), UTC)).toBeTrue();
+    expect(cronMatches('0 8 * * 1-5', at('2026-08-22T08:00:00'), UTC)).toBeFalse();
   });
 
   test('une liste accepte chacune de ses valeurs', () => {
-    expect(cronMatches('0 0,12 * * *', at('2026-08-18T00:00:00'))).toBeTrue();
-    expect(cronMatches('0 0,12 * * *', at('2026-08-18T12:00:00'))).toBeTrue();
-    expect(cronMatches('0 0,12 * * *', at('2026-08-18T06:00:00'))).toBeFalse();
+    expect(cronMatches('0 0,12 * * *', at('2026-08-18T00:00:00'), UTC)).toBeTrue();
+    expect(cronMatches('0 0,12 * * *', at('2026-08-18T12:00:00'), UTC)).toBeTrue();
+    expect(cronMatches('0 0,12 * * *', at('2026-08-18T06:00:00'), UTC)).toBeFalse();
   });
 
   test('jour du mois et jour de semaine se combinent par un OU', () => {
     // Regle historique de cron : « le 1er du mois, et aussi tous les lundis ».
     // 2026-09-01 est un mardi, 2026-09-07 un lundi.
-    expect(cronMatches('0 0 1 * 1', at('2026-09-01T00:00:00'))).toBeTrue();
-    expect(cronMatches('0 0 1 * 1', at('2026-09-07T00:00:00'))).toBeTrue();
-    expect(cronMatches('0 0 1 * 1', at('2026-09-08T00:00:00'))).toBeFalse();
+    expect(cronMatches('0 0 1 * 1', at('2026-09-01T00:00:00'), UTC)).toBeTrue();
+    expect(cronMatches('0 0 1 * 1', at('2026-09-07T00:00:00'), UTC)).toBeTrue();
+    expect(cronMatches('0 0 1 * 1', at('2026-09-08T00:00:00'), UTC)).toBeFalse();
   });
 
   test('un champ restreint seul reste un ET avec le reste', () => {
-    expect(cronMatches('0 0 1 * *', at('2026-09-01T00:00:00'))).toBeTrue();
-    expect(cronMatches('0 0 1 * *', at('2026-09-02T00:00:00'))).toBeFalse();
+    expect(cronMatches('0 0 1 * *', at('2026-09-01T00:00:00'), UTC)).toBeTrue();
+    expect(cronMatches('0 0 1 * *', at('2026-09-02T00:00:00'), UTC)).toBeFalse();
   });
 
   test('un motif invalide ne declenche jamais', () => {
-    expect(cronMatches('nawak', at('2026-08-18T09:00:00'))).toBeFalse();
+    expect(cronMatches('nawak', at('2026-08-18T09:00:00'), UTC)).toBeFalse();
+  });
+});
+
+describe('lecture dans le fuseau du serveur', () => {
+  test('l heure du motif est celle du serveur, pas celle du process', () => {
+    // Le bot tourne en UTC : « tous les jours a 9h » doit partir a 07:00 UTC en
+    // ete a Paris, et surtout pas a 09:00 UTC.
+    expect(cronMatches('0 9 * * *', at('2026-08-18T07:00:00'), 'Europe/Paris')).toBeTrue();
+    expect(cronMatches('0 9 * * *', at('2026-08-18T09:00:00'), 'Europe/Paris')).toBeFalse();
+  });
+
+  test('le decalage suit l heure d hiver', () => {
+    // Meme motif, meme serveur, un decalage de moins : 08:00 UTC en janvier.
+    expect(cronMatches('0 9 * * *', at('2026-01-15T08:00:00'), 'Europe/Paris')).toBeTrue();
+    expect(cronMatches('0 9 * * *', at('2026-01-15T07:00:00'), 'Europe/Paris')).toBeFalse();
+  });
+
+  test('le jour bascule avec le fuseau', () => {
+    // 2026-08-18T23:30 UTC est deja le 19 a Paris, un mercredi.
+    expect(cronMatches('30 1 19 * *', at('2026-08-18T23:30:00'), 'Europe/Paris')).toBeTrue();
+    expect(cronMatches('30 1 19 * 3', at('2026-08-18T23:30:00'), 'Europe/Paris')).toBeTrue();
+    expect(cronMatches('30 23 18 * *', at('2026-08-18T23:30:00'), 'Europe/Paris')).toBeFalse();
+  });
+
+  test('minuit tombe bien sur 0 et non sur 24', () => {
+    expect(cronMatches('0 0 * * *', at('2026-08-17T22:00:00'), 'Europe/Paris')).toBeTrue();
+  });
+
+  test('un fuseau inconnu retombe sur UTC au lieu de tout eteindre', () => {
+    expect(cronMatches('0 9 * * *', at('2026-08-18T09:00:00'), 'Mars/Olympus')).toBeTrue();
+  });
+
+  test('une etoile avec pas se combine par un ET, comme le cron systeme', () => {
+    // `0 0 */2 * 1` : les lundis qui tombent un jour impair du mois.
+    // 2026-09-07 est un lundi (jour 7, impair au sens de `*/2` : 1,3,5,7...).
+    expect(cronMatches('0 0 */2 * 1', at('2026-09-07T00:00:00'), UTC)).toBeTrue();
+    // 2026-09-14 est un lundi, mais le 14 n'est pas dans `*/2` a partir de 1.
+    expect(cronMatches('0 0 */2 * 1', at('2026-09-14T00:00:00'), UTC)).toBeFalse();
+    // 2026-09-09 est dans `*/2` mais c'est un mercredi.
+    expect(cronMatches('0 0 */2 * 1', at('2026-09-09T00:00:00'), UTC)).toBeFalse();
   });
 });
 
@@ -109,6 +156,30 @@ describe('composition depuis l editeur', () => {
 
   test('les valeurs aberrantes sont ramenees dans les bornes', () => {
     expect(scheduleToCron({ frequency: 'daily', minute: 99, hour: -3, weekday: 1, day: 1 })).toBe('59 0 * * *');
+  });
+});
+
+describe('repere de minute murale', () => {
+  test('le retour a l heure d hiver repasse par la meme minute murale', () => {
+    // 2026-10-25, dernier dimanche d'octobre : Paris repasse de 03h CEST a 02h
+    // CET. « 02h30 » y tombe deux fois, a une heure d'intervalle.
+    const premierPassage = at('2026-10-25T00:30:00');
+    const secondPassage = at('2026-10-25T01:30:00');
+
+    expect(cronMatches('30 2 * * *', premierPassage, 'Europe/Paris')).toBeTrue();
+    expect(cronMatches('30 2 * * *', secondPassage, 'Europe/Paris')).toBeTrue();
+    // Le balayage s'appuie la-dessus pour ne pas declencher deux fois.
+    expect(wallClockMinuteKey(premierPassage, 'Europe/Paris'))
+      .toBe(wallClockMinuteKey(secondPassage, 'Europe/Paris'));
+  });
+
+  test('deux minutes distinctes gardent des reperes distincts', () => {
+    expect(wallClockMinuteKey(at('2026-08-18T09:00:00'), UTC)).toBe('2026-08-18T09:00');
+    expect(wallClockMinuteKey(at('2026-08-18T09:01:00'), UTC)).toBe('2026-08-18T09:01');
+  });
+
+  test('le repere suit le fuseau, pas l instant', () => {
+    expect(wallClockMinuteKey(at('2026-08-18T22:30:00'), 'Europe/Paris')).toBe('2026-08-19T00:30');
   });
 });
 

--- a/apps/bot/src/utils/timezone.ts
+++ b/apps/bot/src/utils/timezone.ts
@@ -17,11 +17,12 @@ import {
   DEFAULT_TIMEZONE,
   normalizeTimezone,
   parseDateTimeInTimezone,
+  toWallClockUtcMs,
   zonedTimeToInstant,
 } from '@kotbo/contracts';
 import type { BotLocale } from './i18n.js';
 
-export { DEFAULT_TIMEZONE, parseDateTimeInTimezone, zonedTimeToInstant };
+export { DEFAULT_TIMEZONE, parseDateTimeInTimezone, toWallClockUtcMs, zonedTimeToInstant };
 
 const BCP47: Record<BotLocale, string> = { fr: 'fr-FR', en: 'en-US' };
 

--- a/apps/dashboard/messages/en.json
+++ b/apps/dashboard/messages/en.json
@@ -8103,7 +8103,7 @@
   "wf_schedule_simple": "Back to guided choice",
   "wf_schedule_raw_hint": "Five-field cron pattern.",
   "wf_schedule_invalid": "Unreadable pattern.",
-  "wf_schedule_timezone": "The time follows the time zone of the server hosting the bot.",
+  "wf_schedule_timezone": "Time interpreted in {zone}, the server's time zone.",
   "wf_choose_message": "Choose a message",
   "wf_never_started": "Never started",
   "wf_never_started_hint": "Enabled but never ran: check the trigger and its conditions.",

--- a/apps/dashboard/messages/fr.json
+++ b/apps/dashboard/messages/fr.json
@@ -8103,7 +8103,7 @@
   "wf_schedule_simple": "Revenir au choix guidé",
   "wf_schedule_raw_hint": "Motif cron à cinq champs.",
   "wf_schedule_invalid": "Motif illisible.",
-  "wf_schedule_timezone": "L'heure suit le fuseau du serveur qui héberge le bot.",
+  "wf_schedule_timezone": "Heure interprétée dans {zone}, le fuseau du serveur.",
   "wf_choose_message": "Choisir un message",
   "wf_never_started": "N'a jamais démarré",
   "wf_never_started_hint": "Actif mais aucune exécution : vérifiez le déclencheur et ses conditions.",

--- a/apps/dashboard/src/lib/components/triggers/RecipeEditor.svelte
+++ b/apps/dashboard/src/lib/components/triggers/RecipeEditor.svelte
@@ -280,7 +280,6 @@
           value={String(recipe.trigger.config?.cron ?? '')}
           onChange={(cron) => setTriggerConfig('cron', cron)}
         />
-        <p class="text-[11px] text-on-surface-variant/70">{m.wf_schedule_timezone()}</p>
       {/if}
     {:else}
       <TriggerPicker selected={recipe.trigger.type} onPick={pickTrigger} />

--- a/apps/dashboard/src/lib/components/triggers/ScheduleField.svelte
+++ b/apps/dashboard/src/lib/components/triggers/ScheduleField.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { m } from '../../i18n';
+  import { timezoneStore } from '../../stores/timezone.svelte';
   import {
     DEFAULT_SCHEDULE,
     cronToSchedule,
@@ -55,6 +56,13 @@
   }
 
   const control = 'px-2.5 py-1 rounded-lg text-xs bg-surface-container-highest border border-outline-variant/25 text-on-surface focus:outline-none focus:border-primary/60';
+
+  // Le motif est evalue par le bot dans le fuseau du serveur, pas dans celui du
+  // navigateur : sans ce rappel, une heure choisie ici depuis un autre fuseau
+  // se lit comme locale alors qu'elle ne l'est pas.
+  $effect(() => {
+    void timezoneStore.ensureLoaded();
+  });
 </script>
 
 <div class="flex flex-wrap items-center gap-2">
@@ -136,5 +144,11 @@
       onclick={() => (rawMode = true)}
       class="text-[11px] font-medium text-on-surface-variant/70 hover:text-primary transition-colors"
     >{m.wf_schedule_advanced()}</button>
+  {/if}
+
+  {#if timezoneStore.loaded}
+    <span class="basis-full text-[11px] text-on-surface-variant/70">
+      {m.wf_schedule_timezone({ zone: timezoneStore.timezone })}
+    </span>
   {/if}
 </div>

--- a/apps/dashboard/src/lib/graph/forceLayout.ts
+++ b/apps/dashboard/src/lib/graph/forceLayout.ts
@@ -167,6 +167,15 @@ export function computeForceLayout(
   for (let iter = 0; iter < iterations; iter++) {
     const temp = (iterations - iter) / iterations; // cooling temperature
 
+    // Le vecteur de deplacement repart de zero a chaque passe : c'est la somme
+    // des forces de cette iteration-la qui donne la direction. Le cumuler d'une
+    // passe a l'autre revenait a garder un elan que rien n'amortit, et le
+    // placement final suivait l'historique des forces plutot que l'etat courant.
+    for (const n of workNodes) {
+      n.vx = 0;
+      n.vy = 0;
+    }
+
     // A. Repulsion forces between all nodes
     for (let i = 0; i < workNodes.length; i++) {
       const n1 = workNodes[i];

--- a/apps/dashboard/src/lib/stores/dashboard.svelte.ts
+++ b/apps/dashboard/src/lib/stores/dashboard.svelte.ts
@@ -153,6 +153,15 @@ class DashboardStore {
    */
   private refreshPromise: Promise<void> | null = null;
   /**
+   * Serveur et portee du rafraichissement en vol. Un appel qui charge tout
+   * l'etat du bon serveur repond aussi a une demande d'apercu : sans ces deux
+   * reperes on ne pouvait pas le savoir, et chaque appelant en relancait un de
+   * son cote. Le serveur en fait partie : reutiliser l'appel d'un autre laisse
+   * l'appelant croire le sien charge.
+   */
+  private pendingFull = false;
+  private pendingGuildId: string | null = null;
+  /**
    * Guild pour laquelle un `refresh()` a deja abouti. Sert a distinguer le
    * premier chargement (qui doit afficher un etat d'attente) des
    * rafraichissements en arriere-plan. Compare a la guild courante plutot que
@@ -199,16 +208,25 @@ class DashboardStore {
 
     const inFlight = this.refreshPromise;
     if (inFlight) {
+      // Un appel deja parti couvre le besoin : on se raccroche au sien au lieu
+      // d'en lancer un second sur les memes routes.
+      if (this.covers(requestedGuildId, full)) return inFlight;
+
+      // Sinon il ne repond pas a la demande - autre serveur, ou simple apercu
+      // la ou il faut tout l'etat. On l'attend avant de relancer, sinon les
+      // deux reponses s'ecrasent l'une l'autre.
       await inFlight;
-      // Le rafraichissement qu'on vient d'attendre visait peut-etre une autre
-      // guild, ou n'a ramene qu'un apercu la ou l'appelant demande l'etat
-      // complet : dans ce cas il ne repond pas a notre besoin et on relance.
-      // `startRefresh` n'attend plus rien, la reprise est donc bornee a un tour.
       if (this.isLoadedFor(requestedGuildId, full)) return;
-      return this.startRefresh(full);
     }
 
     return this.startRefresh(full);
+  }
+
+  /** Le rafraichissement en vol repond-il deja a cette demande ? */
+  private covers(guildId: string | null, full: boolean): boolean {
+    if (!this.refreshPromise) return false;
+    if (this.pendingGuildId !== guildId) return false;
+    return this.pendingFull || !full;
   }
 
   /** Vrai si l'etat affiche correspond deja a ce que l'appelant demande. */
@@ -217,17 +235,32 @@ class DashboardStore {
   }
 
   private startRefresh(full: boolean): Promise<void> {
-    if (!authStore.token || !authStore.selectedGuildId) {
+    // Le serveur vise est celui d'ici, pas celui capture avant l'attente
+    // ci-dessus : c'est aussi celui que `runRefresh` va lire.
+    const guildId = authStore.selectedGuildId;
+
+    // Plusieurs appelants peuvent avoir attendu le meme rafraichissement et
+    // repartir ensemble : le premier reveille lance le suivant, les autres
+    // doivent s'y raccrocher plutot que d'en empiler un chacun.
+    if (this.covers(guildId, full)) return this.refreshPromise!;
+
+    if (!authStore.token || !guildId) {
       this.state.loading = false;
       return Promise.resolve();
     }
 
     const pending = this.runRefresh(full);
     this.refreshPromise = pending;
+    this.pendingFull = full;
+    this.pendingGuildId = guildId;
     return pending.finally(() => {
       // Ne libere le verrou que s'il s'agit toujours du notre : un appel parti
       // entre-temps garde la main sur le sien.
-      if (this.refreshPromise === pending) this.refreshPromise = null;
+      if (this.refreshPromise === pending) {
+        this.refreshPromise = null;
+        this.pendingFull = false;
+        this.pendingGuildId = null;
+      }
     });
   }
 

--- a/apps/dashboard/src/lib/stores/timezone.svelte.ts
+++ b/apps/dashboard/src/lib/stores/timezone.svelte.ts
@@ -13,8 +13,26 @@ import { fetchGuildTimezone } from '../api/guild';
  */
 class TimezoneStore {
   timezone = $state<string>(DEFAULT_TIMEZONE);
-  loaded = $state(false);
-  loadedGuildId: string | null = null;
+  loadedGuildId = $state<string | null>(null);
+
+  /**
+   * Vrai seulement si le fuseau en memoire decrit bien le serveur affiche. Un
+   * simple drapeau restait a `true` apres un changement de serveur, et les
+   * libelles annoncaient le fuseau du precedent jusqu'au retour de la lecture.
+   */
+  get loaded(): boolean {
+    return this.loadedGuildId !== null && this.loadedGuildId === authStore.selectedGuildId;
+  }
+
+  /**
+   * Fuseau qu'on vient d'ecrire ailleurs (page Accueil) : evite une relecture
+   * juste apres la sauvegarde, et garde les formulaires en phase.
+   */
+  apply(timezone: string, guildId: string | null = authStore.selectedGuildId): void {
+    if (!guildId) return;
+    this.timezone = timezone;
+    this.loadedGuildId = guildId;
+  }
 
   readonly browserTimezone: string = (() => {
     try {
@@ -24,20 +42,41 @@ class TimezoneStore {
     }
   })();
 
+  /**
+   * Lecture en vol, partagee par tous les appelants. Plusieurs composants
+   * demandent le fuseau au montage : sans ce partage, chacun lancait son propre
+   * GET puisque `loadedGuildId` n'est ecrit qu'a la reponse.
+   */
+  private loading: Promise<void> | null = null;
+  private loadingGuildId: string | null = null;
+
   async ensureLoaded(force = false): Promise<void> {
     const guildId = authStore.selectedGuildId;
     if (!guildId) return;
     if (!force && this.loadedGuildId === guildId) return;
+    // Une lecture en vol ne repond que pour le serveur qu'elle vise : rendre
+    // celle d'un autre laisserait l'appelant croire son fuseau charge.
+    if (!force && this.loading && this.loadingGuildId === guildId) return this.loading;
 
+    const pending = this.load(guildId);
+    this.loading = pending;
+    this.loadingGuildId = guildId;
+    try {
+      await pending;
+    } finally {
+      if (this.loading === pending) {
+        this.loading = null;
+        this.loadingGuildId = null;
+      }
+    }
+  }
+
+  private async load(guildId: string): Promise<void> {
     const state = await fetchGuildTimezone();
     // La selection a pu changer pendant l'appel : n'ecrit que si on est encore
     // sur le serveur demande, sinon on ecraserait un chargement plus recent.
     if (authStore.selectedGuildId !== guildId) return;
-    if (state?.timezone) {
-      this.timezone = state.timezone;
-      this.loaded = true;
-      this.loadedGuildId = guildId;
-    }
+    if (state?.timezone) this.apply(state.timezone, guildId);
   }
 
   /** Vrai si le fuseau du serveur diffère de celui du navigateur. */

--- a/apps/dashboard/src/pages/ChannelsManagement.svelte
+++ b/apps/dashboard/src/pages/ChannelsManagement.svelte
@@ -155,6 +155,20 @@
     selectableChannels.filter(c => c.name.toLowerCase().includes(searchQuery.toLowerCase()))
   );
 
+  /**
+   * Choix d'un selecteur, en gardant la valeur deja enregistree meme si elle ne
+   * fait plus partie des choix proposes. Sans ca, un sticky configure sur un
+   * fil avant ce filtrage s'affichait sur un selecteur vide, et on ne pouvait
+   * plus voir ni changer ce qui etait en place.
+   */
+  function channelOptions(selectedId: string | null | undefined) {
+    const options = selectableChannels.map(c => ({ id: c.id, name: channelDisplayName(c) }));
+    if (!selectedId || options.some(o => o.id === selectedId)) return options;
+
+    const current = availableChannels.find(c => c.id === selectedId);
+    return current ? [...options, { id: current.id, name: channelDisplayName(current) }] : options;
+  }
+
   let activeTempChannels = $state([] as any[]);
   let loadingTempChannels = $state(false);
 
@@ -705,7 +719,7 @@
                       <label for="sticky-channel-{index}" class="text-xs font-bold text-on-surface/80 block">{m.cm_sticky_channel_label()}</label>
                       <SearchableSelect
                         id="sticky-channel-{index}"
-                        options={selectableChannels.map(c => ({ id: c.id, name: channelDisplayName(c) }))}
+                        options={channelOptions(sticky.channelId)}
                         bind:value={sticky.channelId}
                         placeholder={m.cm_select_channel_placeholder()}
                         disabled={!!sticky.id}
@@ -1844,7 +1858,7 @@
                   <div class="grow">
                     <SearchableSelect
                       id="honeypot-channel-select"
-                      options={selectableChannels.map(c => ({ id: c.id, name: channelDisplayName(c) }))}
+                      options={channelOptions(config.honeypotChannelId)}
                       bind:value={config.honeypotChannelId}
                       placeholder={m.cm_select_channel_placeholder()}
                     />

--- a/apps/dashboard/src/pages/Home.svelte
+++ b/apps/dashboard/src/pages/Home.svelte
@@ -680,9 +680,7 @@
         // partage sert aux formulaires ailleurs. Sans cette synchro, changer
         // le fuseau depuis l'accueil sans recharger laisserait Meetings et
         // Planning saisir dans l'ancien.
-        timezoneStore.timezone = state.timezone;
-        timezoneStore.loaded = true;
-        timezoneStore.loadedGuildId = authStore.selectedGuildId;
+        timezoneStore.apply(state.timezone);
       }
     } catch {
       // dashboardRequest a deja notifie l'echec.

--- a/apps/dashboard/src/pages/Planning.svelte
+++ b/apps/dashboard/src/pages/Planning.svelte
@@ -209,11 +209,17 @@
     if (!canManageMeetings) return;
     editMeetingTitle = meeting.title;
     editMeetingDesc = meeting.description || '';
-    // Restaure AVANT le format : sinon `formatLocal` lit encore le fuseau
-    // precedent et affiche une heure decalee au premier rendu du modal.
+    // Le fuseau est passe explicitement : `formatLocal` suit `activeTimezone`,
+    // qui ne bascule sur celui de l'edition qu'une fois la modale marquee comme
+    // ouverte - c'est-a-dire apres ces deux lignes. Nommer la zone ici evite de
+    // dependre de l'ordre des affectations.
     editMeetingTimezone = meeting.timezone ?? null;
-    editMeetingDate = formatLocal(new Date(meeting.scheduledAt));
-    editMeetingEndDate = meeting.endedAt ? formatLocal(new Date(meeting.endedAt)) : formatLocal(new Date(new Date(meeting.scheduledAt).getTime() + 3600000));
+    const editZone = editMeetingTimezone ?? timezoneStore.timezone;
+    editMeetingDate = formatWallClockInTimezone(new Date(meeting.scheduledAt), editZone);
+    editMeetingEndDate = formatWallClockInTimezone(
+      meeting.endedAt ? new Date(meeting.endedAt) : new Date(new Date(meeting.scheduledAt).getTime() + 3600000),
+      editZone,
+    );
     editMeetingError = '';
     meetingEditModalOpen = true;
   }
@@ -569,17 +575,31 @@
     miniCalDate = new Date(miniCalDate.getFullYear(), miniCalDate.getMonth() + 1, 1);
   }
 
-  // Fuseau utilise pour lire et rendre les inputs `datetime-local`. `formTimezone`
-  // porte le fuseau du formulaire de creation courant (une reunion peut porter
-  // le sien), `editMeetingTimezone` celui de l'edition en cours.
+  // Fuseau utilise pour lire et rendre les inputs `datetime-local` du formulaire
+  // de creation et de la modale d'edition.
+  //
+  // Seule une reunion porte son propre fuseau, et le selecteur n'apparait que
+  // sur cet onglet-la. Le retenir au-dela ferait lire une absence, un appel ou
+  // une tache dans le fuseau d'une reunion creee juste avant, alors que le
+  // libelle affiche sous le champ annonce celui du serveur.
   const activeTimezone = $derived(
     meetingEditModalOpen
       ? (editMeetingTimezone ?? timezoneStore.timezone)
-      : (formTimezone ?? timezoneStore.timezone),
+      : creationModalOpen && currentTab === 'meeting'
+        ? (formTimezone ?? timezoneStore.timezone)
+        : timezoneStore.timezone,
   );
   const formatLocal = (date: Date) => formatWallClockInTimezone(date, activeTimezone);
   const parseLocal = (input: string): Date =>
     parseDateTimeInTimezone(input, activeTimezone) ?? new Date();
+
+  /**
+   * Un rappel ne porte pas de fuseau propre : il se lit toujours dans celui du
+   * serveur. Il vit hors des deux modales, donc `activeTimezone` ne le decrit
+   * pas - c'est ce qui le faisait heriter du fuseau de la derniere reunion.
+   */
+  const parseServerLocal = (input: string): Date =>
+    parseDateTimeInTimezone(input, timezoneStore.timezone) ?? new Date();
 
   // Data loading
   async function loadData() {
@@ -654,7 +674,7 @@
     try {
       const payload: any = {
         message: newReminderMessage,
-        targetTime: parseLocal(newReminderTime).toISOString(),
+        targetTime: parseServerLocal(newReminderTime).toISOString(),
         channelId: newReminderChannel === 'CURRENT' ? currentItemDetail.raw.discordChannelId || null : null,
       };
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -82,5 +82,6 @@ export {
   listSupportedTimezones,
   normalizeTimezone,
   parseDateTimeInTimezone,
+  toWallClockUtcMs,
   zonedTimeToInstant,
 } from './types/timezone.js';

--- a/packages/contracts/src/types/timezone.ts
+++ b/packages/contracts/src/types/timezone.ts
@@ -147,6 +147,40 @@ export function zonedTimeToInstant(wallClockUtcMs: number, timezone: string): Da
 const WALL_CLOCK_REGEX = /^(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2}))?)?$/;
 
 /**
+ * Millisecondes UTC de champs date/heure lus tels quels, ou `null` si la
+ * combinaison n'existe pas.
+ *
+ * `Date.UTC` ne refuse rien : il reporte. Le 31 fevrier devient le 3 mars et le
+ * mois 13 devient janvier de l'annee suivante, sans le moindre signal. Un
+ * `/rappel 2026-02-31 09:00` partait donc au mauvais jour au lieu d'etre
+ * refuse. On relit donc ce qu'on vient d'ecrire, seule facon de distinguer une
+ * date valide d'un report.
+ *
+ * `monthIndex` est en base 0, comme `Date.UTC` et `new Date(...)`.
+ */
+export function toWallClockUtcMs(
+  year: number,
+  monthIndex: number,
+  day: number,
+  hour = 0,
+  minute = 0,
+  second = 0,
+): number | null {
+  const ms = Date.UTC(year, monthIndex, day, hour, minute, second);
+  if (Number.isNaN(ms)) return null;
+
+  const back = new Date(ms);
+  const matches = back.getUTCFullYear() === year
+    && back.getUTCMonth() === monthIndex
+    && back.getUTCDate() === day
+    && back.getUTCHours() === hour
+    && back.getUTCMinutes() === minute
+    && back.getUTCSeconds() === second;
+
+  return matches ? ms : null;
+}
+
+/**
  * Lit une date saisie par un humain dans le fuseau donne.
  *
  * Une chaine deja horodatee (`…Z`, `+02:00`) designe un instant sans ambiguite
@@ -159,7 +193,7 @@ export function parseDateTimeInTimezone(input: string, timezone: string): Date |
 
   const match = trimmed.match(WALL_CLOCK_REGEX);
   if (match) {
-    const wallClock = Date.UTC(
+    const wallClock = toWallClockUtcMs(
       Number(match[1]),
       Number(match[2]) - 1,
       Number(match[3]),
@@ -167,7 +201,9 @@ export function parseDateTimeInTimezone(input: string, timezone: string): Date |
       match[5] ? Number(match[5]) : 0,
       match[6] ? Number(match[6]) : 0,
     );
-    if (Number.isNaN(wallClock)) return null;
+    // Une date qui n'existe pas est refusee ici plutot que reportee : la forme
+    // etant reconnue, retomber sur `new Date` reproduirait le meme report.
+    if (wallClock === null) return null;
     return zonedTimeToInstant(wallClock, timezone);
   }
 

--- a/packages/core/src/eventBus.ts
+++ b/packages/core/src/eventBus.ts
@@ -16,6 +16,7 @@
 
 import { EventEmitter } from 'events';
 import { randomUUID } from 'crypto';
+import { currentCascadeDepth, runWithCascadeDepth } from './eventCascade.js';
 import type { KotboEventMap, KotboEventName } from './eventBus.types.js';
 
 export type KotboEventHandler<E extends KotboEventName> = (payload: KotboEventMap[E]) => void | Promise<void>;
@@ -58,12 +59,17 @@ class KotboEventBus {
     this.subscriber.on('message', (channel: string, message: string) => {
       const event = channel.replace('kotbo:', '') as KotboEventName;
       try {
-        const { payload, senderId } = JSON.parse(message);
+        const { payload, senderId, cascade } = JSON.parse(message);
         // Skip our own publishes echoed back by Redis - we already emitted
         // them locally and synchronously in publish(). Without this guard,
         // every bus event (welcome, boost, ...) fires twice on this process.
         if (senderId === this.instanceId) return;
-        this.emitter.emit(event, payload);
+        // La profondeur de cascade est retablie avant la livraison : sans elle
+        // une chaine d'automatisations repartirait de zero a chaque saut de
+        // processus, et sa borne ne l'arreterait jamais.
+        runWithCascadeDepth(typeof cascade === 'number' ? cascade : 0, () => {
+          this.emitter.emit(event, payload);
+        });
       } catch { /* malformed message, skip */ }
     });
 
@@ -84,8 +90,9 @@ class KotboEventBus {
 
     // Distributed delivery via Redis Pub/Sub
     if (this.distributed && this.publisher) {
+      const cascade = currentCascadeDepth();
       this.publisher
-        .publish(`kotbo:${event}`, JSON.stringify({ payload, senderId: this.instanceId }))
+        .publish(`kotbo:${event}`, JSON.stringify({ payload, senderId: this.instanceId, cascade }))
         .catch(() => {});
     }
   }

--- a/packages/core/src/eventCascade.ts
+++ b/packages/core/src/eventCascade.ts
@@ -1,0 +1,41 @@
+/**
+ * Profondeur de cascade d'un evenement du bus.
+ *
+ * Une automatisation qui reagit a un evenement peut en produire un autre :
+ * exclure un membre publie `sanction:applied`, ouvrir un ticket publie
+ * `ticket:created`. Rien n'empeche alors le meme workflow de se rappeler
+ * indefiniment - « quand une sanction est appliquee, exclure le membre » se
+ * redeclenche a chaque tour, sur un membre deja exclu.
+ *
+ * Le chainage reste utile - un workflow qui en declenche un autre est une
+ * fonctionnalite - donc on le borne au lieu de l'interdire : chaque execution
+ * incremente la profondeur, et le moteur refuse de repartir au-dela.
+ *
+ * La valeur voyage par `AsyncLocalStorage` dans le processus, et dans
+ * l'enveloppe Redis entre processus : sans ce second chemin, deux instances se
+ * renverraient la cascade a l'infini, chacune la voyant repartir de zero.
+ */
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+/**
+ * Partage par le symbole global, comme `kotbo.guildContext` : deux copies du
+ * paquet chargees par des chemins differents doivent lire le meme magasin,
+ * sinon la profondeur repart a zero d'un module a l'autre.
+ */
+const key = Symbol.for('kotbo.eventCascade');
+
+const globalScope = globalThis as any;
+if (!globalScope[key]) globalScope[key] = new AsyncLocalStorage<number>();
+
+const cascadeStorage: AsyncLocalStorage<number> = globalScope[key];
+
+/** Nombre d'automatisations deja enchainees pour en arriver a l'evenement courant. */
+export function currentCascadeDepth(): number {
+  const depth = cascadeStorage.getStore();
+  return typeof depth === 'number' && Number.isFinite(depth) && depth > 0 ? depth : 0;
+}
+
+/** Execute `fn` en annoncant la profondeur atteinte a tout ce qu'il publiera. */
+export function runWithCascadeDepth<T>(depth: number, fn: () => T): T {
+  return cascadeStorage.run(Math.max(0, Math.trunc(depth)), fn);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export { kotboEventBus } from './eventBus.js';
 export type { KotboEventHandler } from './eventBus.js';
+export { currentCascadeDepth, runWithCascadeDepth } from './eventCascade.js';
 export type {
   KotboEventMap,
   KotboEventName,

--- a/packages/shared/src/workflow/cron.ts
+++ b/packages/shared/src/workflow/cron.ts
@@ -5,6 +5,11 @@
  * balayage passe chaque minute et demande à chaque workflow planifié si son
  * motif tombe maintenant. C'est ce que répond `cronMatches`.
  *
+ * Le motif est toujours confronté à l'heure murale d'un fuseau explicite, et
+ * jamais à celle du process : le bot tourne en UTC, donc « tous les jours à
+ * 9h00 » serait parti à 11h à Paris en été et à 10h en hiver, alors que le
+ * reste du produit affiche et lit les dates dans le fuseau du serveur.
+ *
  * La grammaire couverte est celle que produit l'éditeur - `*`, une valeur, une
  * liste, un intervalle, un pas - et rien de plus. Les extensions non standard
  * (`@daily`, `L`, `#`) sont refusées plutôt que mal interprétées : un motif
@@ -24,9 +29,11 @@ const FIELD_RANGES: [min: number, max: number][] = [
 /**
  * Valeurs autorisées par un champ, ou `null` si le champ est invalide.
  *
- * `*` est distingué d'une énumération complète : la règle du jour de la
- * semaine en dépend, `* * * * 1` et `* * * 1-31 1` ne se comportant pas
- * pareil dans un cron.
+ * `wildcard` dit que le champ porte une étoile, pas qu'il accepte toutes les
+ * valeurs : une étoile suivie d'un pas n'en accepte qu'une sur deux. C'est bien
+ * la présence de l'étoile que regarde la règle jour du mois / jour de la
+ * semaine, et une énumération complète ne s'y substitue pas - `* * * * 1` et
+ * `* * 1-31 * 1` ne se comportent pas pareil dans un cron.
  */
 function parseField(raw: string, min: number, max: number): { values: Set<number>; wildcard: boolean } | null {
   const field = raw.trim();
@@ -52,7 +59,10 @@ function parseField(raw: string, min: number, max: number): { values: Set<number
     if (spec === '*') {
       from = min;
       to = max;
-      if (stepRaw === undefined) wildcard = true;
+      // `*/2` compte aussi comme une étoile, comme dans le cron système : c'est
+      // la présence de l'étoile, et non l'absence de pas, qui fait basculer la
+      // règle jour du mois / jour de la semaine.
+      wildcard = true;
     } else if (/^\d+$/.test(spec)) {
       from = Number(spec);
       // `5/2` n'a de sens qu'en partant de 5 et en allant jusqu'au bout.
@@ -77,6 +87,7 @@ export interface ParsedCron {
   daysOfMonth: Set<number>;
   months: Set<number>;
   daysOfWeek: Set<number>;
+  /** Le champ portait une étoile, pas forcément toutes les valeurs. */
   dayOfMonthWildcard: boolean;
   dayOfWeekWildcard: boolean;
 }
@@ -108,28 +119,122 @@ export function isValidCron(expression: string): boolean {
   return parseCron(expression) !== null;
 }
 
+/** Champs date et heure d'un instant, lus dans le fuseau demandé. */
+interface ZonedParts {
+  minute: number;
+  hour: number;
+  day: number;
+  month: number;
+  year: number;
+  /** 0 = dimanche, comme `Date.prototype.getDay`. */
+  weekday: number;
+}
+
+/** Découpe un instant en heure murale. */
+function zonedParts(date: Date, timezone: string): ZonedParts {
+  const parts = zonedFormatter(timezone).formatToParts(date);
+
+  const read = (type: Intl.DateTimeFormatPartTypes) =>
+    Number(parts.find((part) => part.type === type)?.value ?? '0');
+
+  const year = read('year');
+  const month = read('month');
+  const day = read('day');
+
+  return {
+    minute: read('minute'),
+    hour: read('hour'),
+    day,
+    month,
+    year,
+    // Le jour de la semaine est déduit de la date murale plutôt que demandé à
+    // `Intl` : pas de nom de jour à reconnaître, donc rien qui dépende de la
+    // locale du runtime.
+    weekday: new Date(Date.UTC(year, month - 1, day)).getUTCDay(),
+  };
+}
+
 /**
- * Le motif tombe-t-il sur cette minute ?
+ * Repère de la minute murale d'un instant : deux instants qui portent le même
+ * repère désignent la même heure au mur, dans ce fuseau.
+ *
+ * Sert à ne pas déclencher deux fois la nuit du retour à l'heure d'hiver, où
+ * l'horloge repasse par la même heure : « tous les jours à 02h30 » y tombe une
+ * fois à 00h30 UTC et une seconde à 01h30 UTC. Comparer les instants ne les
+ * distingue pas d'un jour à l'autre - il faut comparer ce que voit l'humain.
+ */
+export function wallClockMinuteKey(date: Date, timezone: string): string {
+  const { year, month, day, hour, minute } = zonedParts(date, timezone);
+  const pad = (value: number) => String(value).padStart(2, '0');
+  return `${year}-${pad(month)}-${pad(day)}T${pad(hour)}:${pad(minute)}`;
+}
+
+const formatterCache = new Map<string, Intl.DateTimeFormat>();
+
+/**
+ * `Intl.DateTimeFormat` coûte cher à construire, et le balayage passe chaque
+ * minute sur tous les workflows planifiés.
+ *
+ * Un identifiant que le runtime ne connaît pas retombe sur UTC plutôt que de
+ * lever : un fuseau devenu invalide doit décaler les déclenchements, pas
+ * éteindre toutes les planifications. Le repli est mémorisé sous la clé
+ * demandée, pour ne pas retenter la construction à chaque passage.
+ */
+function zonedFormatter(timezone: string): Intl.DateTimeFormat {
+  const cached = formatterCache.get(timezone);
+  if (cached) return cached;
+
+  // `hourCycle: 'h23'` : en `en-US`, minuit ressort « 24 » sans lui, ce qu'aucune
+  // heure de motif ne peut égaler.
+  const options: Intl.DateTimeFormatOptions = {
+    hourCycle: 'h23',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  };
+
+  let formatter: Intl.DateTimeFormat;
+  try {
+    formatter = new Intl.DateTimeFormat('en-US', { ...options, timeZone: timezone });
+  } catch {
+    formatter = new Intl.DateTimeFormat('en-US', { ...options, timeZone: 'UTC' });
+  }
+
+  formatterCache.set(timezone, formatter);
+  return formatter;
+}
+
+/**
+ * Le motif tombe-t-il sur cette minute, dans le fuseau donné ?
+ *
+ * `timezone` est explicite et sans valeur par défaut : c'est la seule façon
+ * d'empêcher un appelant de comparer par mégarde à l'heure du process, qui est
+ * UTC en conteneur.
  *
  * Quand le jour du mois et le jour de la semaine sont tous deux restreints,
  * la règle historique de cron veut qu'ils soient combinés par un OU et non
  * par un ET : `0 0 1 * 1` se lit « le 1er du mois, et aussi tous les lundis ».
- * S'en écarter ferait manquer des déclenchements attendus.
+ * S'en écarter ferait manquer des déclenchements attendus. Dès que l'un des
+ * deux porte une étoile, on revient au ET, comme le cron système.
  */
-export function cronMatches(expression: string, date: Date): boolean {
+export function cronMatches(expression: string, date: Date, timezone: string): boolean {
   const cron = parseCron(expression);
   if (!cron) return false;
 
-  if (!cron.minutes.has(date.getMinutes())) return false;
-  if (!cron.hours.has(date.getHours())) return false;
-  if (!cron.months.has(date.getMonth() + 1)) return false;
+  const now = zonedParts(date, timezone);
 
-  const dayOfMonthMatches = cron.daysOfMonth.has(date.getDate());
-  const dayOfWeekMatches = cron.daysOfWeek.has(date.getDay());
+  if (!cron.minutes.has(now.minute)) return false;
+  if (!cron.hours.has(now.hour)) return false;
+  if (!cron.months.has(now.month)) return false;
 
-  if (cron.dayOfMonthWildcard && cron.dayOfWeekWildcard) return true;
-  if (cron.dayOfMonthWildcard) return dayOfWeekMatches;
-  if (cron.dayOfWeekWildcard) return dayOfMonthMatches;
+  const dayOfMonthMatches = cron.daysOfMonth.has(now.day);
+  const dayOfWeekMatches = cron.daysOfWeek.has(now.weekday);
+
+  if (cron.dayOfMonthWildcard || cron.dayOfWeekWildcard) {
+    return dayOfMonthMatches && dayOfWeekMatches;
+  }
   return dayOfMonthMatches || dayOfWeekMatches;
 }
 


### PR DESCRIPTION
Corrections de bug, fix present dans le commit : 

fix(workflows)	cascades bornées, cron dans le fuseau du serveur, réservation de la minute, doublon à l'heure d'hiver
fix(dates)	une date inexistante est refusée au lieu d'être reportée
fix(clans)	retrait concurrent borné, pas de sacre pour un clan à zéro
fix(sticky)	envoi indexé par salon, repli sur la config persistée
fix(tickets) comptage RGPD honnête
fix(dashboard) rafraîchissement partagé au lieu d'empilé
fix(planning) fuseau de réunion cantonné à son formulaire
fix(salons) salon configuré visible dans le sélecteur
perf(dashboard) vitesses remises à zéro dans le graphe