### PR TITLE
fix(dashboard): reconnaitre l'administrateur dont la session a vieilli

### DIFF
--- a/apps/dashboard/src/App.svelte
+++ b/apps/dashboard/src/App.svelte
@@ -205,8 +205,23 @@
    * routes de la table, et un rafraichissement sur une page de configuration
    * tomberait sur l'ecran 404 avant meme que la liste des serveurs soit connue.
    */
+  /**
+   * Deuxieme source, et non un assouplissement : `canManageSettings` n'est vrai
+   * que pour le niveau `admin` - un moderateur le recoit a false, l'API refuse
+   * de toute facon toute ecriture sans lui.
+   *
+   * Les deux sources ne se valent pas. `authStore.isAdmin` vient de la liste
+   * des serveurs, ou le niveau est deduit des permissions rendues par OAuth :
+   * elles datent de la connexion, et valent zero quand l'appel a Discord ne
+   * ramene rien pour ce serveur. L'etat de guilde, lui, est calcule en allant
+   * chercher le membre sur le serveur et en lisant ses permissions reelles.
+   * Un administrateur dont la session porte des permissions perimees se voyait
+   * donc refuser des pages que le serveur, lui, lui accordait.
+   */
   const canManageSettings = $derived(
-    !authStore.initialized || authStore.isAdmin,
+    !authStore.initialized
+      || authStore.isAdmin
+      || !!dashboardStore.state.access?.canManageSettings,
   );
 
   /**

--- a/apps/dashboard/src/lib/stores/navigation.svelte.ts
+++ b/apps/dashboard/src/lib/stores/navigation.svelte.ts
@@ -80,7 +80,19 @@ class NavigationStore {
     (dashboardStore.state.featureAccess ?? {}) as Record<string, { canView?: boolean }>,
   );
 
-  readonly isAdmin = $derived(this.#guild?.accessLevel === 'admin');
+  /**
+   * Deux sources pour la meme question, parce qu'elles ne se trompent pas au
+   * meme endroit : le niveau de la liste des serveurs vient des permissions
+   * rendues par OAuth, qui datent de la connexion, tandis que l'etat de guilde
+   * lit les permissions reelles du membre sur le serveur. Sans la seconde, un
+   * administrateur dont la session a vieilli perdait le groupe Configuration
+   * de sa barre laterale. `canManageSettings` n'est vrai que pour le niveau
+   * `admin` : le croisement n'ouvre rien a un moderateur.
+   */
+  readonly isAdmin = $derived(
+    this.#guild?.accessLevel === 'admin'
+      || !!dashboardStore.state.access?.canManageSettings,
+  );
   /**
    * Facturation visible pour ce compte sur ce serveur.
    *


### PR DESCRIPTION
Le dashboard posait la question des droits d'administrateur a une seule source: le niveau porte par la liste des serveurs, deduit des permissions que Discord renvoie avec le jeton OAuth. Ces permissions datent de la connexion, et retombent a zero quand l'appel ne ramene rien pour le serveur vise. Un administrateur dont la session a vieilli perdait alors les dix-sept pages de configuration et le groupe Configuration de sa barre laterale, sans que rien n'explique pourquoi.

L'etat de guilde repond a la meme question autrement: il va chercher le membre sur le serveur et lit ses permissions reelles. Les deux sources sont desormais croisees, pour la table de routes comme pour la navigation.

Ce n'est pas un assouplissement. `canManageSettings` n'est vrai que pour le niveau administrateur - un moderateur le recoit a false - et l'API refuse de toute facon toute ecriture sans lui. Le croisement n'ouvre donc rien a personne de nouveau: il cesse de fermer a qui a le droit.