### PR TITLE
feat(mcp): couper une cle quand son porteur perd ses droits

### DIFF
--- a/apps/bot/src/api/mcp/mcpKeyService.ts
+++ b/apps/bot/src/api/mcp/mcpKeyService.ts
@@ -1,6 +1,33 @@
 import prisma from '../../utils/db.js';
 import crypto from 'node:crypto';
-import type { McpKeyPermission } from '@prisma/client';
+import type { McpKeyPermission, McpApiKey } from '@prisma/client';
+import type { Client } from 'discord.js';
+
+/**
+ * Le proprietaire de la cle a-t-il toujours acces au serveur ?
+ *
+ * Une cle ne portait que ses permissions : elle continuait de repondre apres
+ * que son porteur ait perdu son role, ou meme quitte le serveur. Le controle
+ * se fait a chaque appel, sur la meme resolution d'acces que le dashboard -
+ * qui la met en cache, la verification ne coute donc pas une requete Discord
+ * par outil appele.
+ *
+ * Une cle sans proprietaire est laissee telle quelle : ce sont celles
+ * distribuees avant que ce champ existe, et les couper d'office arreterait des
+ * integrations en service sans prevenir.
+ *
+ * Sans `client`, le controle est passe plutot que refuse. Tous les chemins
+ * d'authentification le fournissent aujourd'hui ; le laisser optionnel evite
+ * qu'un appelant oublie coupe toutes les cles du serveur d'un coup, la ou
+ * l'oubli ne fait que ramener au comportement d'avant.
+ */
+const ownerStillAllowed = async (client: Client | undefined, key: McpApiKey): Promise<boolean> => {
+  if (!key.ownerId || !client) return true;
+
+  const { resolveDashboardAccess } = await import('../shared/core.js');
+  const access = await resolveDashboardAccess(client, key.guildId, key.ownerId);
+  return access.canViewDashboard;
+};
 
 export const hashMcpKey = (key: string): string => {
   return crypto.createHash('sha256').update(key).digest('hex');
@@ -15,7 +42,8 @@ export const generateMcpKey = (): { fullKey: string; displayKey: string } => {
 export const createMcpKey = async (
   guildId: string,
   name: string,
-  permissions: McpKeyPermission[]
+  permissions: McpKeyPermission[],
+  ownerId?: string | null
 ) => {
   const { fullKey, displayKey } = generateMcpKey();
   const keyHash = hashMcpKey(fullKey);
@@ -27,6 +55,7 @@ export const createMcpKey = async (
       keyHash,
       displayKey,
       permissions,
+      ownerId: ownerId ?? null,
     },
   });
 
@@ -44,6 +73,7 @@ export const getMcpKeys = async (guildId: string) => {
       isActive: true,
       lastUsedAt: true,
       createdAt: true,
+      ownerId: true,
     },
     orderBy: { createdAt: 'desc' },
   });
@@ -56,13 +86,15 @@ export const deactivateMcpKey = async (guildId: string, keyId: string) => {
   });
 };
 
-export const verifyMcpKey = async (rawKey: string, guildId: string) => {
+export const verifyMcpKey = async (rawKey: string, guildId: string, client?: Client) => {
   const keyHash = hashMcpKey(rawKey);
   const key = await prisma.mcpApiKey.findUnique({ where: { keyHash } });
 
   if (!key || key.guildId !== guildId || !key.isActive) {
     return null;
   }
+
+  if (!(await ownerStillAllowed(client, key))) return null;
 
   await prisma.mcpApiKey.update({
     where: { id: key.id },
@@ -76,7 +108,8 @@ export const verifyMcpKey = async (rawKey: string, guildId: string) => {
 export const verifyMcpKeyByClientCredentials = async (
   clientId: string,
   clientSecret: string,
-  guildId: string
+  guildId: string,
+  client?: Client
 ) => {
   const key = await prisma.mcpApiKey.findFirst({
     where: { id: clientId, guildId, isActive: true },
@@ -88,6 +121,8 @@ export const verifyMcpKeyByClientCredentials = async (
   const secretHash = hashMcpKey(clientSecret);
   if (secretHash !== key.keyHash) return null;
 
+  if (!(await ownerStillAllowed(client, key))) return null;
+
   await prisma.mcpApiKey.update({
     where: { id: key.id },
     data: { lastUsedAt: new Date() },
@@ -96,12 +131,14 @@ export const verifyMcpKeyByClientCredentials = async (
   return key;
 };
 
-export const getActiveMcpKeyById = async (keyId: string, guildId: string) => {
+export const getActiveMcpKeyById = async (keyId: string, guildId: string, client?: Client) => {
   const key = await prisma.mcpApiKey.findFirst({
     where: { id: keyId, guildId, isActive: true },
   });
 
   if (!key) return null;
+
+  if (!(await ownerStillAllowed(client, key))) return null;
 
   await prisma.mcpApiKey.update({
     where: { id: key.id },

--- a/apps/bot/src/api/mcp/mcpServer.ts
+++ b/apps/bot/src/api/mcp/mcpServer.ts
@@ -560,7 +560,7 @@ export function makeMcpDirectToken(guildId: string, keyId: string) {
   );
 }
 
-async function verifyMcpDirectToken(token: string, guildId: string) {
+async function verifyMcpDirectToken(token: string, guildId: string, client?: Client) {
   try {
     const claims = jwt.verify(token, oauthJwtSecret(), {
       issuer: 'kotbo-mcp-direct',
@@ -571,7 +571,7 @@ async function verifyMcpDirectToken(token: string, guildId: string) {
       return null;
     }
 
-    return getActiveMcpKeyById(claims.sub, guildId);
+    return getActiveMcpKeyById(claims.sub, guildId, client);
   } catch {
     return null;
   }
@@ -605,14 +605,14 @@ function openRefreshToken(refreshToken: string): RefreshTokenPayload | null {
   }
 }
 
-async function verifyOAuthAccessToken(token: string, guildId: string, audience: string) {
+async function verifyOAuthAccessToken(token: string, guildId: string, audience: string, client?: Client) {
   try {
     const claims = jwt.verify(token, oauthJwtSecret(), {
       audience,
     }) as McpAccessTokenClaims;
 
     if (claims.guildId !== guildId || typeof claims.sub !== 'string') return null;
-    return getActiveMcpKeyById(claims.sub, guildId);
+    return getActiveMcpKeyById(claims.sub, guildId, client);
   } catch {
     return null;
   }
@@ -798,7 +798,7 @@ export async function handleMCPRoutes(
     }
 
     if (directToken) {
-      const mcpKey = await verifyMcpDirectToken(directToken, guildId);
+      const mcpKey = await verifyMcpDirectToken(directToken, guildId, client);
       if (!mcpKey) {
         mcpLog(req, 'direct_authorize_invalid', { guildId, clientId, redirectUri }, 'warn');
         json(res, 401, { error: 'invalid_direct_token' });
@@ -852,7 +852,7 @@ export async function handleMCPRoutes(
     }
 
     const cleanApiKey = api_key.trim();
-    const mcpKey = await verifyMcpKey(cleanApiKey, guildId);
+    const mcpKey = await verifyMcpKey(cleanApiKey, guildId, client);
     if (!mcpKey) {
       mcpLog(req, 'authorize_post_bad_key', { guildId, clientId: client_id, redirectUri: redirect_uri });
       const clientName = oauthClients.get(client_id)?.clientName ?? 'Agent IA';
@@ -935,7 +935,7 @@ export async function handleMCPRoutes(
         return true;
       }
 
-      const mcpKey = await getActiveMcpKeyById(rt.keyId, guildId);
+      const mcpKey = await getActiveMcpKeyById(rt.keyId, guildId, client);
       if (!mcpKey) {
         oauthError(req, res, 400, 'invalid_grant', 'Clé MCP inactive');
         return true;
@@ -959,7 +959,7 @@ export async function handleMCPRoutes(
         return true;
       }
 
-      const mcpKey = await verifyMcpKeyByClientCredentials(clientId, clientSecret, guildId);
+      const mcpKey = await verifyMcpKeyByClientCredentials(clientId, clientSecret, guildId, client);
       if (!mcpKey) {
         oauthError(req, res, 401, 'invalid_client', 'Client ID ou secret invalide');
         return true;
@@ -1073,7 +1073,7 @@ export async function handleMCPRoutes(
     let keyId: string | null = null;
 
     if (directToken) {
-      const mcpKey = await verifyMcpDirectToken(directToken, guildId);
+      const mcpKey = await verifyMcpDirectToken(directToken, guildId, client);
       if (!mcpKey) {
         mcpLog(req, 'mcp_direct_invalid', { guildId }, 'warn');
         json(res, 401, { error: 'URL MCP directe invalide ou expirée' });
@@ -1085,8 +1085,8 @@ export async function handleMCPRoutes(
       mcpLog(req, 'mcp_direct_valid', { guildId, keyId, method: jsonRpcMethod(parsedBody), permissions });
     } else if (rawKey) {
       const mcpKey = rawKey.startsWith('mcp_')
-        ? await verifyMcpKey(rawKey, guildId)
-        : await verifyOAuthAccessToken(rawKey, guildId, base);
+        ? await verifyMcpKey(rawKey, guildId, client)
+        : await verifyOAuthAccessToken(rawKey, guildId, base, client);
       if (!mcpKey) {
         mcpLog(req, 'mcp_bearer_invalid', { guildId });
         res.setHeader('WWW-Authenticate', authChallenge(req, url, guildId, 'invalid_token', 'Clé MCP invalide ou inactive'));
@@ -1098,7 +1098,7 @@ export async function handleMCPRoutes(
       keyId = mcpKey.id;
       mcpLog(req, 'mcp_bearer_valid', { guildId, keyId, tokenKind: rawKey.startsWith('mcp_') ? 'mcp_key' : 'oauth_jwt', method: jsonRpcMethod(parsedBody), permissions });
     } else if (basicCredentials) {
-      const mcpKey = await verifyMcpKeyByClientCredentials(basicCredentials.clientId, basicCredentials.clientSecret, guildId);
+      const mcpKey = await verifyMcpKeyByClientCredentials(basicCredentials.clientId, basicCredentials.clientSecret, guildId, client);
       if (!mcpKey) {
         mcpLog(req, 'mcp_basic_invalid', { guildId, clientId: basicCredentials.clientId });
         res.setHeader('WWW-Authenticate', authChallenge(req, url, guildId, 'invalid_token', 'Client MCP invalide ou inactif'));

--- a/apps/bot/src/api/routes/dashboard/mcp.ts
+++ b/apps/bot/src/api/routes/dashboard/mcp.ts
@@ -31,7 +31,7 @@ export async function handleMCPKeyRoutes(
   parts: string[],
   _url: URL,
   _client: Client,
-  _user: AuthClaims,
+  user: AuthClaims,
   guildId: string,
   access: DashboardAccess
 ): Promise<boolean> {
@@ -75,7 +75,9 @@ export async function handleMCPKeyRoutes(
       const permissions: McpKeyPermission[] = (body.permissions ?? ['READ_STATS', 'READ_MEMBERS', 'READ_SANCTIONS'])
         .filter((p): p is McpKeyPermission => VALID_PERMISSIONS.includes(p as McpKeyPermission));
 
-      const created = await createMcpKey(guildId, body.name.trim(), permissions);
+      // La cle agit au nom de qui la cree : c'est ce rattachement qui permet
+      // de la couper quand ce compte perd ses droits sur le serveur.
+      const created = await createMcpKey(guildId, body.name.trim(), permissions, user.userId);
       json(res, 201, {
         id: created.id,
         name: created.name,

--- a/apps/dashboard/messages/en.json
+++ b/apps/dashboard/messages/en.json
@@ -9690,5 +9690,7 @@
   "ma_perm_view_desc": "Open the section and read its data. Without it, the page leaves the navigation and the API refuses even reads.",
   "ma_perm_moderate_desc": "Act on what the section holds day to day - handle, decide, answer - without touching its settings.",
   "ma_perm_configure_desc": "Change the section settings. This is the right that allows saving, beyond plain reading.",
-  "ma_perm_delete_desc": "Erase within the section: meetings, automations, staff ranks and warnings, quests, ticket macros and blacklist. A role that configures a section may still not erase from it."
+  "ma_perm_delete_desc": "Erase within the section: meetings, automations, staff ranks and warnings, quests, ticket macros and blacklist. A role that configures a section may still not erase from it.",
+  "mcp_key_orphan": "No owner",
+  "mcp_key_orphan_hint": "Key created before keys were tied to an account. It keeps answering even if whoever uses it loses access to the server: revoke and recreate it so it follows its holder."
 }

--- a/apps/dashboard/messages/fr.json
+++ b/apps/dashboard/messages/fr.json
@@ -9690,5 +9690,7 @@
   "ma_perm_view_desc": "Ouvrir la section et lire ses donnees. Sans ce droit, la page disparait de la navigation et l'API refuse meme la lecture.",
   "ma_perm_moderate_desc": "Agir au quotidien sur ce que la section contient - traiter, decider, repondre - sans toucher a ses reglages.",
   "ma_perm_configure_desc": "Modifier les reglages de la section. C'est ce droit qui autorise les enregistrements, au-dela de la simple lecture.",
-  "ma_perm_delete_desc": "Effacer dans la section : reunions, automatisations, grades et avertissements du staff, quetes, macros et liste noire des tickets. Un role qui regle la section n'a pas pour autant le droit d'y effacer."
+  "ma_perm_delete_desc": "Effacer dans la section : reunions, automatisations, grades et avertissements du staff, quetes, macros et liste noire des tickets. Un role qui regle la section n'a pas pour autant le droit d'y effacer.",
+  "mcp_key_orphan": "Sans proprietaire",
+  "mcp_key_orphan_hint": "Cle creee avant que les cles soient rattachees a un compte. Elle continue de repondre meme si celui qui s'en sert perd ses droits sur le serveur : revoquez-la et recreez-la pour qu'elle suive son porteur."
 }

--- a/apps/dashboard/src/pages/MCPSettings.svelte
+++ b/apps/dashboard/src/pages/MCPSettings.svelte
@@ -37,6 +37,7 @@
     permissions: string[];
     lastUsedAt: string | null;
     createdAt: string;
+    ownerId?: string | null;
   };
 
   type CreatedKey = {
@@ -409,7 +410,17 @@
 
               <!-- Name -->
               <div class="flex-1 min-w-0">
-                <p class="text-sm font-medium text-white">{key.name}</p>
+                <p class="flex items-center gap-1.5 text-sm font-medium text-white">
+                  {key.name}
+                  {#if !key.ownerId}
+                    <!-- Une cle sans proprietaire survit au depart de celui qui
+                         s'en sert : rien ne la relie a un compte, seule une
+                         revocation a la main l'arrete. -->
+                    <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-500/15 text-amber-400" title={m.mcp_key_orphan_hint()}>
+                      {m.mcp_key_orphan()}
+                    </span>
+                  {/if}
+                </p>
                 <p class="text-xs text-gray-600 mt-0.5">
                   {m.mcp_last_used({ date: formatDate(key.lastUsedAt) })}
                 </p>

--- a/packages/database/prisma/mcp.prisma
+++ b/packages/database/prisma/mcp.prisma
@@ -33,6 +33,17 @@ model McpApiKey {
   isActive    Boolean  @default(true)
   lastUsedAt  DateTime?
 
+  /// Compte Discord au nom duquel la cle agit.
+  ///
+  /// Une cle sans proprietaire n'est rattachee a personne : elle survivait au
+  /// depart de celui qui s'en servait, puisque rien ne reliait ses droits a un
+  /// compte. Quand il est renseigne, chaque appel verifie que ce compte a
+  /// toujours acces au dashboard du serveur.
+  ///
+  /// Nul sur les cles creees avant ce champ : elles gardent l'ancien
+  /// comportement plutot que de cesser de fonctionner du jour au lendemain.
+  ownerId     String?
+
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 

--- a/packages/database/prisma/migrations/20260905120000_mcp_key_owner/migration.sql
+++ b/packages/database/prisma/migrations/20260905120000_mcp_key_owner/migration.sql
@@ -1,0 +1,12 @@
+-- Proprietaire d'une cle MCP.
+--
+-- Une cle ne portait que son serveur et ses permissions. Elle continuait donc
+-- de fonctionner apres que celui qui s'en servait ait perdu ses droits, ou
+-- meme quitte le serveur : rien ne la reliait a un compte, et seule une
+-- revocation manuelle pouvait la couper.
+--
+-- La colonne reste nullable a dessein. Les cles deja distribuees n'ont pas de
+-- proprietaire connu, et les eteindre d'office couperait des integrations en
+-- service sans prevenir. Elles gardent l'ancien comportement, signalees comme
+-- telles dans le dashboard ; les nouvelles sont rattachees a leur createur.
+ALTER TABLE "mcp_api_keys" ADD COLUMN IF NOT EXISTS "ownerId" TEXT;


### PR DESCRIPTION
Une cle MCP ne portait que son serveur et ses permissions. Rien ne la reliait a un compte, si bien qu'elle continuait de repondre apres que celui qui s'en servait ait perdu son role, quitte le serveur, ou en ait ete banni. Restreindre quelqu'un dans le Centre de gestion ne changeait rien a ce qu'il pouvait faire par le MCP - y compris, avec READ_STAFF et WRITE_MEMBERS, relire et reecrire la matrice des acces elle-meme. Seule une revocation a la main arretait la cle.

Une cle est desormais creee au nom de son createur, et chaque authentification verifie que ce compte a toujours acces au dashboard. Le controle passe par la meme resolution d'acces que le dashboard, qui la met en cache: il ne coute pas une requete Discord par outil appele. Les huit points d'authentification sont couverts - cle brute, identifiants client, jeton direct, jeton OAuth et son rafraichissement.

Les cles deja distribuees n'ont pas de proprietaire connu. Les eteindre d'office arreterait des integrations en service sans prevenir: elles gardent donc l'ancien comportement, et le dashboard les signale comme sans proprietaire en expliquant qu'il faut les recreer pour qu'elles suivent leur porteur. La colonne reste nullable pour cette raison.

Sans client Discord, le controle est passe plutot que refuse. Tous les chemins le fournissent; le laisser optionnel evite qu'un oubli coupe toutes les cles d'un serveur, la ou il ne fait que ramener au comportement d'avant.