### PR TITLE
refactor(dashboard): renomme la page publique des clans en /clan-rpg

### DIFF
--- a/apps/bot/src/services/system/ogMetadataService.ts
+++ b/apps/bot/src/services/system/ogMetadataService.ts
@@ -651,7 +651,7 @@ async function guildPageMetadata(
     return meta;
   }
 
-  if (section === 'dev') {
+  if (section === 'clan-rpg') {
     meta.title = m.og_dev_title({ guild: guild.name }, { locale });
     meta.description = m.og_dev_desc({}, { locale });
     meta.imagePath = imagePathFor(path, 'v1');

--- a/apps/dashboard/src/App.svelte
+++ b/apps/dashboard/src/App.svelte
@@ -66,7 +66,7 @@
       /^\/\d{17,19}\/leveling\/clan\/?$/.test($router.path) ||
       /^\/\d{17,19}\/clan\/?$/.test($router.path) ||
       /^\/\d{17,19}\/rpg\/?$/.test($router.path) ||
-      /^\/\d{17,19}\/dev\/?$/.test($router.path) ||
+      /^\/\d{17,19}\/clan-rpg\/?$/.test($router.path) ||
       /^\/\d{17,19}\/giveaways(\/[A-Za-z0-9_-]+)?\/?$/.test($router.path) ||
       ($router.path.startsWith("/profile/") && !authStore.isAuthenticated) ||
       $router.path.startsWith("/transcripts/") ||
@@ -574,7 +574,7 @@
         props={(meta) => ({ serverId: meta.params.serverId })}
       />
       <LazyRoute
-        path="/:serverId/dev"
+        path="/:serverId/clan-rpg"
         load={() => import("./pages/ClanBoardPublic.svelte")}
         props={(meta) => ({ serverId: meta.params.serverId })}
       />

--- a/apps/dashboard/src/pages/Clans.svelte
+++ b/apps/dashboard/src/pages/Clans.svelte
@@ -138,7 +138,7 @@
   let copySuccess = $state(false);
   const publicClanUrl = $derived(
     authStore.selectedGuildId
-      ? `${window.location.origin}/${authStore.selectedGuildId}/dev`
+      ? `${window.location.origin}/${authStore.selectedGuildId}/clan-rpg`
       : ''
   );
 

--- a/apps/dashboard/src/pages/Economy.svelte
+++ b/apps/dashboard/src/pages/Economy.svelte
@@ -75,7 +75,7 @@ import EmojiText from '../lib/components/EmojiText.svelte';
   let publicUrlCopied = $state(false);
   const publicRpgUrl = $derived(
     authStore.selectedGuildId
-      ? `${window.location.origin}/${authStore.selectedGuildId}/dev`
+      ? `${window.location.origin}/${authStore.selectedGuildId}/clan-rpg`
       : ''
   );
 


### PR DESCRIPTION
L'adresse se terminait par /dev, un reste de mise au point qui ne disait rien de ce que la page montre. Elle porte pourtant le tableau des clans et du RPG, et c'est un lien que les serveurs partagent a leurs membres.

Les deux boutons qui copient l'adresse, dans Economie et dans Clans, et l'apercu Open Graph suivent le nouveau chemin.