### PR TITLE
fix(dashboard): remonter la route du Centre de gestion, perdue a la fusion

### DIFF
--- a/apps/dashboard/src/App.svelte
+++ b/apps/dashboard/src/App.svelte
@@ -233,7 +233,7 @@
    * le bloc de la table de routes garde par `canManageSettings`.
    */
   const ADMIN_ROUTES = [
-    "/management", "/modules", "/server-template", "/setup", "/formation",
+    "/management", "/modules", "/server-template", "/setup",
     "/migration", "/campaigns", "/module-settings", "/notifications",
     "/command-access", "/backups", "/schedules", "/mcp-settings",
     "/custom-bot", "/automations", "/staff-management", "/channels-management",
@@ -793,6 +793,10 @@
               remountKey={() => profileUserIdFromPath($router.path)}
             />
             {#if canManageSettings}
+              <LazyRoute
+                path="/management"
+                load={() => import("./pages/ManagementCenter.svelte")}
+              />
               <LazyRoute
                 path="/modules"
                 load={() => import("./pages/ModuleCatalog.svelte")}


### PR DESCRIPTION
La page etait injoignable: son entree de navigation, ses raccourcis, son fil d'Ariane et son titre de partage etaient tous en place, mais la table de routes ne la declarait plus. Rien ne repondait donc a l'adresse, et l'ecran 404 s'affichait sous un fil d'Ariane qui annoncait la page.

La ligne a disparu en ramenant recette dans la branche: les retours en arriere sur le tunnel de mise en place ont reecrit la table depuis une version anterieure, ou la route n'existait pas encore. Le reste de l'integration a survecu - c'est la seule ligne perdue.

`/formation` quitte au passage la liste des chemins reserves aux administrateurs: la meme reecriture a retire cette route et sa page, si bien que la liste promettait un droit sur une adresse qui n'existe plus pour personne.