### PR TITLE
fix(clans): repare la recherche publique, cassee des la premiere frappe

### DIFF
--- a/apps/dashboard/src/lib/api/clans.ts
+++ b/apps/dashboard/src/lib/api/clans.ts
@@ -394,7 +394,14 @@ export interface PublicClanSearchResult {
   matchCounts: Record<string, number>;
 }
 
-const EMPTY_CLAN_SEARCH: PublicClanSearchResult = {
+/**
+ * Résultat vide de la recherche publique.
+ *
+ * Exporté pour que la page l'utilise à l'initialisation et à la remise à zéro :
+ * réécrire l'objet à la main laissait les listes ajoutées ensuite à `undefined`,
+ * et la page cassait sur la première lecture de leur `length`.
+ */
+export const EMPTY_CLAN_SEARCH: PublicClanSearchResult = {
   participants: [], scores: [], matchCounts: {}, bets: [], bettors: [], debts: [],
 };
 

--- a/apps/dashboard/src/pages/LevelingClanPublic.svelte
+++ b/apps/dashboard/src/pages/LevelingClanPublic.svelte
@@ -10,6 +10,7 @@
     type PublicClanDebts,
     type PublicClanSearchResult,
     type PublicDebtor,
+    EMPTY_CLAN_SEARCH,
   } from '../lib/api';
   import { m, dateLocale, getLocale, locales, type Locale } from '../lib/i18n';
   import { themeStore } from '../lib/stores/theme.svelte';
@@ -158,13 +159,13 @@
   // très bas au classement - et renvoie son historique de gains de la saison.
   const searchActive = $derived(searchQuery.trim().length >= 2);
   let searching = $state(false);
-  let searchResult = $state<PublicClanSearchResult>({ participants: [], scores: [], matchCounts: {} });
+  let searchResult = $state<PublicClanSearchResult>({ ...EMPTY_CLAN_SEARCH });
   let searchToken = 0;
 
   $effect(() => {
     const q = searchQuery.trim();
     if (q.length < 2) {
-      searchResult = { participants: [], scores: [], matchCounts: {} };
+      searchResult = { ...EMPTY_CLAN_SEARCH };
       searching = false;
       return;
     }


### PR DESCRIPTION
L'initialisation et la remise a zero de searchResult reecrivaient l'objet a la main, avec les trois seuls champs d'origine. Les listes ajoutees ensuite - paris, palmares, dettes - restaient donc a undefined, et la page cassait sur la premiere lecture de leur length : « can't access property length ».

Le vide de reference est desormais exporte par le module d'API et partage par les deux endroits, plutot que reecrit. Un champ ajoute au resultat ne peut plus manquer a l'initialisation.