### PR TITLE
fix(giveaways): remet le formulaire devant l'envoi direct dans la liste des modeles

### DIFF
--- a/apps/dashboard/messages/en.json
+++ b/apps/dashboard/messages/en.json
@@ -6231,6 +6231,8 @@
   "giv_cfg_success_save_template": "Configuration saved, and its template is in the gallery.",
   "giv_tpl_config_prize": "Prize to be set",
   "giv_tpl_publish": "Publish",
+  "giv_tpl_launch": "Launch",
+  "giv_tpl_publish_now": "Publish as is, with no changes",
   "giv_tpl_publish_confirm_title": "Publish “{name}”?",
   "giv_tpl_publish_confirm_desc": "{prize} goes out now in {channel}, for {duration}. Nothing else will be asked.",
   "giv_tpl_publish_no_channel": "This template has no channel: pick one before sending.",

--- a/apps/dashboard/messages/fr.json
+++ b/apps/dashboard/messages/fr.json
@@ -6231,6 +6231,8 @@
   "giv_cfg_success_save_template": "Configuration enregistrée, et son modèle est dans la galerie.",
   "giv_tpl_config_prize": "Lot à définir",
   "giv_tpl_publish": "Publier",
+  "giv_tpl_launch": "Lancer",
+  "giv_tpl_publish_now": "Publier tel quel, sans rien changer",
   "giv_tpl_publish_confirm_title": "Publier « {name} » ?",
   "giv_tpl_publish_confirm_desc": "{prize} part maintenant dans {channel}, pour {duration}. Rien d'autre ne vous sera demandé.",
   "giv_tpl_publish_no_channel": "Ce modèle n'a pas de salon : choisissez-en un avant d'envoyer.",

--- a/apps/dashboard/src/pages/Giveaways.svelte
+++ b/apps/dashboard/src/pages/Giveaways.svelte
@@ -839,7 +839,9 @@
     const duration = splitDuration(template.durationMinutes);
     return {
       name: template.name,
-      prize: template.prize,
+      // Le lot d'attente d'un modèle né d'une configuration n'est pas un lot :
+      // le recopier dans le formulaire obligerait à l'effacer avant d'écrire.
+      prize: template.prize === m.giv_tpl_config_prize() ? '' : template.prize,
       description: template.description ?? '',
       winnerCount: template.winnerCount,
       durationValue: duration.durationValue,
@@ -1337,20 +1339,27 @@
                       <Papicon icon="Cross" size={14} />
                     </button>
                   {:else}
-                    <button
-                      onclick={() => handlePublishTemplate(template)}
-                      disabled={actionState.state.loading}
-                      class="flex items-center gap-2 px-3 py-2 rounded-lg bg-primary/10 hover:bg-primary/20 text-primary font-medium text-xs transition-all cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                      <Papicon icon="PaperPlaneTilt" size={14} />
-                      {m.giv_tpl_publish()}
-                    </button>
+                    <!--
+                      Le formulaire prérempli passe devant l'envoi direct : le
+                      lot, la durée et le salon se règlent presque toujours au
+                      moment de lancer, et un bouton qui part sans rien demander
+                      ne sert que le jour où un modèle est déjà prêt tel quel.
+                    -->
                     <button
                       onclick={() => startFromTemplate(template)}
-                      class="p-2 rounded-lg bg-surface-container-high/40 hover:bg-primary/15 hover:text-primary text-on-surface-variant transition-colors cursor-pointer"
+                      class="flex items-center gap-2 px-3 py-2 rounded-lg bg-primary/10 hover:bg-primary/20 text-primary font-medium text-xs transition-all cursor-pointer"
                       title={m.giv_tpl_use()}
                     >
                       <Papicon icon="Sparkles" size={14} />
+                      {m.giv_tpl_launch()}
+                    </button>
+                    <button
+                      onclick={() => handlePublishTemplate(template)}
+                      disabled={actionState.state.loading}
+                      class="p-2 rounded-lg bg-surface-container-high/40 hover:bg-primary/15 hover:text-primary text-on-surface-variant transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                      title={m.giv_tpl_publish_now()}
+                    >
+                      <Papicon icon="PaperPlaneTilt" size={14} />
                     </button>
                     <button
                       onclick={() => startRename(template)}


### PR DESCRIPTION
Le bouton Publier occupait la place principale de chaque ligne, alors qu'il part sans rien demander : le lot, la duree et le salon se reglent presque toujours au moment de lancer, et un modele ne les porte tout prets que le jour ou on relance le meme concours a l'identique.

Lancer, qui ouvre le formulaire prerempli, prend la place en vue. L'envoi direct reste a cote, en icone, avec sa confirmation qui annonce le lot, le salon et la duree.

Le lot d'attente d'un modele ne du cote configuration n'est plus recopie dans le formulaire : il fallait l'effacer avant d'ecrire le vrai lot.