### PR TITLE
fix(paris): fiabilise les primes de fin de saison des parieurs

### DIFF
--- a/apps/bot/src/api/routes/dashboard/clans.ts
+++ b/apps/bot/src/api/routes/dashboard/clans.ts
@@ -746,6 +746,9 @@ export async function handleClansRoutes(
       // Les instantanés partent aussi : conservés, ils rétabliraient au premier
       // retour arrière des dettes rattachées à des clans qui n'existent plus.
       await prisma.clanDebtSnapshot.deleteMany({ where: { guildId } });
+      // La saison repart à 1 : garder les marques de primes versées priverait
+      // les prochaines saisons de leur podium.
+      await prisma.clanBetSeasonAward.deleteMany({ where: { guildId } });
 
       // 3. Réinitialiser la guilde
       await prisma.guild.update({
@@ -826,6 +829,11 @@ export async function handleClansRoutes(
         // partie, et l'instantané fait foi.
         const restored = await restoreClanDebts(guildId, targetSeason);
         await dropClanDebtSnapshotsAfter(guildId, targetSeason);
+
+        // La clôture de la saison visée n'a plus eu lieu : sa marque de primes
+        // versées s'en va avec elle, sinon la reclore laisserait son podium
+        // sans récompense.
+        await prisma.clanBetSeasonAward.deleteMany({ where: { guildId, season: { gte: targetSeason } } });
 
         logger.info(
           'ClansAPI',

--- a/apps/bot/src/services/community/clanBetService.ts
+++ b/apps/bot/src/services/community/clanBetService.ts
@@ -67,6 +67,7 @@ import {
   type BetShape,
   type BetStakeMode,
   type ClanBetSettings,
+  type SettledBet,
 } from '@kotbo/shared';
 import { kotboEventBus } from '@kotbo/core';
 import prisma from '../../utils/db.js';
@@ -2531,15 +2532,103 @@ export async function buildMemberBetOverview(guild: DiscordGuild, userId: string
 // ─── Récompenses de fin de saison ────────────────────────────────────────────
 
 export interface SeasonRewardOutcome {
+  /** Identifiant sous lequel ses points sont comptés, comptes liés repliés. */
   userId: string;
+  /**
+   * Compte réellement présent sur le serveur : celui qui porte le titre et
+   * qu'il faut mentionner. `null` quand le lauréat a quitté le serveur.
+   */
+  memberId: string | null;
   rank: number;
   netGain: number;
   wins: number;
   /** Prime prévue par les réglages. */
   reward: number;
-  /** Points réellement inscrits, remboursement de dette compris. */
+  /**
+   * Points réellement arrivés au classement. Remboursement de dette **exclu** :
+   * cette part-là ne bouge aucun score, l'annoncer comme des points ferait lire
+   * un gain que le classement ne montrera jamais.
+   */
   credited: number;
+  /** Part de la prime partie en remboursement de sa dette. */
+  debtRepaid: number;
   roleGiven: boolean;
+}
+
+/**
+ * Retrouve le lauréat sur le serveur.
+ *
+ * Le palmarès replie les comptes liés sur un seul identifiant, qui n'est pas
+ * forcément celui que la personne utilise encore : chercher ce seul compte
+ * faisait perdre titre et prime à quelqu'un dont le compte racine a quitté le
+ * serveur, alors qu'il est bien là sous son autre compte.
+ */
+async function findLaureateMember(guild: DiscordGuild, userId: string): Promise<GuildMember | null> {
+  const linked = await linkedUserIds(guild.id, userId);
+  const candidates = [userId, ...linked.filter((id) => id !== userId)];
+
+  for (const id of candidates) {
+    const member = guild.members.cache.get(id) ?? await guild.members.fetch(id).catch(() => null);
+    if (member) return member;
+  }
+  return null;
+}
+
+/** Taille d'une page de paris tranchés, à la lecture du palmarès d'une saison. */
+const SEASON_BET_PAGE = 500;
+/**
+ * Garde-fou de boucle. Une saison qui l'atteint a de toute façon dépassé ce
+ * qu'un palmarès sait dire de lisible, et la borne se voit dans les logs.
+ */
+const SEASON_BET_LIMIT = 100_000;
+
+/**
+ * Tous les paris tranchés d'une saison, réduits à ce qu'un palmarès en attend.
+ *
+ * Lus par pages et dans un ordre stable. Une lecture unique plafonnée laissait
+ * Postgres choisir quels paris entraient dans le podium dès que la saison
+ * dépassait le plafond : au-delà, le titre revenait au meilleur d'un
+ * échantillon arbitraire, sans que rien ne le signale.
+ */
+async function readSeasonSettledBets(
+  guildId: string,
+  season: number,
+  rootOf: (id: string) => string,
+): Promise<SettledBet[]> {
+  const settled: SettledBet[] = [];
+  let cursor: string | null = null;
+
+  while (settled.length < SEASON_BET_LIMIT) {
+    const page: FullBet[] = await prisma.clanBet.findMany({
+      where: { guildId, season, status: 'RESOLVED', winningSideId: { not: null } },
+      include: BET_INCLUDE,
+      orderBy: { id: 'asc' },
+      take: SEASON_BET_PAGE,
+      ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+    });
+    if (page.length === 0) break;
+
+    for (const bet of page) {
+      settled.push({
+        entries: allJoined(bet).map((entry) => ({
+          userId: rootOf(entry.userId),
+          engaged: engagedAmount(entry),
+          payout: entry.payout,
+          won: entry.sideId === bet.winningSideId,
+        })),
+        resolvedAt: bet.resolvedAt ?? bet.updatedAt,
+      });
+    }
+
+    if (page.length < SEASON_BET_PAGE) break;
+    cursor = page[page.length - 1]?.id ?? null;
+    if (!cursor) break;
+  }
+
+  if (settled.length >= SEASON_BET_LIMIT) {
+    logger.warn('ClanBet', `Palmarès de la saison ${season} sur ${guildId} arrêté à ${SEASON_BET_LIMIT} paris.`);
+  }
+  return settled;
 }
 
 /**
@@ -2552,6 +2641,9 @@ export interface SeasonRewardOutcome {
  * vient de se fermer, elles n'apparaîtraient dans aucun classement consultable ;
  * versées sur la suivante, elles récompensent visiblement et alimentent le clan
  * que le lauréat porte à ce moment-là.
+ *
+ * Une saison ne se récompense qu'une fois : la marque posée en base avant le
+ * premier versement arrête toute clôture qui repasserait sur le même numéro.
  */
 export async function awardSeasonBettors(params: {
   client: Client;
@@ -2563,35 +2655,31 @@ export async function awardSeasonBettors(params: {
   const settings = await getClanBetSettings(guildId);
   if (!settings.betsEnabled || !settings.betSeasonRewardEnabled) return [];
 
-  const bets = await prisma.clanBet.findMany({
-    where: { guildId, season, status: 'RESOLVED', winningSideId: { not: null } },
-    include: BET_INCLUDE,
-    take: 5_000,
-  });
-  if (bets.length === 0) return [];
-
   // Les comptes liés sont repliés avant le calcul : sans ce repli, une personne
   // qui a parié depuis ses deux comptes apparaîtrait deux fois sur le podium et
   // toucherait deux primes.
   const rootOf = await buildLinkedAccountFolder(guildId).catch(() => (id: string) => id);
 
-  const standings = buildBettorStandings(
-    bets.map((bet) => ({
-      entries: allJoined(bet).map((entry) => ({
-        userId: rootOf(entry.userId),
-        engaged: engagedAmount(entry),
-        payout: entry.payout,
-        won: entry.sideId === bet.winningSideId,
-      })),
-      resolvedAt: bet.resolvedAt ?? bet.updatedAt,
-    })),
-  );
+  const settledBets = await readSeasonSettledBets(guildId, season, rootOf);
+  if (settledBets.length === 0) return [];
 
-  const laureates = buildSeasonLaureates(standings, settings);
+  const laureates = buildSeasonLaureates(buildBettorStandings(settledBets), settings);
   if (laureates.length === 0) return [];
 
   const guild = client.guilds.cache.get(guildId) ?? await client.guilds.fetch(guildId).catch(() => null);
   if (!guild) return [];
+
+  // Marque posée avant le premier versement : deux clôtures de la même saison -
+  // deux remises à zéro qui lisent le même numéro avant de l'incrémenter, un
+  // cron qui repasse pendant que le précédent travaille encore - verseraient
+  // sinon les primes deux fois. L'échec d'écriture est la réponse : c'est
+  // l'unicité qui tranche, pas une lecture préalable qui laisserait la place à
+  // deux clôtures simultanées.
+  const claim = await prisma.clanBetSeasonAward.create({ data: { guildId, season } }).catch(() => null);
+  if (!claim) {
+    logger.warn('ClanBet', `Primes de la saison ${season} déjà versées sur ${guildId} : clôture ignorée.`);
+    return [];
+  }
 
   const context = await loadBetContext(guildId);
   const role = settings.betSeasonRewardRoleId
@@ -2612,10 +2700,10 @@ export async function awardSeasonBettors(params: {
 
   for (const laureate of laureates) {
     let credited = 0;
+    let debtRepaid = 0;
     let roleGiven = false;
 
-    const member = guild.members.cache.get(laureate.userId)
-      ?? await guild.members.fetch(laureate.userId).catch(() => null);
+    const member = await findLaureateMember(guild, laureate.userId);
 
     if (member && role && laureate.rank === 1) {
       roleGiven = await member.roles.add(role.id, `Meilleur parieur de la saison ${season}`)
@@ -2641,12 +2729,23 @@ export async function awardSeasonBettors(params: {
         return { granted: 0, debtRepaid: 0 };
       });
       // Comme partout ailleurs, ce qui compte est ce qui est arrivé : un
-      // lauréat endetté voit sa prime partir d'abord en remboursement.
-      credited = moved.granted + moved.debtRepaid;
+      // lauréat endetté voit sa prime partir d'abord en remboursement. Les deux
+      // parts restent séparées, elles ne se lisent pas au même endroit - l'une
+      // au classement, l'autre sur l'ardoise.
+      credited = moved.granted;
+      debtRepaid = moved.debtRepaid;
     }
 
-    outcomes.push({ ...laureate, credited, roleGiven });
+    outcomes.push({ ...laureate, memberId: member?.id ?? null, credited, debtRepaid, roleGiven });
   }
+
+  await prisma.clanBetSeasonAward.update({
+    where: { id: claim.id },
+    data: {
+      laureates: outcomes.length,
+      awardedPoints: outcomes.reduce((sum, outcome) => sum + outcome.credited + outcome.debtRepaid, 0),
+    },
+  }).catch(() => undefined);
 
   logger.info(
     'ClanBet',

--- a/apps/bot/src/services/community/clanService.ts
+++ b/apps/bot/src/services/community/clanService.ts
@@ -1374,14 +1374,30 @@ export async function handleEndSeason(
           // parieur peut briller dans un clan qui finit dernier.
           if (bettorLaureates.length > 0) {
             const medals = ['🥇', '🥈', '🥉'];
+            const points = (value: number) => value.toLocaleString('fr-FR');
             const lines = bettorLaureates.map((laureate) => {
-              // Ce qui est annoncé est ce qui a été inscrit : une prime partie
-              // en remboursement de dette est signalée plutôt que promise.
+              // Ce qui est annoncé est ce qui est arrivé au classement. La part
+              // partie en remboursement de dette est dite à côté : comptée avec
+              // les points, elle annonce un gain que le score ne montrera pas.
+              const paid = laureate.credited + laureate.debtRepaid;
+              const capped = paid > 0 && paid < laureate.reward ? ` sur ${points(laureate.reward)} prévus` : '';
+              const repaid = laureate.debtRepaid > 0
+                ? ` (${points(laureate.debtRepaid)} de plus partis en remboursement de dette)`
+                : '';
+
               const prize = laureate.credited > 0
-                ? ` - **+${laureate.credited.toLocaleString('fr-FR')} points**`
-                : laureate.reward > 0 ? ' - *prime non versée, aucun clan*' : '';
-              return `${medals[laureate.rank - 1] ?? '•'} <@${laureate.userId}> · `
-                + `**${laureate.netGain >= 0 ? '+' : ''}${laureate.netGain.toLocaleString('fr-FR')}** de gain net`
+                ? ` - **+${points(laureate.credited)} points**${capped}${repaid}`
+                : laureate.debtRepaid > 0
+                  ? ` - *prime de ${points(laureate.debtRepaid)} entièrement partie en remboursement de dette*`
+                  : laureate.reward > 0
+                    ? laureate.memberId
+                      ? ' - *prime non versée, aucun clan*'
+                      : ' - *prime non versée, lauréat absent du serveur*'
+                    : '';
+              // Mention du compte réellement présent : la racine des comptes
+              // liés peut être un double qui a quitté le serveur.
+              return `${medals[laureate.rank - 1] ?? '•'} <@${laureate.memberId ?? laureate.userId}> · `
+                + `**${laureate.netGain >= 0 ? '+' : ''}${points(laureate.netGain)}** de gain net`
                 + ` sur ${laureate.wins} victoire(s)${prize}`;
             });
             globalEmbed.addFields({

--- a/apps/bot/src/tests/unit/clanBets.test.ts
+++ b/apps/bot/src/tests/unit/clanBets.test.ts
@@ -443,6 +443,18 @@ describe('podium des parieurs', () => {
       .toEqual([['a', 1, 250], ['b', 1, 250], ['c', 3, 100]]);
   });
 
+  // Le classement départage deux gains nets égaux au nombre de victoires : le
+  // podium doit suivre, sinon il sacre « premiers » deux parieurs que la page
+  // affiche l'un au-dessus de l'autre.
+  test('un gain net égal départagé aux victoires occupe deux marches distinctes', () => {
+    const standings = [
+      { userId: 'a', netGain: 500, wins: 5, losses: 0, bestStreak: 5, currentStreak: 5 },
+      { userId: 'b', netGain: 500, wins: 2, losses: 3, bestStreak: 1, currentStreak: 0 },
+    ];
+    expect(buildSeasonLaureates(standings, REWARDS).map((e) => [e.userId, e.rank, e.reward]))
+      .toEqual([['a', 1, 300], ['b', 2, 200]]);
+  });
+
   test('des ex aequo plus nombreux que le podium se partagent tout', () => {
     expect(podium([['a', 5], ['b', 5], ['c', 5], ['d', 5]]).map((e) => e.reward)).toEqual([150, 150, 150, 150]);
   });

--- a/packages/database/prisma/bets.prisma
+++ b/packages/database/prisma/bets.prisma
@@ -170,3 +170,32 @@ model ClanBetParticipant {
   @@index([userId, status])
   @@map("clan_bet_participants")
 }
+
+/// Marque une saison dont le podium des parieurs a déjà été récompensé.
+///
+/// La ligne est posée avant le premier versement, et son unicité fait foi : une
+/// clôture qui n'arrive pas à l'écrire est une clôture déjà passée, elle
+/// s'arrête là. Sans elle, deux clôtures de la même saison - deux clics sur la
+/// remise à zéro qui lisent le même numéro avant de l'incrémenter, ou un cron
+/// qui repasse pendant que le précédent travaille encore - versaient les primes
+/// deux fois.
+///
+/// Effacée par un retour arrière, qui rend la saison à récompenser de nouveau.
+model ClanBetSeasonAward {
+  id      String @id @default(cuid())
+  guildId String
+  /// Saison qui vient de se clore, celle dont le palmarès est récompensé.
+  season  Int
+
+  /// Renseignés une fois les primes versées, pour que la table dise aussi ce
+  /// que la clôture a coûté.
+  laureates     Int @default(0)
+  awardedPoints Int @default(0)
+
+  guild Guild @relation(fields: [guildId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+
+  @@unique([guildId, season])
+  @@map("clan_bet_season_awards")
+}

--- a/packages/database/prisma/guild.prisma
+++ b/packages/database/prisma/guild.prisma
@@ -299,6 +299,7 @@ model Guild {
   clanMemberContributions ClanMemberContribution[]
   clanContributionEvents ClanContributionEvent[]
   clanBets ClanBet[]
+  clanBetSeasonAwards ClanBetSeasonAward[]
   clanPointDebts ClanPointDebt[]
   clanDebtSnapshots ClanDebtSnapshot[]
   memberLevels MemberLevel[]

--- a/packages/database/prisma/migrations/20260824180000_clan_bet_season_awards/migration.sql
+++ b/packages/database/prisma/migrations/20260824180000_clan_bet_season_awards/migration.sql
@@ -1,0 +1,20 @@
+-- Marque une saison dont le podium des parieurs a déjà été récompensé.
+--
+-- Deux clôtures de la même saison - deux clics sur la remise à zéro qui lisent
+-- le même numéro avant de l'incrémenter, ou un cron qui repasse pendant que le
+-- précédent travaille encore - versaient les primes deux fois. La ligne est
+-- posée avant le premier versement, et son unicité fait foi.
+CREATE TABLE "clan_bet_season_awards" (
+    "id" TEXT NOT NULL,
+    "guildId" TEXT NOT NULL,
+    "season" INTEGER NOT NULL,
+    "laureates" INTEGER NOT NULL DEFAULT 0,
+    "awardedPoints" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "clan_bet_season_awards_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "clan_bet_season_awards_guildId_season_key" ON "clan_bet_season_awards"("guildId", "season");
+
+ALTER TABLE "clan_bet_season_awards" ADD CONSTRAINT "clan_bet_season_awards_guildId_fkey" FOREIGN KEY ("guildId") REFERENCES "guilds"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/shared/src/clans/bets.ts
+++ b/packages/shared/src/clans/bets.ts
@@ -162,6 +162,16 @@ export interface BetSeasonLaureate {
 }
 
 /**
+ * Deux parieurs partagent une marche quand le départage de `buildBettorStandings`
+ * les laisse à égalité. L'identifiant, dernier critère de ce tri, n'en fait pas
+ * partie : il ne sert qu'à rendre l'ordre stable.
+ */
+function sameRank(a: BettorStanding | undefined, b: BettorStanding | undefined): boolean {
+  if (!a || !b) return false;
+  return a.netGain === b.netGain && a.wins === b.wins;
+}
+
+/**
  * Podium des parieurs d'une saison, prime comprise.
  *
  * Seul un gain net positif est récompensé : sans ce filtre, une saison où tout
@@ -173,6 +183,10 @@ export interface BetSeasonLaureate {
  * du second, exactement comme un camp de deux se partage le pot d'un pari. Leur
  * verser à chacun la prime pleine multiplierait la dépense par leur nombre,
  * pour une saison qui n'a pourtant rien distribué de plus.
+ *
+ * Sont ex aequo ceux que le classement lui-même ne départage pas, gain net
+ * **et** victoires : le partager sur le seul gain net sacrait « premiers » deux
+ * parieurs que la page et l'embed affichent pourtant l'un au-dessus de l'autre.
  *
  * Le total ne dépasse donc jamais la somme des trois primes, quel que soit le
  * nombre d'ex aequo.
@@ -191,11 +205,11 @@ export function buildSeasonLaureates(
   let step = 0;
 
   for (let index = 0; index < eligible.length && step < steps.length; ) {
-    // Tous ceux qui affichent le même gain net forment un groupe : ils montent
-    // sur la même marche et repartent avec la même part.
-    const gain = eligible[index]?.netGain ?? 0;
-    let size = 0;
-    while (index + size < eligible.length && eligible[index + size]?.netGain === gain) size += 1;
+    // Tous ceux que le classement laisse à égalité forment un groupe : ils
+    // montent sur la même marche et repartent avec la même part.
+    const head = eligible[index];
+    let size = 1;
+    while (index + size < eligible.length && sameRank(eligible[index + size], head)) size += 1;
 
     // Marches réellement occupées : un groupe plus nombreux que ce qu'il reste
     // de podium ne crée pas de marche supplémentaire.


### PR DESCRIPTION
Le calcul du podium etait juste, sa remise ne l'etait pas toujours.

Les ex aequo etaient definis sur le seul gain net, alors que le classement departage aussi au nombre de victoires : deux parieurs que la page et l'embed affichent l'un au-dessus de l'autre etaient sacres "premiers" ensemble et se partageaient les deux premieres primes. Le podium reprend desormais le meme departage que le classement.

Le palmares replie les comptes lies sur un seul identifiant, le plus petit du groupe, qui n'est pas forcement celui que la personne utilise encore. Le titre et la prime etaient cherches sur ce seul compte : quelqu'un dont le compte racine avait quitte le serveur perdait les deux, tout en etant bien present sous son autre compte. Le laureat est maintenant cherche sur tous ses comptes, et c'est celui qui est la qui recoit le role et qui est mentionne. Les points restent credites sur l'identifiant racine, celui qui porte la ligne de contribution.
