### PR TITLE
Add missing bump_states DB migration

### DIFF
--- a/packages/database/prisma/migrations/20260909190000_add_bump_states/migration.sql
+++ b/packages/database/prisma/migrations/20260909190000_add_bump_states/migration.sql
@@ -1,0 +1,24 @@
+-- Rappel de bump auto-detecte : un etat par serveur (introduit par 91394438
+-- sans migration).
+
+CREATE TABLE IF NOT EXISTS "bump_states" (
+    "guildId" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "providerLabel" TEXT NOT NULL,
+    "lastBumpAt" TIMESTAMP(3) NOT NULL,
+    "lastBumpUserId" TEXT,
+    "lastChannelId" TEXT NOT NULL,
+    "nextBumpAt" TIMESTAMP(3) NOT NULL,
+    "reminded" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "bump_states_pkey" PRIMARY KEY ("guildId")
+);
+
+CREATE INDEX IF NOT EXISTS "bump_states_nextBumpAt_reminded_idx" ON "bump_states"("nextBumpAt", "reminded");
+
+DO $$ BEGIN
+  ALTER TABLE "bump_states" ADD CONSTRAINT "bump_states_guildId_fkey"
+    FOREIGN KEY ("guildId") REFERENCES "guilds"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;


### PR DESCRIPTION
Adds a Prisma SQL migration to create the `bump_states` table that was previously introduced without a migration. The migration defines the guild-based primary key, bump tracking fields, index on `(nextBumpAt, reminded)`, and a foreign key to `guilds(id)` with cascade behavior, using idempotent guards to avoid failures on already-updated databases.