### PR TITLE
refactor(dash): remplace les emoji des derniers paris par des icônes

### DIFF
--- a/apps/dashboard/messages/en.json
+++ b/apps/dashboard/messages/en.json
@@ -9363,6 +9363,7 @@
   "clan_bet_status_expired": "Expired",
   "clan_bets_debt_cleared": "Debt cleared.",
   "clan_bets_history_line": "Stake {stake} · pot {pot} · season {season}",
+  "clan_bets_history_credit": "credit {amount}",
   "clan_bets_managers_heading": "Roles allowed to manage bets",
   "clan_bets_managers_desc": "Hand refereeing to a team without opening up server administration.",
   "clan_bets_managers_scope_winner": "Name the winner of a running bet.",

--- a/apps/dashboard/messages/fr.json
+++ b/apps/dashboard/messages/fr.json
@@ -9363,6 +9363,7 @@
   "clan_bet_status_expired": "Expiré",
   "clan_bets_debt_cleared": "Dette effacée.",
   "clan_bets_history_line": "Mise {stake} · enjeu {pot} · saison {season}",
+  "clan_bets_history_credit": "crédit {amount}",
   "clan_bets_managers_heading": "Rôles autorisés à gérer les paris",
   "clan_bets_managers_desc": "Confie l'arbitrage à une équipe sans lui ouvrir l'administration du serveur.",
   "clan_bets_managers_scope_winner": "Désigner le gagnant d'un pari en cours.",

--- a/apps/dashboard/src/pages/Clans.svelte
+++ b/apps/dashboard/src/pages/Clans.svelte
@@ -2148,7 +2148,7 @@ savedBetSettings = {
                   <div class="text-xs text-on-surface-variant/70 space-y-0.5">
                     {#each bet.sides as side (side.id)}
                       <p class:font-semibold={side.won} class:text-primary={side.won}>
-                        {#if side.won}🏆 {/if}{side.label}{side.capacity ? ` (${side.members.length}/${side.capacity})` : ''} ·
+                        {#if side.won}<Papicon icon="Crown" size={12} class="inline-block align-[-0.2em] mr-0.5" />{/if}{side.label}{side.capacity ? ` (${side.members.length}/${side.capacity})` : ''} ·
                         {#if side.members.length === 0}
                           <span class="opacity-60">-</span>
                         {:else}
@@ -2165,7 +2165,7 @@ savedBetSettings = {
                       pot: bet.pot.toLocaleString(dateLocale()),
                       season: bet.season,
                     })}
-                    {#if bet.creditUsed > 0}· 💳 {bet.creditUsed.toLocaleString(dateLocale())}{/if}
+                    {#if bet.creditUsed > 0}· <Papicon icon="Card" size={11} class="inline-block align-[-0.2em] mr-0.5" />{m.clan_bets_history_credit({ amount: bet.creditUsed.toLocaleString(dateLocale()) })}{/if}
                   </p>
                 </div>
               {/each}


### PR DESCRIPTION
Le trophée du camp gagnant et la carte du crédit utilisé laissent place à Crown et Card, du jeu Papicons déjà utilisé dans la page.

Le montant du crédit était annoncé par le seul emoji : il est maintenant précédé du mot crédit, traduit, l'icône ne portant plus le sens à elle seule.