### PR TITLE
Add repair for instance stats identity

### DIFF
--- a/packages/database/prisma/repair-production.ts
+++ b/packages/database/prisma/repair-production.ts
@@ -22,6 +22,7 @@ const repairs = [
   "20260804120000_add_voice_captcha",
   "20260806120000_add_captcha_voice_locale",
   "20260806130000_add_captcha_verified_role",
+  "20260909180000_add_instance_stats_and_identity",
 ];
 
 async function run(command: string[]) {

--- a/packages/database/prisma/repairs/20260909180000_add_instance_stats_and_identity.sql
+++ b/packages/database/prisma/repairs/20260909180000_add_instance_stats_and_identity.sql
@@ -1,0 +1,14 @@
+ALTER TABLE "bot_instance_stats" ADD COLUMN IF NOT EXISTS "machineFingerprint" TEXT;
+ALTER TABLE "bot_instance_stats" ADD COLUMN IF NOT EXISTS "firstSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+CREATE INDEX IF NOT EXISTS "bot_instance_stats_machineFingerprint_idx" ON "bot_instance_stats"("machineFingerprint");
+
+CREATE TABLE IF NOT EXISTS "local_instance_identity" (
+    "id" TEXT NOT NULL DEFAULT 'singleton',
+    "machineFingerprint" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "local_instance_identity_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "local_instance_identity_machineFingerprint_key" ON "local_instance_identity"("machineFingerprint");


### PR DESCRIPTION
Registers a new production repair migration and adds SQL to evolve instance tracking schema. The repair adds `machineFingerprint` and `firstSeenAt` to `bot_instance_stats`, creates an index on `machineFingerprint`, and introduces `local_instance_identity` with a singleton primary key plus a unique `machineFingerprint` constraint.