### PR TITLE
feat(paris): distingue la dette ferme du credit engage dans les paris

### DIFF
--- a/apps/bot/src/api/mcp/tools/read-clan-bets.ts
+++ b/apps/bot/src/api/mcp/tools/read-clan-bets.ts
@@ -1,7 +1,8 @@
 /** Outils MCP - lecture des paris en points de clan (permission READ_COMMUNITY). */
 import prisma from '../../../utils/db.js';
 import { z } from 'zod';
-import { buildBettorStandings, engagedAmount } from '@kotbo/shared';
+import { buildBettorStandings, engagedAmount, firmDebtOf } from '@kotbo/shared';
+import { getEngagedBetCredit } from '../../../services/community/clanBetService.js';
 import { type McpToolContext, err, ok, resolveMember } from '../toolkit.js';
 
 const BET_STATUSES = ['PENDING', 'ACTIVE', 'RESOLVED', 'REFUNDED', 'DECLINED', 'CANCELLED', 'EXPIRED'] as const;
@@ -183,7 +184,9 @@ export function registerReadClanBetsTools(ctx: McpToolContext) {
     {
       description:
         'Dettes de points de clan ouvertes sur le serveur. Une dette naît quand un membre mise des points '
-        + "qu'il n'a pas, et se rembourse automatiquement sur ses gains suivants.",
+        + "qu'il n'a pas, et se rembourse automatiquement sur ses gains suivants. `engaged` est la part encore "
+        + 'engagée dans des paris non tranchés, effacée si le pari est annulé ou si la saison se termine ; '
+        + '`firm` est ce qui reste dû quoi qu\'il arrive.',
       inputSchema: {
         member: z.string().optional().describe("Ne regarder que ce membre ; sinon, toutes les dettes ouvertes"),
         limit: z.number().int().min(1).max(100).optional().describe('Nombre maximum de lignes (défaut 25)'),
@@ -204,15 +207,24 @@ export function registerReadClanBetsTools(ctx: McpToolContext) {
         take: limit ?? 25,
       });
 
-      return ok({
-        count: debts.length,
-        totalOwed: debts.reduce((sum, row) => sum + row.amount, 0),
-        debts: debts.map((row) => ({
+      const engagedByUser = await getEngagedBetCredit(guildId, debts.map((row) => row.userId));
+      const rows = debts.map((row) => {
+        const engaged = Math.min(row.amount, engagedByUser.get(row.userId) ?? 0);
+        return {
           userId: row.userId,
           amount: row.amount,
+          engaged,
+          firm: firmDebtOf(row.amount, engaged),
           source: row.source,
           since: row.createdAt.toISOString(),
-        })),
+        };
+      });
+
+      return ok({
+        count: rows.length,
+        totalOwed: rows.reduce((sum, row) => sum + row.amount, 0),
+        totalEngaged: rows.reduce((sum, row) => sum + row.engaged, 0),
+        debts: rows,
       });
     })
   );

--- a/apps/bot/src/api/mcp/tools/write-clan-bets.ts
+++ b/apps/bot/src/api/mcp/tools/write-clan-bets.ts
@@ -4,10 +4,12 @@ import prisma from '../../../utils/db.js';
 import {
   betPotOf,
   describeBetSides,
+  getEngagedBetCredit,
   loadFullBet,
   settleBetBySide,
   voidBetById,
 } from '../../../services/community/clanBetService.js';
+import { firmDebtOf } from '@kotbo/shared';
 import { cancelClanPointDebt } from '../../../services/community/clanDebtService.js';
 import { type McpToolContext, err, ok, resolveMember } from '../toolkit.js';
 
@@ -111,10 +113,12 @@ export function registerWriteClanBetsTools(ctx: McpToolContext) {
     {
       description:
         "Efface tout ou partie de la dette de points de clan d'un membre, sans contrepartie. "
-        + 'Geste de correction : la dette disparaît sans que personne ne la rembourse.',
+        + 'Geste de correction : la dette disparaît sans que personne ne la rembourse. '
+        + "Par défaut, seule la part ferme part : le crédit engagé dans des paris non tranchés reste dû "
+        + "tant que le verdict n'est pas rendu.",
       inputSchema: {
         member: z.string().describe('Nom, surnom, @mention ou ID Discord du membre'),
-        amount: z.number().int().min(1).optional().describe('Montant à effacer ; par défaut, toute la dette'),
+        amount: z.number().int().min(1).optional().describe('Montant à effacer ; par défaut, la dette ferme, paris en cours exclus'),
         key_name: z.string().optional().describe("Nom de la clé MCP (pour l'audit)"),
       },
       _meta: toolMeta,
@@ -129,7 +133,16 @@ export function registerWriteClanBetsTools(ctx: McpToolContext) {
       });
       if (!debt || debt.amount <= 0) return err("Ce membre n'a aucune dette de points de clan.");
 
-      const remaining = await cancelClanPointDebt(guildId, resolved.userId, amount ?? debt.amount);
+      const engaged = Math.min(debt.amount, (await getEngagedBetCredit(guildId, [resolved.userId])).get(resolved.userId) ?? 0);
+      const firm = firmDebtOf(debt.amount, engaged);
+      if (amount === undefined && firm <= 0) {
+        return err(
+          `Toute la dette de ce membre (${debt.amount}) est engagée dans des paris en cours. `
+          + 'Précise un montant pour l\'effacer quand même.',
+        );
+      }
+
+      const remaining = await cancelClanPointDebt(guildId, resolved.userId, amount ?? firm);
       const cleared = debt.amount - remaining;
 
       await audit(
@@ -139,7 +152,7 @@ export function registerWriteClanBetsTools(ctx: McpToolContext) {
         `${cleared} point(s) de dette effacé(s), reste ${remaining}.`,
       );
 
-      return ok({ ok: true, userId: resolved.userId, cleared, remaining });
+      return ok({ ok: true, userId: resolved.userId, cleared, remaining, engaged });
     })
   );
 }

--- a/apps/bot/src/api/routes/dashboard/clans.ts
+++ b/apps/bot/src/api/routes/dashboard/clans.ts
@@ -17,6 +17,7 @@ import {
   BET_SIDES_MIN,
   BET_SEASON_REWARD_CEILING,
   BET_STAKE_MODES,
+  firmDebtOf,
   MAX_CLAN_POINTS_PER_LEVEL_UP,
   MIN_CLAN_REFERENCE_LEVEL,
   normalizeClanBetSettings,
@@ -957,10 +958,12 @@ export async function handleClansRoutes(
           take: 50,
           include: { sides: { orderBy: { position: 'asc' }, include: { participants: { orderBy: { joinedAt: 'asc' } } } } },
         }),
+        // Plus large que les 50 lignes affichées : le classement se fait sur la
+        // dette ferme, qui ne suit pas l'ordre des montants bruts.
         prisma.clanPointDebt.findMany({
           where: { guildId, amount: { gt: 0 } },
           orderBy: { amount: 'desc' },
-          take: 50,
+          take: 200,
         }),
         prisma.clanBet.count({ where: { guildId } }),
         prisma.clanPointDebt.count({ where: { guildId, amount: { gt: 0 } } }),
@@ -981,6 +984,27 @@ export async function handleClansRoutes(
       const discordGuild = client.guilds.cache.get(guildId) || await client.guilds.fetch(guildId).catch(() => null);
       const nameFor = (userId: string) =>
         discordGuild?.members.cache.get(userId)?.displayName ?? null;
+
+      // Une dette se lit en deux morceaux : ce qui est ferme, et ce qui n'est
+      // encore qu'engagé dans des paris non tranchés. Le tri porte sur le
+      // ferme, seul montant qui ne peut plus disparaître tout seul.
+      const { getEngagedBetCredit } = await import('../../../services/community/clanBetService.js');
+      const engagedByUser = await getEngagedBetCredit(guildId, debts.map((debt) => debt.userId));
+      const debtRows = debts
+        .map((debt) => {
+          const engaged = Math.min(debt.amount, engagedByUser.get(debt.userId) ?? 0);
+          return {
+            userId: debt.userId,
+            displayName: nameFor(debt.userId),
+            amount: debt.amount,
+            engaged,
+            firm: firmDebtOf(debt.amount, engaged),
+            source: debt.source,
+            createdAt: debt.createdAt,
+          };
+        })
+        .sort((a, b) => b.firm - a.firm || b.amount - a.amount)
+        .slice(0, 50);
 
       json(res, 200, {
         betCount,
@@ -1021,13 +1045,7 @@ export async function handleClansRoutes(
             createdAt: bet.createdAt,
           };
         }),
-        debts: debts.map((debt) => ({
-          userId: debt.userId,
-          displayName: nameFor(debt.userId),
-          amount: debt.amount,
-          source: debt.source,
-          createdAt: debt.createdAt,
-        })),
+        debts: debtRows,
       });
     } catch (err) {
       logger.error('ClansAPI', 'Error fetching bets:', err);
@@ -1036,25 +1054,57 @@ export async function handleClansRoutes(
     return true;
   }
 
-  // DELETE /api/dashboard/guilds/:guildId/clans/bets/debts/:userId
+  // DELETE /api/dashboard/guilds/:guildId/clans/bets/debts/:userId[?engaged=1]
   //
   // Efface une dette à la main. Utile après un incident : sans ce geste, un
   // membre endetté par erreur voit tous ses gains partir en remboursement.
+  //
+  // Seule la part ferme part par défaut : le crédit encore engagé dans des
+  // paris non tranchés a été misé en connaissance de cause, et l'effacer
+  // rendrait gratuits des paris toujours en jeu. `engaged=1` l'emporte quand
+  // même, pour les incidents où le pari lui-même est en cause.
   if (subAction === 'bets' && parts[6] === 'debts' && parts[7] && method === 'DELETE') {
     const userId = parts[7];
+    const includeEngaged = new URL(req.url ?? '', 'http://localhost').searchParams.get('engaged') === '1';
     try {
-      await prisma.clanPointDebt.deleteMany({ where: { guildId, userId } });
+      const existing = await prisma.clanPointDebt.findUnique({
+        where: { guildId_userId: { guildId, userId } },
+        select: { amount: true },
+      });
+      if (!existing) {
+        json(res, 200, { success: true, remaining: 0, cleared: 0 });
+        return true;
+      }
+
+      let engaged = 0;
+      if (!includeEngaged) {
+        const { getEngagedBetCredit } = await import('../../../services/community/clanBetService.js');
+        engaged = Math.min(existing.amount, (await getEngagedBetCredit(guildId, [userId])).get(userId) ?? 0);
+      }
+
+      if (engaged > 0) {
+        await prisma.clanPointDebt.update({
+          where: { guildId_userId: { guildId, userId } },
+          data: { amount: engaged },
+        });
+      } else {
+        await prisma.clanPointDebt.deleteMany({ where: { guildId, userId } });
+      }
+
+      const cleared = existing.amount - engaged;
       await pushAudit(guildId, {
         user: auditUser,
         action: 'Effacement d\'une dette de points de clan',
         context: getGuildName(client, guildId),
         module: 'Clans',
         eventType: 'Manuel',
-        details: `Dette effacée pour ${userId}.`,
+        details: engaged > 0
+          ? `${cleared} point(s) de dette effacé(s) pour ${userId} ; ${engaged} laissé(s) en jeu sur des paris en cours.`
+          : `Dette de ${cleared} point(s) effacée pour ${userId}${includeEngaged ? ', crédit des paris en cours compris' : ''}.`,
         channelId: null,
       });
       broadcastDashboardStateChange(guildId, 'clans_updated');
-      json(res, 200, { success: true });
+      json(res, 200, { success: true, remaining: engaged, cleared });
     } catch (err) {
       logger.error('ClansAPI', 'Error clearing clan point debt:', err);
       json(res, 500, { error: 'Erreur lors de l\'effacement de la dette.' });

--- a/apps/bot/src/api/routes/public.ts
+++ b/apps/bot/src/api/routes/public.ts
@@ -3,7 +3,8 @@ import { promisify } from 'node:util';
 import { gzip } from 'node:zlib';
 import { Client } from 'discord.js';
 import { LinkedAccountStatus, Prisma } from '@prisma/client';
-import { buildBettorStandings, normalizeLevelCurve } from '@kotbo/shared';
+import { buildBettorStandings, firmDebtOf, normalizeLevelCurve } from '@kotbo/shared';
+import { getEngagedBetCredit, getEngagedBetCreditTotal } from '../../services/community/clanBetService.js';
 import { buildLinkedAccountFolder } from '../../services/moderation/altAccountService.js';
 import prisma from '../../utils/db.js';
 import { logger } from '../../utils/logger.js';
@@ -1361,23 +1362,32 @@ export async function handlePublicRoutes(
               for (const profile of debtorProfiles) profileMap.set(profile.userId, profile);
             }
 
+            // Une dette se lit en deux morceaux : la part ferme, et le crédit
+            // encore engagé dans des paris non tranchés, qui s'efface si le pari
+            // est annulé ou si la saison se termine. Le classement porte sur le
+            // ferme, seul montant qui ne peut plus disparaître tout seul.
+            const engagedByUser = await getEngagedBetCredit(guildId, debtRows.map((row) => row.userId));
+
             const debtors = debtRows.map((row) => {
               const clan = clanByUserId.get(row.userId) ?? null;
               const role = clan ? discordGuild?.roles.cache.get(clan.roleId) : null;
               const profile = profileMap.get(row.userId);
               const discordMember = discordGuild?.members.cache.get(row.userId);
+              const engaged = Math.min(row.amount, engagedByUser.get(row.userId) ?? 0);
 
               return {
                 userId: row.userId,
                 displayName: discordMember?.displayName || profile?.displayName || profile?.globalName || `Utilisateur ${row.userId}`,
                 avatarUrl: resolveMemberAvatarUrl(discordMember, 128) || profile?.avatarUrl || null,
                 amount: row.amount,
+                engaged,
+                firm: firmDebtOf(row.amount, engaged),
                 clanId: clan?.id ?? null,
                 clanName: clan?.name ?? null,
                 clanColor: role?.color ? `#${role.color.toString(16).padStart(6, '0')}` : null,
                 since: row.createdAt.toISOString(),
               };
-            });
+            }).sort((a, b) => b.firm - a.firm || b.amount - a.amount);
 
             const byClan = clans.map((clan) => {
               const members = debtors.filter((debtor) => debtor.clanId === clan.id);
@@ -1387,6 +1397,7 @@ export async function handlePublicRoutes(
                 name: clan.name,
                 roleColor: role?.color ? `#${role.color.toString(16).padStart(6, '0')}` : null,
                 totalDebt: members.reduce((sum, debtor) => sum + debtor.amount, 0),
+                totalEngaged: members.reduce((sum, debtor) => sum + debtor.engaged, 0),
                 debtorCount: members.length,
                 debtors: members.slice(0, 10),
               };
@@ -1404,6 +1415,9 @@ export async function handlePublicRoutes(
 
             debtsPayload = {
               total: overall._sum.amount ?? 0,
+              // Compté sur toute la table plutôt que sur les 200 lignes lues,
+              // pour la même raison que le total.
+              totalEngaged: Math.min(overall._sum.amount ?? 0, await getEngagedBetCreditTotal(guildId)),
               debtorCount: overall._count._all,
               // Membres sans clan : leur dette existe mais n'est rattachée à
               // aucune colonne, elle serait invisible sans cette liste.
@@ -1412,7 +1426,7 @@ export async function handlePublicRoutes(
               clans: byClan,
             };
           } else {
-            debtsPayload = { total: 0, debtorCount: 0, unaffiliated: [], top: [], clans: [] };
+            debtsPayload = { total: 0, totalEngaged: 0, debtorCount: 0, unaffiliated: [], top: [], clans: [] };
           }
         } catch (debtErr: unknown) {
           const message = debtErr instanceof Error ? debtErr.message : String(debtErr);
@@ -1776,13 +1790,17 @@ export async function handlePublicRoutes(
               .map((standing) => ({ ...standing, ...betNameOf(standing.userId) }));
           }
 
+          const engagedBySearchedUser = await getEngagedBetCredit(guildId, debtRows.map((row) => row.userId));
           debts = debtRows.map((row) => {
             const discordMember = discordGuild?.members.cache.get(row.userId);
             const clan = discordMember ? clans.find((c) => discordMember.roles.cache.has(c.roleId)) : undefined;
+            const engaged = Math.min(row.amount, engagedBySearchedUser.get(row.userId) ?? 0);
             return {
               userId: row.userId,
               ...betNameOf(row.userId),
               amount: row.amount,
+              engaged,
+              firm: firmDebtOf(row.amount, engaged),
               clanId: clan?.id ?? null,
               clanName: clan?.name ?? null,
               clanColor: clanColor(clan),

--- a/apps/bot/src/services/community/clanBetService.ts
+++ b/apps/bot/src/services/community/clanBetService.ts
@@ -2126,6 +2126,46 @@ async function refundBet(bet: FullBet, resolvedById: string | null, status: BetS
   return (await loadBet(bet.id)) ?? bet;
 }
 
+/**
+ * Crédit encore engagé dans des paris non tranchés, par membre.
+ *
+ * Cette part de la dette n'est pas perdue : elle s'efface si le pari est
+ * annulé, expire, ou tombe à la clôture d'une saison. La séparer du reste
+ * évite de lire comme une somme due un total qui va fondre de lui-même.
+ *
+ * La clé est `userKey`, comme la dette elle-même : un membre à comptes liés
+ * n'en a qu'une.
+ */
+export async function getEngagedBetCredit(guildId: string, userKeys?: string[]): Promise<Map<string, number>> {
+  if (userKeys && userKeys.length === 0) return new Map();
+
+  const rows = await prisma.clanBetParticipant.groupBy({
+    by: ['userKey'],
+    where: {
+      status: 'JOINED',
+      debt: { gt: 0 },
+      ...(userKeys ? { userKey: { in: userKeys } } : {}),
+      bet: { guildId, status: { in: OPEN_STATUSES } },
+    },
+    _sum: { debt: true },
+  });
+
+  return new Map(rows.map((row) => [row.userKey, row._sum.debt ?? 0]));
+}
+
+/** Total du crédit engagé sur un serveur, sans passer par la liste des membres. */
+export async function getEngagedBetCreditTotal(guildId: string): Promise<number> {
+  const aggregate = await prisma.clanBetParticipant.aggregate({
+    where: {
+      status: 'JOINED',
+      debt: { gt: 0 },
+      bet: { guildId, status: { in: OPEN_STATUSES } },
+    },
+    _sum: { debt: true },
+  });
+  return aggregate._sum.debt ?? 0;
+}
+
 // ─── Balayage ────────────────────────────────────────────────────────────────
 
 /**

--- a/apps/bot/src/tests/unit/clanBets.test.ts
+++ b/apps/bot/src/tests/unit/clanBets.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, test } from 'bun:test';
 import {
   applyDebtRepayment,
   checkStake,
+  firmDebtOf,
   normalizeClanBetSettings,
   planStakeFunding,
   BET_DEBT_CEILING,
@@ -121,6 +122,18 @@ describe('remboursement de la dette', () => {
 
   test('le plafond de dette reste sous l\'entier 32 bits de Postgres', () => {
     expect(BET_DEBT_CEILING).toBeLessThan(2_147_483_647);
+  });
+
+  test('la part engagée dans des paris en cours sort de la dette ferme', () => {
+    expect(firmDebtOf(526, 150)).toBe(376);
+  });
+
+  test('une dette entièrement engagée n\'a rien de ferme', () => {
+    expect(firmDebtOf(300, 300)).toBe(0);
+  });
+
+  test('un engagement plus grand que la dette ne la rend pas négative', () => {
+    expect(firmDebtOf(100, 250)).toBe(0);
   });
 });
 

--- a/apps/dashboard/messages/en.json
+++ b/apps/dashboard/messages/en.json
@@ -8932,6 +8932,12 @@
   "clan_bets_debt_list_label": "Open debts",
   "clan_bets_debt_clear": "Clear",
   "clan_bets_debt_empty": "No open debt.",
+  "clan_bets_debt_engaged_hint": "including {amount} on running bets",
+  "clan_bets_debt_clear_title": "Clear this member's debt?",
+  "clan_bets_debt_clear_desc": "The firm share disappears with nothing in return: nobody pays it back.",
+  "clan_bets_debt_clear_engaged_note": "{amount} point(s) are still staked on running bets. Without the box below, that share stays owed until the bet is settled.",
+  "clan_bets_debt_clear_include_engaged": "also clear the debt from their running bets",
+  "clan_bets_debt_cleared_partial": "Firm debt cleared. {amount} point(s) remain staked on running bets.",
   "clan_bets_history_heading": "Latest bets",
   "clan_bets_history_empty": "No bets yet.",
   "clan_bets_list_truncated": "{shown} of {total} shown.",
@@ -9058,5 +9064,7 @@
   "clan_public_search_no_match": "No result for this search.",
   "clan_public_debt_average_label": "Average debt",
   "clan_public_debt_search_scope": "Across search results only.",
+  "clan_public_debt_engaged_hint": "including {amount} on running bets",
+  "clan_public_debt_engaged_desc": "Share of the debt staked on unsettled bets: it vanishes if the bet falls through or when the season ends.",
   "clan_public_debt_average_hint": "What an indebted member owes on average, taken from their next clan-point gains."
 }

--- a/apps/dashboard/messages/fr.json
+++ b/apps/dashboard/messages/fr.json
@@ -8932,6 +8932,12 @@
   "clan_bets_debt_list_label": "Dettes en cours",
   "clan_bets_debt_clear": "Effacer",
   "clan_bets_debt_empty": "Aucune dette en cours.",
+  "clan_bets_debt_engaged_hint": "dont {amount} en paris en cours",
+  "clan_bets_debt_clear_title": "Effacer la dette de ce membre ?",
+  "clan_bets_debt_clear_desc": "La part ferme disparaît sans contrepartie : personne ne la rembourse.",
+  "clan_bets_debt_clear_engaged_note": "{amount} point(s) sont encore engagés dans des paris en cours. Sans la case ci-dessous, cette part reste due jusqu'au verdict.",
+  "clan_bets_debt_clear_include_engaged": "effacer aussi la dette de ses paris en cours",
+  "clan_bets_debt_cleared_partial": "Dette ferme effacée. {amount} point(s) restent engagés sur des paris en cours.",
   "clan_bets_history_heading": "Derniers paris",
   "clan_bets_history_empty": "Aucun pari pour le moment.",
   "clan_bets_list_truncated": "{shown} affichés sur {total}.",
@@ -9058,5 +9064,7 @@
   "clan_public_search_no_match": "Aucun résultat pour cette recherche.",
   "clan_public_debt_average_label": "Dette moyenne",
   "clan_public_debt_search_scope": "Sur les résultats de la recherche uniquement.",
+  "clan_public_debt_engaged_hint": "dont {amount} en paris en cours",
+  "clan_public_debt_engaged_desc": "Part des dettes engagée dans des paris non tranchés : elle s'efface si le pari tombe ou à la fin de la saison.",
   "clan_public_debt_average_hint": "Ce que doit en moyenne un membre endetté, prélevé sur ses prochains gains de points de clan."
 }

--- a/apps/dashboard/src/lib/api/clans.ts
+++ b/apps/dashboard/src/lib/api/clans.ts
@@ -311,6 +311,10 @@ export interface ClanPointDebtEntry {
   userId: string;
   displayName: string | null;
   amount: number;
+  /** Part encore engagée dans des paris non tranchés, rendue si le pari tombe. */
+  engaged: number;
+  /** Ce qui reste dû quoi qu'il arrive : `amount` moins `engaged`. */
+  firm: number;
   source: string;
   createdAt: string;
 }
@@ -332,12 +336,19 @@ export async function fetchClanBets(
   });
 }
 
-/** Efface la dette de points de clan d'un membre. */
+/**
+ * Efface la dette de points de clan d'un membre.
+ *
+ * Seule la part ferme part par défaut : le crédit engagé dans des paris en
+ * cours a été misé en connaissance de cause, et l'effacer rendrait gratuits des
+ * paris toujours en jeu.
+ */
 export async function clearClanPointDebt(
   userId: string,
+  includeEngaged = false,
   guildId = authStore.selectedGuildId,
 ): Promise<boolean> {
-  return dashboardMutation(`/clans/bets/debts/${userId}`, {
+  return dashboardMutation(`/clans/bets/debts/${userId}${includeEngaged ? '?engaged=1' : ''}`, {
     method: 'DELETE',
     guildId,
     errorContext: 'API Error (Clear Clan Debt):',
@@ -376,6 +387,10 @@ export interface PublicDebtor {
   displayName: string;
   avatarUrl: string | null;
   amount: number;
+  /** Part encore engagée dans des paris non tranchés. */
+  engaged: number;
+  /** Ce qui reste dû quoi qu'il arrive. */
+  firm: number;
   clanId: string | null;
   clanName: string | null;
   clanColor: string | null;
@@ -384,6 +399,7 @@ export interface PublicDebtor {
 
 export interface PublicClanDebts {
   total: number;
+  totalEngaged: number;
   debtorCount: number;
   unaffiliated: PublicDebtor[];
   top: PublicDebtor[];
@@ -392,6 +408,7 @@ export interface PublicClanDebts {
     name: string;
     roleColor: string | null;
     totalDebt: number;
+    totalEngaged: number;
     debtorCount: number;
     debtors: PublicDebtor[];
   }>;

--- a/apps/dashboard/src/pages/Clans.svelte
+++ b/apps/dashboard/src/pages/Clans.svelte
@@ -306,14 +306,33 @@
     }
   });
 
-  async function handleClearDebt(userId: string) {
+  // Effacement d'une dette : la part ferme part toujours, le crédit engagé dans
+  // des paris en cours seulement si on le demande. Un pari toujours en jeu a été
+  // misé en connaissance de cause, l'effacer le rendrait gratuit.
+  let debtToClear = $state<ClanPointDebtEntry | null>(null);
+  let clearEngagedDebt = $state(false);
+
+  function openDebtClear(debt: ClanPointDebtEntry) {
     if (!canManageSettings) return;
+    debtToClear = debt;
+    clearEngagedDebt = false;
+  }
+
+  async function handleClearDebt() {
+    if (!canManageSettings || !debtToClear) return;
+    const target = debtToClear;
+    const includeEngaged = clearEngagedDebt;
+    debtToClear = null;
     await betsAction.run(async () => {
-      const ok = await clearClanPointDebt(userId);
+      const ok = await clearClanPointDebt(target.userId, includeEngaged);
       if (!ok) return false;
       await refreshBets();
       return true;
-    }, { successMessage: m.clan_bets_debt_cleared() });
+    }, {
+      successMessage: !includeEngaged && target.engaged > 0
+        ? m.clan_bets_debt_cleared_partial({ amount: target.engaged.toLocaleString(dateLocale()) })
+        : m.clan_bets_debt_cleared(),
+    });
   }
 
   // Confirmation state for reset/clear/distribute/reset-all/rollback
@@ -2032,12 +2051,19 @@ savedBetSettings = {
                 <div class="flex items-center justify-between gap-4 bg-surface-container-high/30 rounded-lg px-4 py-2.5">
                   <span class="text-sm text-on-surface truncate">{debt.displayName ?? debt.userId}</span>
                   <div class="flex items-center gap-3 shrink-0">
-                    <span class="text-sm font-bold text-amber-600">{debt.amount.toLocaleString(dateLocale())} pts</span>
+                    <span class="text-sm font-bold text-amber-600 text-right">
+                      {debt.amount.toLocaleString(dateLocale())} pts
+                      {#if debt.engaged > 0}
+                        <span class="block text-[10px] font-medium text-on-surface-variant/60">
+                          {m.clan_bets_debt_engaged_hint({ amount: debt.engaged.toLocaleString(dateLocale()) })}
+                        </span>
+                      {/if}
+                    </span>
                     <button
                       type="button"
                       class="text-xs font-semibold text-rose-500 hover:underline cursor-pointer disabled:opacity-40"
                       disabled={!canManageSettings}
-                      onclick={() => handleClearDebt(debt.userId)}
+                      onclick={() => openDebtClear(debt)}
                     >
                       {m.clan_bets_debt_clear()}
                     </button>
@@ -2262,6 +2288,54 @@ savedBetSettings = {
           </button>
         </div>
       </form>
+    </div>
+  </div>
+{/if}
+
+<!-- Modal: Effacement d'une dette -->
+{#if debtToClear}
+  {@const target = debtToClear}
+  <div class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4" transition:fade={{ duration: 150 }}>
+    <div class="bg-surface-container-low border border-outline-variant/20 max-w-md w-full rounded-xl p-6 space-y-6 shadow-lg" transition:scale={{ start: 0.97, duration: 150 }}>
+      <div>
+        <h3 class="text-lg font-semibold text-on-surface">
+          {m.clan_bets_debt_clear_title()}
+        </h3>
+        <p class="text-sm font-bold text-amber-600 mt-2">
+          {target.displayName ?? target.userId} · {target.amount.toLocaleString(dateLocale())} pts
+        </p>
+        <p class="text-xs text-on-surface-variant/80 mt-2">{m.clan_bets_debt_clear_desc()}</p>
+      </div>
+
+      {#if target.engaged > 0}
+        <div class="space-y-3 bg-surface-container-high/40 rounded-lg p-4">
+          <p class="text-xs text-on-surface-variant/80">
+            {m.clan_bets_debt_clear_engaged_note({ amount: target.engaged.toLocaleString(dateLocale()) })}
+          </p>
+          <label class="flex items-center gap-3 text-sm text-on-surface cursor-pointer">
+            <input type="checkbox" bind:checked={clearEngagedDebt} class="w-4 h-4 accent-rose-500 cursor-pointer" />
+            {m.clan_bets_debt_clear_include_engaged()}
+          </label>
+        </div>
+      {/if}
+
+      <div class="flex justify-end gap-2">
+        <button
+          type="button"
+          onclick={() => debtToClear = null}
+          class="px-4 py-2 border border-outline-variant/30 hover:bg-surface-container-high/60 text-on-surface text-xs font-semibold rounded-lg transition-colors cursor-pointer"
+        >
+          {m.clan_cancel_btn()}
+        </button>
+        <button
+          type="button"
+          onclick={handleClearDebt}
+          disabled={target.firm <= 0 && !clearEngagedDebt}
+          class="px-4 py-2 bg-rose-500 text-white text-xs font-semibold rounded-lg hover:bg-rose-600 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          {m.clan_bets_debt_clear()}
+        </button>
+      </div>
     </div>
   </div>
 {/if}

--- a/apps/dashboard/src/pages/LevelingClanPublic.svelte
+++ b/apps/dashboard/src/pages/LevelingClanPublic.svelte
@@ -239,7 +239,7 @@
     if (!debts) return [];
     if (!searchActive) return debts.clans;
 
-    const byClan = new Map<string, { id: string; name: string; roleColor: string | null; totalDebt: number; debtorCount: number; debtors: PublicDebtor[] }>();
+    const byClan = new Map<string, { id: string; name: string; roleColor: string | null; totalDebt: number; totalEngaged: number; debtorCount: number; debtors: PublicDebtor[] }>();
     for (const debtor of searchResult.debts) {
       if (!debtor.clanId) continue;
       const existing = byClan.get(debtor.clanId) ?? {
@@ -247,10 +247,12 @@
         name: debtor.clanName ?? debtor.clanId,
         roleColor: debtor.clanColor,
         totalDebt: 0,
+        totalEngaged: 0,
         debtorCount: 0,
         debtors: [],
       };
       existing.totalDebt += debtor.amount;
+      existing.totalEngaged += debtor.engaged;
       existing.debtorCount += 1;
       existing.debtors.push(debtor);
       byClan.set(debtor.clanId, existing);
@@ -272,12 +274,13 @@
    * a l'ecran ne justifie, et la moyenne porterait sur une population invisible.
    */
   const debtTotals = $derived.by(() => {
-    if (!debts) return { owed: 0, count: 0, partial: false };
-    if (!searchActive) return { owed: debts.total, count: debts.debtorCount, partial: false };
+    if (!debts) return { owed: 0, engaged: 0, count: 0, partial: false };
+    if (!searchActive) return { owed: debts.total, engaged: debts.totalEngaged, count: debts.debtorCount, partial: false };
 
     const found = [...displayedDebtClans.flatMap((clan) => clan.debtors), ...displayedUnaffiliated];
     return {
       owed: found.reduce((sum, debtor) => sum + debtor.amount, 0),
+      engaged: found.reduce((sum, debtor) => sum + debtor.engaged, 0),
       count: found.length,
       partial: true,
     };
@@ -797,6 +800,11 @@
           <div class="clean-card bg-white dark:bg-[#111a2e] border border-slate-200 dark:border-slate-800 rounded-2xl p-5">
             <p class="text-[10px] font-bold text-slate-400 uppercase tracking-widest">{m.clan_public_debt_total_label()}</p>
             <p class="text-2xl font-black text-rose-500 tracking-tight mt-1">{debtTotals.owed.toLocaleString(dateLocale())}</p>
+            {#if debtTotals.engaged > 0}
+              <p class="text-[10px] text-slate-400 dark:text-slate-500 mt-1 leading-snug" title={m.clan_public_debt_engaged_desc()}>
+                {m.clan_public_debt_engaged_hint({ amount: debtTotals.engaged.toLocaleString(dateLocale()) })}
+              </p>
+            {/if}
           </div>
           <div class="clean-card bg-white dark:bg-[#111a2e] border border-slate-200 dark:border-slate-800 rounded-2xl p-5">
             <p class="text-[10px] font-bold text-slate-400 uppercase tracking-widest">{m.clan_public_debt_people_label()}</p>
@@ -844,8 +852,15 @@
 
                   <div class="flex items-center justify-between p-3.5 rounded-xl bg-slate-50/50 dark:bg-[#0c1322]/50 border border-slate-200/10">
                     <span class="text-[10px] font-bold text-slate-400 uppercase tracking-widest">{m.clan_public_debt_clan_total()}</span>
-                    <span class="text-lg font-black text-rose-500 tracking-tight">
-                      {clan.totalDebt.toLocaleString(dateLocale())}
+                    <span class="text-right">
+                      <span class="block text-lg font-black text-rose-500 tracking-tight">
+                        {clan.totalDebt.toLocaleString(dateLocale())}
+                      </span>
+                      {#if clan.totalEngaged > 0}
+                        <span class="block text-[10px] text-slate-400 dark:text-slate-500 leading-snug">
+                          {m.clan_public_debt_engaged_hint({ amount: clan.totalEngaged.toLocaleString(dateLocale()) })}
+                        </span>
+                      {/if}
                     </span>
                   </div>
                 </div>
@@ -874,8 +889,15 @@
                               {debtor.displayName}
                             </span>
                           </div>
-                          <span class="text-xs font-extrabold text-rose-500 tracking-tight shrink-0 pl-2">
-                            -{debtor.amount.toLocaleString(dateLocale())}
+                          <span class="shrink-0 pl-2 text-right">
+                            <span class="block text-xs font-extrabold text-rose-500 tracking-tight">
+                              -{debtor.amount.toLocaleString(dateLocale())}
+                            </span>
+                            {#if debtor.engaged > 0}
+                              <span class="block text-[10px] text-slate-400 dark:text-slate-500 leading-snug">
+                                {m.clan_public_debt_engaged_hint({ amount: debtor.engaged.toLocaleString(dateLocale()) })}
+                              </span>
+                            {/if}
                           </span>
                         </div>
                       {/each}
@@ -901,7 +923,14 @@
                 {#each displayedUnaffiliated as debtor}
                   <div class="flex items-center justify-between p-2.5 rounded-xl">
                     <span class="text-sm font-bold text-slate-700 dark:text-slate-350 truncate">{debtor.displayName}</span>
-                    <span class="text-xs font-extrabold text-rose-500 tracking-tight shrink-0 pl-2">-{debtor.amount.toLocaleString(dateLocale())}</span>
+                    <span class="shrink-0 pl-2 text-right">
+                      <span class="block text-xs font-extrabold text-rose-500 tracking-tight">-{debtor.amount.toLocaleString(dateLocale())}</span>
+                      {#if debtor.engaged > 0}
+                        <span class="block text-[10px] text-slate-400 dark:text-slate-500 leading-snug">
+                          {m.clan_public_debt_engaged_hint({ amount: debtor.engaged.toLocaleString(dateLocale()) })}
+                        </span>
+                      {/if}
+                    </span>
                   </div>
                 {/each}
               </div>

--- a/packages/shared/src/clans/bets.ts
+++ b/packages/shared/src/clans/bets.ts
@@ -387,6 +387,18 @@ export function applyDebtRepayment(gain: number, debt: number): { repaid: number
 }
 
 /**
+ * Part d'une dette qui reste due quoi qu'il arrive.
+ *
+ * Le reste est du crédit encore engagé dans des paris non tranchés : il
+ * s'efface si le pari est annulé, expire ou tombe à la clôture d'une saison.
+ * Confondre les deux fait lire un total qui va fondre tout seul comme une somme
+ * réellement perdue.
+ */
+export function firmDebtOf(amount: number, engaged: number): number {
+  return Math.max(0, Math.floor(amount) - Math.max(0, Math.floor(engaged)));
+}
+
+/**
  * Le sujet part dans un titre d'embed et dans un nom de fil : les retours à la
  * ligne y sont invisibles ou cassants, ils sont donc aplatis à la saisie plutôt
  * qu'à chaque affichage.


### PR DESCRIPTION
Une dette affichee melangeait deux choses : ce qui est reellement du, et le credit encore engage dans des paris non tranches, qui s'efface si le pari est annule, expire ou tombe a la cloture d'une saison. Un total qui fond tout seul au changement de saison se lisait comme une somme perdue.

Le dashboard et la page publique affichent desormais le montant total puis, en dessous, la part encore en jeu. Les listes d'endettes sont triees sur la dette ferme, seul montant qui ne peut plus disparaitre de lui-meme.

L'effacement manuel ne porte plus que sur la part ferme : un pari toujours en jeu a ete mise en connaissance de cause, et l'effacer le rendrait gratuit. Une case a cocher dans la confirmation permet d'emporter aussi le credit engage, pour les incidents ou le pari lui-meme est en cause. Meme regle cote MCP.