### PR TITLE
feat(rpg): restitue les pièces de niveau lors du reset des profils

### DIFF
--- a/apps/bot/src/api/mcp/tools/write-server-assets.ts
+++ b/apps/bot/src/api/mcp/tools/write-server-assets.ts
@@ -743,10 +743,13 @@ export function registerWriteServerAssetsTools(ctx: McpToolContext) {
 
         try {
           const { adminResetGuildEconomy } = await import('../../../services/features/economyService.js');
-          await adminResetGuildEconomy(guildId, component);
+          const { restored } = await adminResetGuildEconomy(guildId, component);
 
           await audit(key_name, 'Réinitialisation Économie MCP', `Reset de component: ${component}`, 'Action validée par le staff');
-          return ok({ ok: true, message: `L'économie (${component}) a été réinitialisée avec succès.` });
+          const restitution = restored.players > 0
+            ? ` ${restored.coins} pièces de montée de niveau ont été restituées à ${restored.players} membre(s).`
+            : '';
+          return ok({ ok: true, message: `L'économie (${component}) a été réinitialisée avec succès.${restitution}` });
         } catch (e) {
           return err(`Erreur : ${e instanceof Error ? e.message : String(e)}`);
         }

--- a/apps/bot/src/api/routes/dashboard/economy.ts
+++ b/apps/bot/src/api/routes/dashboard/economy.ts
@@ -1177,7 +1177,7 @@ export async function handleEconomyRoutes(
         }
 
         const { adminResetGuildEconomy } = await import('../../../services/features/economyService.js');
-        await adminResetGuildEconomy(guildId, body.component);
+        const { restored } = await adminResetGuildEconomy(guildId, body.component);
 
         const componentLabels: Record<string, string> = {
           all: 'Global (tout réinitialiser)',
@@ -1194,7 +1194,9 @@ export async function handleEconomyRoutes(
           context: getGuildName(client, guildId),
           module: 'Économie',
           eventType: 'Manuel',
-          details: `Composant réinitialisé : ${componentLabels[body.component] || body.component}`,
+          details: restored.players > 0
+            ? `Composant réinitialisé : ${componentLabels[body.component] || body.component} - ${restored.coins} pièces de niveau restituées à ${restored.players} membre(s)`
+            : `Composant réinitialisé : ${componentLabels[body.component] || body.component}`,
           channelId: null
         });
 

--- a/apps/bot/src/handlers/interactionHandler.ts
+++ b/apps/bot/src/handlers/interactionHandler.ts
@@ -376,7 +376,7 @@ export async function handleButton(interaction: Interaction, client: Client): Pr
     await interaction.deferUpdate();
     
     const { adminResetGuildEconomy } = await import('../services/features/economyService.js');
-    await adminResetGuildEconomy(guildId!, component);
+    const { restored } = await adminResetGuildEconomy(guildId!, component);
 
     const componentLabels: Record<string, string> = {
       all: "l'Économie & RPG (Global)",
@@ -386,8 +386,12 @@ export async function handleButton(interaction: Interaction, client: Client): Pr
       guilds: 'les Guildes RPG'
     };
 
+    const restitution = restored.players > 0
+      ? `\n\n**${restored.coins.toLocaleString('fr-FR')}** pièces de montée de niveau ont été restituées à **${restored.players}** membre(s).`
+      : '';
+
     await interaction.editReply({
-      embeds: [successEmbed('Réinitialisation terminée', `Le composant **${componentLabels[component] || component}** a été réinitialisé avec succès !`)],
+      embeds: [successEmbed('Réinitialisation terminée', `Le composant **${componentLabels[component] || component}** a été réinitialisé avec succès !${restitution}`)],
       components: []
     });
     return;

--- a/apps/bot/src/services/features/economyService.ts
+++ b/apps/bot/src/services/features/economyService.ts
@@ -993,10 +993,45 @@ export async function sellShopItem(guildId: string, userId: string, itemId: stri
   };
 }
 
+export type RestoredLevelUpCoins = { players: number; coins: number };
+
+/**
+ * Recrée les profils RPG des membres ayant au moins un niveau, avec pour seul acquis les
+ * KotboCoins gagnés à leurs montées de niveau.
+ *
+ * Ces pièces récompensent l'activité sur le serveur et sont créditées par le module de
+ * niveaux, pas par le RPG : les effacer avec les profils ferait payer aux membres une remise
+ * à zéro qui ne concerne pas la progression qui les leur a values.
+ */
+async function restoreLevelUpCoins(guildId: string): Promise<RestoredLevelUpCoins> {
+  const { totalLevelUpCoins } = await import('../progression/levelingService.js');
+
+  const leveled = await prisma.memberLevel.findMany({
+    where: { guildId, level: { gt: 0 } },
+    select: { userId: true, level: true }
+  });
+  if (leveled.length === 0) return { players: 0, coins: 0 };
+
+  const profiles = leveled.map(({ userId, level }) => ({
+    guildId,
+    userId,
+    balance: totalLevelUpCoins(level)
+  }));
+
+  // `skipDuplicates` : un joueur peut recréer son profil entre la suppression et cet insert.
+  const created = await prisma.rpgProfile.createMany({ data: profiles, skipDuplicates: true });
+  const coins = profiles.reduce((total, profile) => total + profile.balance, 0);
+
+  logger.info('EconomyService', `Restitution de ${coins} KotboCoins de niveau a ${created.count} profil(s) sur la guilde ${guildId}`);
+  return { players: created.count, coins };
+}
+
 /**
  * Réinitialise certains éléments ou toute l'économie RPG pour une guilde.
  */
 export async function adminResetGuildEconomy(guildId: string, component: 'all' | 'profiles' | 'items' | 'config' | 'guilds' | 'bestiary') {
+  let restored: RestoredLevelUpCoins = { players: 0, coins: 0 };
+
   // Les paliers de difficulté décrivent le bestiaire et la boutique, pas le rythme de
   // l'économie : les oublier en réinitialisant la seule configuration laisserait des fiches
   // déjà réécrites face à un palier revenu à « moyen », et le clic suivant les multiplierait
@@ -1101,6 +1136,7 @@ export async function adminResetGuildEconomy(guildId: string, component: 'all' |
     await prisma.rpgProfile.deleteMany({
       where: { guildId }
     });
+    restored = await restoreLevelUpCoins(guildId);
   }
 
   if (component === 'config' || component === 'all') {
@@ -1110,7 +1146,7 @@ export async function adminResetGuildEconomy(guildId: string, component: 'all' |
     }
   }
 
-  return { success: true };
+  return { success: true, restored };
 }
 
 /**

--- a/apps/bot/src/services/progression/levelingService.ts
+++ b/apps/bot/src/services/progression/levelingService.ts
@@ -901,6 +901,21 @@ export async function removeXp(guildId: string, userId: string, amount: number, 
   }
 }
 
+/** KotboCoins accordés pour la montée au niveau `level`. */
+export function levelUpCoinReward(level: number): number {
+  return level * 20;
+}
+
+/**
+ * Somme des récompenses de montée de niveau reçues par un membre arrivé au niveau `level`,
+ * soit `20 * (1 + 2 + ... + level)`. Sert à restituer ces pièces après une remise à zéro
+ * des profils RPG : elles ont été gagnées par l'activité sur le serveur, pas dans le RPG.
+ */
+export function totalLevelUpCoins(level: number): number {
+  if (level <= 0) return 0;
+  return 10 * level * (level + 1);
+}
+
 /**
  * Calcule (sans l'appliquer) la récompense en KotboCoins due pour une montée de niveau.
  */
@@ -910,7 +925,7 @@ async function getLevelUpCoinReward(guildId: string, newLevel: number): Promise<
     const econConfig = await getOrCreateEconomyConfig(guildId).catch(() => null);
     if (!econConfig || !econConfig.enabled) return null;
     return {
-      amount: newLevel * 20,
+      amount: levelUpCoinReward(newLevel),
       currencyEmoji: econConfig.currencyEmoji,
       currencyName: econConfig.currencyName,
     };


### PR DESCRIPTION
Les KotboCoins accordés aux montées de niveau récompensent l'activité sur le serveur, pas la progression RPG. Les effacer avec les profils faisait payer aux membres une remise à zéro qui ne concernait pas ce qui les leur avait values.

Le reset des profils recrée désormais une fiche vierge pour chaque membre de niveau 1 ou plus, créditée de la somme de ses récompenses de niveau. La formule de récompense est extraite en `levelUpCoinReward` et son cumulé en `totalLevelUpCoins` pour que les deux restent liés.

Le nombre de membres et le total restitués remontent dans l'embed de confirmation, l'audit du dashboard et la réponse de l'outil MCP.