### PR TITLE
feat(rpg): ouvre les points de clan aux quetes personnelles et cesse de les faire attendre

### DIFF
--- a/apps/bot/src/commands/community/quests.ts
+++ b/apps/bot/src/commands/community/quests.ts
@@ -156,7 +156,7 @@ async function execute(interaction: ChatInputCommandInteraction) {
       // L'identifiant peut designer une quete RPG : les deux systemes se partagent la meme
       // commande, et rien ne distingue leurs identifiants a l'oeil.
       try {
-        const rpg = await claimRpgQuest(guildId, userId, questId);
+        const rpg = await claimRpgQuest(interaction.client, guildId, userId, questId);
         result = { success: true, coins: rpg.coins, xp: rpg.xp };
       } catch (error) {
         if (!(error instanceof QuestError)) throw error;

--- a/apps/bot/src/services/community/clanService.ts
+++ b/apps/bot/src/services/community/clanService.ts
@@ -282,6 +282,17 @@ export async function awardClanPointsToMembers(params: {
       `${total} point(s) de clan attribué(s) à ${granted.size} membre(s) (${params.source}${params.reason ? ` · ${params.reason}` : ''}) sur ${params.guildId}.`,
     );
     broadcastDashboardStateChange(params.guildId, 'clans_updated');
+
+    // Les pages publiques servent une reponse mise en cache trente secondes : sans cette
+    // invalidation, des points gagnes a l'instant mettaient jusqu'a une demi-minute a
+    // apparaitre, ce qui se lit comme un compteur qui ne bouge pas. Seules les deux cles
+    // concernees sont retirees : balayer tout le prefixe du serveur reviendrait a vider
+    // l'analytique a chaque monstre vaincu.
+    const { cache } = await import('../../utils/cache.js');
+    await Promise.all([
+      cache.delete(`guild:${params.guildId}:public-clans`),
+      cache.delete(`guild:${params.guildId}:public-rpg`),
+    ]).catch(() => null);
   }
 
   return granted;

--- a/apps/bot/src/services/features/rpg/rpgQuestPolicy.ts
+++ b/apps/bot/src/services/features/rpg/rpgQuestPolicy.ts
@@ -132,12 +132,13 @@ export function normalizeRpgQuestInput(input: RpgQuestInput): RpgQuestNormalizeR
       windowHours: clampInt(input.windowHours, QUEST_WINDOW_RANGE, 24),
       rewardCoins: clampInt(input.rewardCoins, QUEST_REWARD_RANGE, 0),
       rewardXp: clampInt(input.rewardXp, QUEST_REWARD_RANGE, 0),
-      // Seule une quête d'équipe adossée aux clans du serveur a un clan à créditer. Garder
-      // un montant ailleurs ferait promettre au dashboard des points que rien ne verserait,
-      // ni sur une quête personnelle ni sur une guilde RPG, qui n'a pas de classement.
-      rewardClanPoints: scope === 'TEAM' && teamMode === 'CLAN'
-        ? clampInt(input.rewardClanPoints, QUEST_CLAN_POINTS_RANGE, 0)
-        : 0,
+      // Une quête personnelle peut créditer le clan de celui qui la termine, comme le fait
+      // déjà un monstre vaincu. Seule une quête d'équipe adossée aux guildes RPG n'a aucun
+      // clan à créditer : y garder un montant ferait promettre des points que rien ne
+      // verserait.
+      rewardClanPoints: scope === 'TEAM' && teamMode !== 'CLAN'
+        ? 0
+        : clampInt(input.rewardClanPoints, QUEST_CLAN_POINTS_RANGE, 0),
       enabled: input.enabled !== false,
     },
   };

--- a/apps/bot/src/services/features/rpg/rpgQuestService.ts
+++ b/apps/bot/src/services/features/rpg/rpgQuestService.ts
@@ -13,6 +13,7 @@ import type { Client } from 'discord.js';
 import prisma from '../../../utils/db.js';
 import { logger } from '../../../utils/logger.js';
 import { checkLevelUp } from '../economyService.js';
+import { shouldAwardClanPoints } from './rpgBestiaryPolicy.js';
 import { splitRaidRewards } from './rpgRaidPolicy.js';
 import { asRpgTeamMode, resolveRpgTeamForUser } from './rpgTeamResolver.js';
 import {
@@ -239,19 +240,41 @@ async function rewardTeamQuest(client: Client, quest: QuestRow, teamKey: string,
     }
   }
 
-  const awards = [...pointShares.entries()].map(([userId, amount]) => ({ userId, amount }));
-  if (awards.some((award) => award.amount > 0)) {
-    const { awardClanPointsToMembers } = await import('../../community/clanService.js');
-    await awardClanPointsToMembers({
-      guildId: quest.guildId,
-      client,
-      source: 'RPG_QUEST',
-      awards,
-      reason: quest.name,
-    }).catch((error: unknown) => {
-      logger.error('RpgQuest', `Points de clan non versés sur ${quest.guildId}:`, error);
+  await awardQuestClanPoints(
+    client,
+    quest.guildId,
+    [...pointShares.entries()].map(([userId, amount]) => ({ userId, amount })),
+    quest.name,
+  );
+}
+
+/**
+ * Verse des points de clan si le pont RPG est ouvert.
+ *
+ * Le pont se coupe sans toucher aux primes reglees sur les fiches : un serveur qui l'a
+ * ferme ne doit plus rien recevoir du RPG, quete comprise, exactement comme pour un
+ * monstre vaincu.
+ */
+async function awardQuestClanPoints(
+  client: Client,
+  guildId: string,
+  awards: Array<{ userId: string; amount: number }>,
+  reason: string,
+): Promise<void> {
+  const positive = awards.filter((award) => award.amount > 0);
+  if (positive.length === 0) return;
+
+  const guild = await prisma.guild.findUnique({
+    where: { id: guildId },
+    select: { clansEnabled: true, clanPointsFromRpg: true },
+  });
+  if (!shouldAwardClanPoints(guild, positive[0].amount)) return;
+
+  const { awardClanPointsToMembers } = await import('../../community/clanService.js');
+  await awardClanPointsToMembers({ guildId, client, source: 'RPG_QUEST', awards: positive, reason })
+    .catch((error: unknown) => {
+      logger.error('RpgQuest', `Points de clan non versés sur ${guildId}:`, error);
     });
-  }
 }
 
 // ── Lecture et réclamation ────────────────────────────────────────────────
@@ -337,7 +360,7 @@ export async function getMemberQuests(client: Client, guildId: string, userId: s
 }
 
 /** Réclame une quête personnelle terminée. Les quêtes d'équipe se paient seules. */
-export async function claimRpgQuest(guildId: string, userId: string, questId: string) {
+export async function claimRpgQuest(client: Client, guildId: string, userId: string, questId: string) {
   const quest = await prisma.rpgQuest.findUnique({ where: { id: questId } });
   if (!quest || quest.guildId !== guildId) throw new QuestError('Quête introuvable.', 404);
   if (quest.scope !== 'MEMBER') throw new QuestError("Une quête d'équipe se règle d'elle-même.", 409);
@@ -364,6 +387,12 @@ export async function claimRpgQuest(guildId: string, userId: string, questId: st
     },
   });
   await checkLevelUp(guildId, userId);
+  await awardQuestClanPoints(client, guildId, [{ userId, amount: quest.rewardClanPoints }], quest.name);
 
-  return { coins: quest.rewardCoins, xp: quest.rewardXp, name: quest.name };
+  return {
+    coins: quest.rewardCoins,
+    xp: quest.rewardXp,
+    clanPoints: quest.rewardClanPoints,
+    name: quest.name,
+  };
 }

--- a/apps/bot/src/services/features/rpg/rpgRaidService.ts
+++ b/apps/bot/src/services/features/rpg/rpgRaidService.ts
@@ -41,6 +41,7 @@ import {
 } from './rpgRaidPolicy.js';
 import { runRaidAssault, type RaidAssaultResult } from './rpgRaidCombat.js';
 import { resolveRpgTeam, type RpgTeamIdentity } from './rpgTeamResolver.js';
+import { shouldAwardClanPoints } from './rpgBestiaryPolicy.js';
 
 type EconomyConfig = Awaited<ReturnType<typeof getOrCreateEconomyConfig>>;
 
@@ -589,7 +590,14 @@ async function rewardTeam(
   // et la gestion des comptes liés.
   if (forClans) {
     const awards = [...pointShares.entries()].map(([userId, amount]) => ({ userId, amount }));
-    if (awards.some((award) => award.amount > 0)) {
+    // Le pont RPG vers les clans se coupe sans toucher aux primes reglees : un serveur qui
+    // l'a ferme ne doit plus rien recevoir du RPG, raid compris, comme c'est deja le cas
+    // pour un monstre vaincu.
+    const guild = await prisma.guild.findUnique({
+      where: { id: raid.guildId },
+      select: { clansEnabled: true, clanPointsFromRpg: true },
+    });
+    if (shouldAwardClanPoints(guild, 1) && awards.some((award) => award.amount > 0)) {
       const { awardClanPointsToMembers } = await import('../../community/clanService.js');
       await awardClanPointsToMembers({
         guildId: raid.guildId,

--- a/apps/bot/src/tests/unit/rpgQuestPolicy.test.ts
+++ b/apps/bot/src/tests/unit/rpgQuestPolicy.test.ts
@@ -67,10 +67,16 @@ describe('fiche de quête', () => {
     expect(normalizeRpgQuestInput({ ...VALID, description: '' }).ok).toBe(false);
   });
 
-  // Une quete personnelle n'a pas d'equipe a crediter : garder un montant ferait promettre
-  // au dashboard des points que rien ne verserait.
-  test('une quête personnelle ne garde pas de points de clan', () => {
+  // Une quete personnelle credite le clan de celui qui la termine, comme un monstre vaincu.
+  // Seule une equipe adossee aux guildes RPG n'a aucun clan a crediter.
+  test('une quête personnelle garde ses points de clan', () => {
     const result = normalizeRpgQuestInput({ ...VALID, scope: 'MEMBER' });
+    if (!result.ok) throw new Error(result.error);
+    expect(result.value.rewardClanPoints).toBe(250);
+  });
+
+  test('une quête de guilde RPG ne garde pas de points de clan', () => {
+    const result = normalizeRpgQuestInput({ ...VALID, scope: 'TEAM', teamMode: 'RPG_GUILD' });
     if (!result.ok) throw new Error(result.error);
     expect(result.value.rewardClanPoints).toBe(0);
   });

--- a/apps/dashboard/messages/en.json
+++ b/apps/dashboard/messages/en.json
@@ -5597,6 +5597,7 @@
   "eco_quest_window_hint": "The window is clock-aligned: 24 h resets at midnight UTC, 6 h at 00, 06, 12 and 18. Every team runs the same clock.",
   "eco_quest_goal": "{target} {objective} in {hours} h",
   "eco_quest_window_ends": "Current window until {date}",
+  "eco_quest_rewards_bridge_hint": "Clan points are only paid while the RPG to clans bridge is open, in the Bosses & Monsters tab.",
   "eco_quest_rewards_member_hint": "Paid on claim, by the player, once the target is reached.",
   "eco_quest_rewards_team_hint": "Pools shared between participants: 30% split evenly, the rest in proportion to what each brought. Paid automatically on completion.",
   "eco_quest_obj_monsters": "monsters killed",

--- a/apps/dashboard/messages/fr.json
+++ b/apps/dashboard/messages/fr.json
@@ -5597,6 +5597,7 @@
   "eco_quest_window_hint": "La fenêtre est alignée sur l'heure : 24 h se remet à zéro à minuit UTC, 6 h à 00, 06, 12 et 18. Toutes les équipes courent ainsi la même horloge.",
   "eco_quest_goal": "{target} {objective} en {hours} h",
   "eco_quest_window_ends": "Fenêtre en cours jusqu'au {date}",
+  "eco_quest_rewards_bridge_hint": "Les points de clan ne partent que si le pont RPG vers les clans est ouvert, dans l'onglet Boss & Monstres.",
   "eco_quest_rewards_member_hint": "Versées à la réclamation, par le joueur, une fois la cible atteinte.",
   "eco_quest_rewards_team_hint": "Enveloppes partagées entre les participants : 30 % à parts égales, le reste au prorata de ce que chacun a apporté. Versées toutes seules à la complétion.",
   "eco_quest_obj_monsters": "monstres vaincus",

--- a/apps/dashboard/src/pages/Economy.svelte
+++ b/apps/dashboard/src/pages/Economy.svelte
@@ -2964,15 +2964,21 @@ import EmojiPicker from '../lib/components/EmojiPicker.svelte';
             <label for="questCoins" class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest ml-2">{m.eco_bestiary_coin_reward({ currency: config.currencyName })}</label>
             <input id="questCoins" type="number" min="0" bind:value={editingQuest.rewardCoins} class="w-full bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-4 py-2.5 text-xs focus:outline-none" />
           </div>
-          {#if editingQuest.scope === 'TEAM'}
+          <!-- Une quete personnelle credite le clan de celui qui la termine, comme le fait
+               deja un monstre vaincu. Seule une quete d'equipe en guildes RPG n'a aucun clan
+               a crediter. -->
+          {#if !(editingQuest.scope === 'TEAM' && editingQuest.teamMode !== 'CLAN')}
             <div class="space-y-1">
               <label for="questPoints" class="text-[10px] font-bold text-on-surface-variant/60 uppercase tracking-widest ml-2">{m.eco_raid_reward_points()}</label>
-              <input id="questPoints" type="number" min="0" bind:value={editingQuest.rewardClanPoints} disabled={!config.clansEnabled || editingQuest.teamMode !== 'CLAN'} class="w-full bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-4 py-2.5 text-xs focus:outline-none disabled:opacity-50" />
+              <input id="questPoints" type="number" min="0" bind:value={editingQuest.rewardClanPoints} disabled={!config.clansEnabled} class="w-full bg-surface-container-high/40 border border-outline-variant/10 rounded-lg px-4 py-2.5 text-xs focus:outline-none disabled:opacity-50" />
             </div>
           {/if}
         </div>
         <p class="text-[11px] text-on-surface-variant/50 leading-relaxed ml-2">
           {editingQuest.scope === 'TEAM' ? m.eco_quest_rewards_team_hint() : m.eco_quest_rewards_member_hint()}
+          {#if editingQuest.rewardClanPoints > 0}
+            {' '}{m.eco_quest_rewards_bridge_hint()}
+          {/if}
         </p>
 
         <div class="flex items-center justify-between gap-4 bg-surface-container-high/30 border border-outline-variant/10 rounded-xl px-5 py-4">


### PR DESCRIPTION
Une quete personnelle ne pouvait pas verser de points de clan : je zerotais le montant des qu'elle n'etait pas collective. C'etait incoherent avec le reste du jeu, ou un simple monstre vaincu credite deja le clan de celui qui l'abat. Seule une quete d'equipe adossee aux guildes RPG n'a desormais aucun clan a crediter, faute de clan derriere l'equipe.

Le raid et les quetes ne verifiaient pas le pont RPG vers les clans, que le bestiaire respecte pourtant. Un serveur qui ferme ce pont gardait ses primes reglees sur les fiches, dormantes, mais continuait de recevoir les points du raid et des quetes. Les deux passent maintenant par la meme garde.

Enfin, les pages publiques servent une reponse mise en cache trente secondes et rien ne l'invalidait quand des points etaient verses : un gain de l'instant mettait jusqu'a une demi-minute a apparaitre, ce qui se lit comme un compteur bloque. L'attribution retire les deux cles concernees, et elles seules : balayer tout le prefixe du serveur reviendrait a vider l'analytique a chaque monstre vaincu.