### PR TITLE
fix(meetings): controle les dates a la source et rend les refus lisibles

### DIFF
--- a/apps/bot/src/api/routes/dashboard/leadership/meetings.ts
+++ b/apps/bot/src/api/routes/dashboard/leadership/meetings.ts
@@ -48,6 +48,7 @@ import {
   
   
   
+  MeetingValidationError,
 } from '../../../../services/staff/staffLeadershipService.js';
 
 export async function handleMeetingRoutes(
@@ -157,7 +158,7 @@ export async function handleMeetingRoutes(
 
           json(res, 201, { meeting });
         } catch (err: unknown) {
-          const isValidationError = err instanceof Error && err.message.includes('Configurez');
+          const isValidationError = err instanceof MeetingValidationError;
           if (isValidationError) {
             logger.warn('StaffAPI', `Error creating meeting: ${err.message}`);
           } else {

--- a/apps/bot/src/commands/admin/meeting.ts
+++ b/apps/bot/src/commands/admin/meeting.ts
@@ -6,7 +6,7 @@ import {
 } from 'discord.js';
 import { errorContainer, infoContainer, kotboContainer, successContainer } from '../../utils/embeds.js';
 import { E } from '../../utils/emojis.js';
-import { checkInMeeting, getMeetings, createMeeting, syncMeetingPresencesWithAbsences } from '../../services/staff/staffLeadershipService.js';
+import { checkInMeeting, getMeetings, createMeeting, syncMeetingPresencesWithAbsences, MeetingValidationError } from '../../services/staff/staffLeadershipService.js';
 import { getStaffMember } from '../../services/staff/staffManagementService.js';
 import { logger } from '../../utils/logger.js';
 import { separator, v2Message } from '@arcscord/components';
@@ -170,11 +170,13 @@ async function execute(interaction: ChatInputCommandInteraction) {
         successContainer('Réunion planifiée', `Réunion planifiée: **${title}** pour le <t:${Math.floor(scheduledAt.getTime()/1000)}:F>.\nL'événement Discord a été créé et l'annonce a été postée.`),
       ));
     } catch (err) {
-      if (err instanceof Error && err.message.includes('Configurez')) {
+      // Un refus previsible porte deja son explication : la jeter pour un
+      // « Erreur lors de la creation » laissait l'admin sans la moindre piste.
+      if (err instanceof MeetingValidationError) {
         logger.warn('MeetingCmd', `Error creating meeting: ${err.message}`);
         await interaction.reply(v2Message(
           { flags: MessageFlags.Ephemeral },
-          errorContainer('Erreur de configuration', err.message),
+          errorContainer('Création impossible', err.message),
         ));
       } else {
         logger.error('MeetingCmd', 'Error creating meeting:', err);

--- a/apps/bot/src/services/staff/staffLeadershipService.ts
+++ b/apps/bot/src/services/staff/staffLeadershipService.ts
@@ -456,6 +456,22 @@ export const getMeetings = async (guildId: string) => {
 /**
  * Crée une réunion staff avec synchronisation Discord (Événement + Annonce).
  */
+/**
+ * Refus previsible d'une creation de reunion : configuration incomplete, salon
+ * introuvable, date deja passee. Distinct d'une panne, pour que les appelants
+ * repondent 400 et montrent le message.
+ *
+ * Ils triaient jusqu'ici sur `message.includes('Configurez')` : les autres
+ * refus finissaient en erreur serveur, et la commande /meeting jetait meme
+ * leur message pour repondre « Erreur lors de la creation de la reunion ».
+ */
+export class MeetingValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MeetingValidationError';
+  }
+}
+
 export const createMeeting = async (
   client: Client,
   guildId: string,
@@ -473,6 +489,17 @@ export const createMeeting = async (
   timezone?: string | null,
 ) => {
   try {
+    // Discord refuse un événement planifié dans le passé, et une fin qui
+    // précède son début. Le contrôle vit ici parce que les trois portes
+    // d'entrée - dashboard, /meeting, MCP - passent toutes par cette fonction :
+    // ailleurs, il aurait fallu l'écrire trois fois et il en manquait deux.
+    if (scheduledAt.getTime() <= Date.now()) {
+      throw new MeetingValidationError('La réunion doit être planifiée dans le futur : Discord refuse un événement déjà passé.');
+    }
+    if (endedAt && endedAt.getTime() <= scheduledAt.getTime()) {
+      throw new MeetingValidationError('La fin de la réunion doit être postérieure à son début.');
+    }
+
     // 1. Récupération de la configuration Discord pour la guilde
     const guildConfig = await prisma.guild.findUnique({
       where: { id: guildId },
@@ -486,23 +513,23 @@ export const createMeeting = async (
     const voiceChannelId = guildConfig?.meetingVoiceChannelId;
 
     if (!announcementChannelId || !voiceChannelId) {
-      throw new Error('Configurez les salons de réunion (annonce + vocal/conférence) dans la configuration staff avant de créer une réunion.');
+      throw new MeetingValidationError('Configurez les salons de réunion (annonce + vocal/conférence) dans la configuration staff avant de créer une réunion.');
     }
 
     // 2. Récupération de la guilde et des salons Discord
     const discordGuild = client.guilds.cache.get(guildId) ?? await client.guilds.fetch(guildId).catch(() => null);
     if (!discordGuild) {
-      throw new Error("Impossible d'accéder au serveur Discord pour créer la réunion.");
+      throw new MeetingValidationError("Impossible d'accéder au serveur Discord pour créer la réunion.");
     }
 
     const announcementChannel = await client.channels.fetch(announcementChannelId).catch(() => null);
     if (!announcementChannel || (announcementChannel.type !== ChannelType.GuildText && announcementChannel.type !== ChannelType.GuildAnnouncement)) {
-      throw new Error("Le salon d'annonce configuré est introuvable ou n'est pas un salon texte/annonces.");
+      throw new MeetingValidationError("Le salon d'annonce configuré est introuvable ou n'est pas un salon texte/annonces.");
     }
 
     const voiceChannel = await client.channels.fetch(voiceChannelId).catch(() => null);
     if (!voiceChannel || (voiceChannel.type !== ChannelType.GuildVoice && voiceChannel.type !== ChannelType.GuildStageVoice)) {
-      throw new Error('Le salon vocal/conférence configuré est introuvable ou invalide.');
+      throw new MeetingValidationError('Le salon vocal/conférence configuré est introuvable ou invalide.');
     }
 
     // 3. Création de l'événement programmé Discord

--- a/apps/dashboard/src/pages/Planning.svelte
+++ b/apps/dashboard/src/pages/Planning.svelte
@@ -814,6 +814,13 @@
           saving = false;
           return;
         }
+        // Seul l'onglet Absence testait l'ordre des deux dates. La page
+        // Reunions le fait aussi, avec ce meme libelle et ce meme test.
+        if (selectedEndDate.getTime() <= selectedStartDate.getTime()) {
+          formError = m.meetings_err_end_before_start();
+          saving = false;
+          return;
+        }
         const ok = await createMeeting(formTitle, formDescription, selectedStartDate.toISOString(), selectedEndDate.toISOString(), formTimezone);
         if (!ok) throw new Error(m.planning_err_create_meeting());
       } else if (currentTab === 'absence') {


### PR DESCRIPTION
Trois portes menent a createMeeting : dashboard, /meeting, outil MCP - et aucune ne verifiait que la reunion tombe dans le futur. Le controle ajoute cote dashboard ne couvrait donc qu'un tiers des cas : il vit maintenant dans createMeeting, ou les trois convergent, avec celui de l'ordre des deux dates.

Les appelants triaient les refus sur message.includes('Configurez'). Les trois autres refus previsibles de createMeeting - serveur Discord inaccessible, salon d'annonce introuvable, salon vocal invalide - repondaient donc 500, et la commande /meeting jetait carrement leur message pour afficher un « Erreur lors de la creation de la reunion » sans la moindre piste. Un type d'erreur dedie remplace la recherche de sous-chaine.

L'onglet Reunion du planning ne testait pas l'ordre des deux dates, la ou l'onglet Absence et la page Reunions le font. Il reprend le libelle et le test de cette derniere.