### PR TITLE
fix(dash): coupe les dernieres lectures qui traversaient une autre section

### DIFF
--- a/apps/bot/src/api/routes/dashboard.ts
+++ b/apps/bot/src/api/routes/dashboard.ts
@@ -167,6 +167,11 @@ export async function handleDashboardRoutes(
     // comprise. Sans elle, la page d'un module désactivé continuerait de se
     // charger et de s'enregistrer pour qui connaît son URL, alors même que le
     // bot n'exécute plus rien derrière.
+    //
+    // Deux nuances, décrites dans `featureGate.ts` : une sous-route que des
+    // pages étrangères au module appellent à chaque ouverture répond vide
+    // plutôt que de refuser, et un segment partagé par deux modules reste
+    // ouvert tant que l'un des deux tourne.
     const routeModuleKey = isModuleUngatedSubroute(parts[4], parts[5])
       ? undefined
       : getModuleForApiSegment(parts[4]);

--- a/apps/bot/src/api/routes/dashboard/modules/verification.ts
+++ b/apps/bot/src/api/routes/dashboard/modules/verification.ts
@@ -19,33 +19,6 @@ import { readWordStatsEnabled, startWordStatsBackfillIfTurnedOn, type ModuleRout
  * autre page ne les ecrit. Les statistiques de mots gardent leur seconde porte
  * dans `channels-management`, ou le panneau d'analytique avancee les allume.
  */
-const VERIFICATION_SELECT = {
-  verificationEnabled: true,
-  verificationMode: true,
-  verificationAction: true,
-  verificationChannelId: true,
-  verificationFallbackChannelId: true,
-  verificationRoleId: true,
-  verificationLogChannelId: true,
-  verificationEmbedTitle: true,
-  verificationEmbedDesc: true,
-  verificationEmbedColor: true,
-  verificationOnJoin: true,
-  verificationSaveIp: true,
-  verificationSaveDevice: true,
-  verificationLevelCommand: true,
-  verificationLevelJoin: true,
-  verificationWarnThreshold: true,
-  verificationWarnAutoMode: true,
-  verificationWarnReason: true,
-  warnWeightingEnabled: true,
-  warnDecayDays: true,
-  countArchivedInWarnScore: true,
-  warnAutoArchiveDays: true,
-  wordStatsEnabled: true,
-  banHygieneEnabled: true,
-} as const;
-
 export async function handleVerificationRoutes(ctx: ModuleRouteContext): Promise<boolean> {
   const { req, res, parts, client, guildId, method, auditUser, moduleKey } = ctx;
 
@@ -56,7 +29,32 @@ export async function handleVerificationRoutes(ctx: ModuleRouteContext): Promise
     try {
       const guild = await prisma.guild.findUnique({
         where: { id: guildId },
-        select: VERIFICATION_SELECT,
+        select: {
+          verificationEnabled: true,
+          verificationMode: true,
+          verificationAction: true,
+          verificationChannelId: true,
+          verificationFallbackChannelId: true,
+          verificationRoleId: true,
+          verificationLogChannelId: true,
+          verificationEmbedTitle: true,
+          verificationEmbedDesc: true,
+          verificationEmbedColor: true,
+          verificationOnJoin: true,
+          verificationSaveIp: true,
+          verificationSaveDevice: true,
+          verificationLevelCommand: true,
+          verificationLevelJoin: true,
+          verificationWarnThreshold: true,
+          verificationWarnAutoMode: true,
+          verificationWarnReason: true,
+          warnWeightingEnabled: true,
+          warnDecayDays: true,
+          countArchivedInWarnScore: true,
+          warnAutoArchiveDays: true,
+          wordStatsEnabled: true,
+          banHygieneEnabled: true,
+        },
       });
       if (!guild) {
         json(res, 404, { error: 'Serveur introuvable' });
@@ -181,7 +179,7 @@ export async function handleVerificationRoutes(ctx: ModuleRouteContext): Promise
         user: auditUser,
         action: 'Sauvegarde configuration Vérification',
         context: getGuildName(client, guildId),
-        module: 'Doubles comptes',
+        module: 'Vérification de sécurité',
         eventType: 'Manuel',
         details: 'Configuration de la vérification de sécurité mise à jour.',
         channelId: null,

--- a/apps/dashboard/src/lib/config/pages.ts
+++ b/apps/dashboard/src/lib/config/pages.ts
@@ -77,6 +77,11 @@ export const securityItems: PageConfig[] = [
 /**
  * Anciennes URL -> nouvel onglet. Sert a la fois aux redirections de routes
  * et a la reecriture des favoris deja enregistres en localStorage.
+ *
+ * `/security/verification` n'a jamais ete une page : c'est l'adresse que le
+ * registre declare pour le module « Verification de securite », donc celle du
+ * bouton « Configurer » du catalogue. Elle mene a l'onglet qui porte vraiment
+ * ces reglages, au lieu de ne mener nulle part.
  */
 export const SECURITY_LEGACY_REDIRECTS: Record<string, string> = {
   '/automod':               '/security/filters',
@@ -88,6 +93,7 @@ export const SECURITY_LEGACY_REDIRECTS: Record<string, string> = {
   '/sanctions':             '/security/sanctions',
   '/appeals':               '/security/sanctions/appeals',
   '/admin-lock':            '/security/sanctions/admin-approval',
+  '/security/verification': '/security/accounts/verification',
 };
 
 /**

--- a/apps/dashboard/src/pages/DailyAlgo.svelte
+++ b/apps/dashboard/src/pages/DailyAlgo.svelte
@@ -12,7 +12,6 @@
     fetchCurrentDailyAlgoWeek,
     fetchDailyAlgoWeekHistory,
     closeDailyAlgoWeek,
-    fetchClansData,
     updateGlobalSettings,
   } from '../lib/api';
   import { authStore } from '../lib/stores/auth.svelte';
@@ -156,8 +155,13 @@
   let closeWeekConfirmOpen = $state(false);
 
   // Les clans sont un module indépendant : le pont Daily Algo → Clans ne peut
-  // être configuré que s'ils sont activés sur le serveur.
-  let clansEnabled = $state(false);
+  // être configuré que s'ils sont activés sur le serveur. L'état vient de la
+  // liste des modules, déjà chargée : lire /clans pour ce seul booléen faisait
+  // dépendre cette page de la section Leveling, qui garde ce segment.
+  const clansEnabled = $derived(
+    (dashboardStore.state.modules as Array<{ id: string; status: string }>)
+      .some((mod) => mod.id === 'clans' && mod.status === 'active')
+  );
 
   function formatWeekLabel(label?: string) {
     if (!label) return '';
@@ -255,15 +259,6 @@
       console.error('Error fetching daily algo week:', err);
     } finally {
       isFetchingWeek = false;
-    }
-  }
-
-  async function loadClansEnabled() {
-    try {
-      const clans = await fetchClansData();
-      clansEnabled = !!clans?.clansEnabled;
-    } catch {
-      clansEnabled = false;
     }
   }
 
@@ -367,8 +362,7 @@
       loadDailyAlgoSchedule(),
       loadMyApiKeys(),
       loadFeatureConfig(),
-      loadWeekData(),
-      loadClansEnabled()
+      loadWeekData()
     ]);
   });
 

--- a/apps/dashboard/src/pages/DoubleAccounts.svelte
+++ b/apps/dashboard/src/pages/DoubleAccounts.svelte
@@ -1413,26 +1413,27 @@
               </label>
             </div>
           </div>
-
-          <!-- Actions -->
-          <div class="flex flex-wrap gap-2">
-            <button onclick={saveVerifConfig}
-              class="px-5 py-2.5 bg-indigo-600 text-white rounded-lg text-[13px] font-medium hover:bg-indigo-500 transition-all flex items-center gap-1.5">
-              <Papicon icon="Save" size={13} /> {m.da_save()}
-            </button>
-            {#if verifConfig.verificationMode === 'EMBED' && verifConfig.verificationChannelId}
-              <button onclick={deployVerifEmbed} disabled={deployingEmbed}
-                class="px-5 py-2.5 border border-indigo-500/20 text-indigo-400 rounded-lg text-[13px] font-medium hover:bg-indigo-500 hover:text-white transition-all disabled:opacity-50 flex items-center gap-1.5">
-                {#if deployingEmbed}
-                  <div class="h-3 w-3 animate-spin rounded-full border-2 border-indigo-400 border-t-transparent"></div>
-                  {m.da_sending()}
-                {:else}
-                  <Papicon icon="Send" size={13} /> {m.da_deploy_embed()}
-                {/if}
-              </button>
-            {/if}
-          </div>
         {/if}
+
+        <!-- La sauvegarde reste hors du bloc : cachee avec les champs, elle
+             empechait d'enregistrer l'extinction de la verification. -->
+        <div class="flex flex-wrap gap-2">
+          <button onclick={saveVerifConfig}
+            class="px-5 py-2.5 bg-indigo-600 text-white rounded-lg text-[13px] font-medium hover:bg-indigo-500 transition-all flex items-center gap-1.5">
+            <Papicon icon="Save" size={13} /> {m.da_save()}
+          </button>
+          {#if verifConfig.verificationEnabled && verifConfig.verificationMode === 'EMBED' && verifConfig.verificationChannelId}
+            <button onclick={deployVerifEmbed} disabled={deployingEmbed}
+              class="px-5 py-2.5 border border-indigo-500/20 text-indigo-400 rounded-lg text-[13px] font-medium hover:bg-indigo-500 hover:text-white transition-all disabled:opacity-50 flex items-center gap-1.5">
+              {#if deployingEmbed}
+                <div class="h-3 w-3 animate-spin rounded-full border-2 border-indigo-400 border-t-transparent"></div>
+                {m.da_sending()}
+              {:else}
+                <Papicon icon="Send" size={13} /> {m.da_deploy_embed()}
+              {/if}
+            </button>
+          {/if}
+        </div>
       </div>
     {:else}
       <div class="flex flex-col items-center py-20 gap-3">


### PR DESCRIPTION
Trois restes du meme genre, trouves en relisant les appels de chaque page :

- la page Daily Algo lisait /clans pour un seul booleen, ce qui la faisait dependre de la section Leveling ; l'etat du module est deja dans la liste chargee au demarrage, elle le lit la ;
- le bouton « Configurer » du catalogue menait a /security/verification, une adresse declaree par le registre mais sans page ; elle redirige vers l'onglet qui porte ces reglages ;
- la sauvegarde de l'onglet Verification vivait dans le bloc masque quand la verification est eteinte : on ne pouvait donc jamais enregistrer son extinction. Elle passe hors du bloc, le bouton de deploiement de l'embed garde sa condition.

Le journal de la nouvelle route porte le nom du module qui la possede.